### PR TITLE
Add alerter error metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -6,7 +6,9 @@ import (
 )
 
 var (
-	Namespace       = "adxmon"
+	Namespace = "adxmon"
+
+	// Ingestor metrics
 	SamplesReceived = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "ingestor",
@@ -20,4 +22,19 @@ var (
 		Name:      "samples_stored_total",
 		Help:      "Counter of samples stored for an ingestor instance",
 	}, []string{"node"})
+
+	// Alerting metrics
+	AlertQueryFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "alerter",
+		Name:      "alert_query_failures_total",
+		Help:      "Number of alert query failures",
+	}, []string{"namespace", "name"})
+
+	NotificationFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "alerter",
+		Name:      "notification_failures_total",
+		Help:      "Number of alert notification failures",
+	}, []string{"namespace", "name"})
 )


### PR DESCRIPTION
This adds two metrics: one counter incremented when a kusto query fails to execute and a second when there is a failure posting to the notification endpoint.