### PR TITLE
Switch query/notification metrics to guages

### DIFF
--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -51,7 +51,7 @@ func (e *Executor) queryWorker(rule rules.Rule) {
 	// do-while
 	if err := e.KustoClient.Query(e.ctx, rule, e.ICMHandler); err != nil {
 		logger.Error("Failed to execute query=%s/%s: %s", rule.Namespace, rule.Name, err)
-		metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+		metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 	}
 	ticker := time.NewTicker(rule.Interval)
 	defer ticker.Stop()
@@ -67,9 +67,9 @@ func (e *Executor) queryWorker(rule rules.Rule) {
 			logger.Info("Executing %s/%s", rule.Namespace, rule.Name)
 			if err := e.KustoClient.Query(e.ctx, rule, e.ICMHandler); err != nil {
 				logger.Error("Failed to execute query=%s.%s: %s", rule.Namespace, rule.Name, err)
-				metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+				metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 			} else {
-				metrics.AlertQuerySuccess.WithLabelValues(rule.Namespace, rule.Name).Inc()
+				metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(1)
 				logger.Info("Completed %s/%s in %s", rule.Namespace, rule.Name, time.Since(start))
 			}
 
@@ -104,7 +104,7 @@ func (e *Executor) ICMHandler(endpoint string, rule rules.Rule, row *table.Row) 
 		case "severity":
 			v, err := e.asInt64(value)
 			if err != nil {
-				metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+				metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 				return err
 			}
 			res.Severity = v
@@ -120,7 +120,7 @@ func (e *Executor) ICMHandler(endpoint string, rule rules.Rule, row *table.Row) 
 	}
 
 	if err := res.Validate(); err != nil {
-		metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+		metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 		return err
 	}
 
@@ -129,14 +129,14 @@ func (e *Executor) ICMHandler(endpoint string, rule rules.Rule, row *table.Row) 
 		case string:
 			query = strings.Replace(query, k, fmt.Sprintf("\"%s\"", vv), -1)
 		default:
-			metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+			metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 			return fmt.Errorf("unimplemented query type: %v", vv)
 		}
 	}
 
 	url, err := kustoDeepLink(query)
 	if err != nil {
-		metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+		metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 		return fmt.Errorf("failed to create kusto deep link: %w", err)
 	}
 
@@ -171,10 +171,10 @@ func (e *Executor) ICMHandler(endpoint string, rule rules.Rule, row *table.Row) 
 	logger.Info("Sending alert %s %v", addr, a)
 	if err := e.AlertCli.Create(context.Background(), addr, a); err != nil {
 		fmt.Printf("Failed to create Notification: %s\n", err)
-		metrics.AlertQueryFailures.WithLabelValues(rule.Namespace, rule.Name).Inc()
+		metrics.NotificationHealth.WithLabelValues(rule.Namespace, rule.Name).Set(0)
 		return nil
 	}
-	metrics.NotificationSuccess.WithLabelValues(rule.Namespace, rule.Name).Inc()
+	metrics.NotificationHealth.WithLabelValues(rule.Namespace, rule.Name).Set(1)
 
 	//log.Infof("Created Notification %s - %s", resp.IncidentId, res.Title)
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,31 +24,17 @@ var (
 	}, []string{"node"})
 
 	// Alerting metrics
-	AlertQueryFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+	QueryHealth = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "alerter",
-		Name:      "query_failures_total",
-		Help:      "Number of alert query failures",
+		Name:      "query_health",
+		Help:      "Gauge indicating if a query is healthy or not",
 	}, []string{"namespace", "name"})
 
-	AlertQuerySuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+	NotificationHealth = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "alerter",
-		Name:      "query_success_total",
-		Help:      "Number of alert query successfully executed",
-	}, []string{"namespace", "name"})
-
-	NotificationFailures = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "alerter",
-		Name:      "notification_failures_total",
-		Help:      "Number of alert notification failures",
-	}, []string{"namespace", "name"})
-
-	NotificationSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: "alerter",
-		Name:      "notification_success_total",
-		Help:      "Number of alert notification successfully created",
+		Name:      "notification_health",
+		Help:      "Gauge indicating if a notification is healthy or not",
 	}, []string{"namespace", "name"})
 )


### PR DESCRIPTION
The counters were more complicated to determine if a health.  Switching these to gauges where 1 is healhty and 0 is not.  This will make it easier to setup alerts.