### PR TITLE
Try and make a simpler adx-mon linter.

### DIFF
--- a/alerter/rules/localStore.go
+++ b/alerter/rules/localStore.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	alertrulev1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/logger"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type fileStore struct {
+	rules []*Rule
+}
+
+func FromPath(path, region string) (*fileStore, error) {
+	s := &fileStore{}
+	//walk files in directory
+	err := filepath.WalkDir(path, func(path string, info os.DirEntry, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file '%s': %w", path, err)
+		}
+		err = s.fromStream(f, region)
+		if err != nil {
+			return fmt.Errorf("failed to read file '%s': %w", path, err)
+		}
+		return nil
+	})
+	return s, err
+
+}
+
+func (s *fileStore) fromStream(file io.Reader, region string) error {
+	d := yaml.NewYAMLOrJSONDecoder(file, 4096)
+	for {
+		// create new spec here
+		rule := alertrulev1.AlertRule{}
+
+		// pass a reference to spec reference
+		err := d.Decode(&rule)
+		// break the loop in case of EOF
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		logger.Info("found rule '%s'", rule.ObjectMeta.Name)
+		r, err := toRule(rule, region)
+		if err != nil {
+			return err
+		}
+		s.rules = append(s.rules, r)
+	}
+	return nil
+}
+
+func (s *fileStore) Rules() []*Rule {
+	return s.rules
+}

--- a/alerter/rules/localStore_test.go
+++ b/alerter/rules/localStore_test.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var alertruleExample = `apiVersion: adx-mon.azure.com/v1
+kind: AlertRule
+metadata:
+  name: bar
+  namespace: foo
+spec:
+  database: SomeDB
+  interval: 1h
+  query: |
+    BadThings
+    | where stuff  > 1
+    | summarize count() by region
+    | extend Severity=3
+    | extend  Title = "Bad Things!"
+    | extend  Summary  =  "Bad Things! Oh no"
+    | extend CorrelationId = region
+    | extend TSG="http://gofixit.com"
+  autoMitigateAfter: 2h
+  destination: "peoplewhocare"
+`
+
+func TestFromPAth(t *testing.T) {
+	s := &fileStore{}
+	err := s.fromStream(strings.NewReader(alertruleExample), "newmexico")
+	require.NoError(t, err)
+	require.Equal(t, "foo", s.rules[0].Namespace)
+	require.Equal(t, "bar", s.rules[0].Name)
+}

--- a/cmd/alerter/main.go
+++ b/cmd/alerter/main.go
@@ -3,6 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
 	"github.com/Azure/adx-mon/alerter"
 	alertrulev1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/logger"
@@ -11,11 +16,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"os/signal"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"syscall"
+)
+
+var (
+	kendpointsArg = &cli.StringSliceFlag{Name: "kusto-endpoint", Usage: "Kusto endpoint in the format of <name>=<endpoint>"}
+	maxNotifArg   = &cli.IntFlag{Name: "max-notifications", Value: 25, Usage: "Maximum number of notifications to send per rule"}
+	regionArg     = &cli.StringFlag{Name: "region", Usage: "Current region"}
 )
 
 func main() {
@@ -23,27 +30,70 @@ func main() {
 		Name:  "alerter",
 		Usage: "adx-mon alerting engine for ADX",
 		Flags: []cli.Flag{
+			kendpointsArg,
 			&cli.StringFlag{Name: "kubeconfig", Usage: "/etc/kubernetes/admin.conf"},
 			&cli.IntFlag{Name: "port", Value: 4023, Usage: "Metrics port number"},
 			// Either the msi-id or msi-resource must be specified
 			&cli.StringFlag{Name: "msi-id", Usage: "MSI client ID"},
 			&cli.StringFlag{Name: "msi-resource", Usage: "MSI resource ID"},
 			&cli.StringFlag{Name: "cloud", Usage: "Azure cloud"},
-			&cli.StringFlag{Name: "region", Usage: "Current region"},
-			&cli.StringSliceFlag{Name: "kusto-endpoint", Usage: "Kusto endpoint in the format of <name>=<endpoint>"},
+			regionArg,
 			&cli.StringFlag{Name: "alerter-address", Usage: "Address of the alert notification service"},
 			&cli.IntFlag{Name: "concurrency", Value: 10, Usage: "Number of concurrent queries to run"},
-			&cli.IntFlag{Name: "max-notifications", Value: 25, Usage: "Maximum number of notifications to send per rule"},
+			maxNotifArg,
 		},
-
-		Action: func(ctx *cli.Context) error {
-			return realMain(ctx)
+		Action: realMain,
+		Commands: []*cli.Command{
+			{
+				Name:    "lint",
+				Aliases: []string{"l"},
+				Usage:   "lint a directory by running each rule once",
+				Flags: []cli.Flag{
+					kendpointsArg,
+					&cli.StringFlag{Name: "lint-dir", Usage: "Read alert rules from local filesystem", Required: true},
+					maxNotifArg,
+					regionArg,
+				},
+				Action: lintMain,
+			},
 		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
 		logger.Fatal(err.Error())
 	}
+}
+
+func lintMain(ctx *cli.Context) error {
+	endpoints := make(map[string]string)
+	endpointsArg := ctx.StringSlice("kusto-endpoint")
+	for _, v := range endpointsArg {
+		parts := strings.Split(v, "=")
+		if len(parts) != 2 {
+			return cli.Exit("Invalid kusto-endpoint format, expected <name>=<endpoint>", 1)
+		}
+		endpoints[parts[0]] = parts[1]
+	}
+
+	scheme := clientgoscheme.Scheme
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := alertrulev1.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	opts := &alerter.AlerterOpts{
+		KustoEndpoints:   endpoints,
+		Port:             4023, //needs to be adjustable?Failed to create Notification
+		Region:           ctx.String("region"),
+		MaxNotifications: ctx.Int("max-notifications"),
+	}
+
+	lintCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	//TODO fail early if azlogin is not up to date
+	return alerter.Lint(lintCtx, opts, ctx.String("lint-dir"))
 }
 
 func realMain(ctx *cli.Context) error {
@@ -66,6 +116,9 @@ func realMain(ctx *cli.Context) error {
 	}
 
 	_, _, ctrlCli, err := newKubeClient(ctx)
+	if err != nil {
+		return err
+	}
 
 	opts := &alerter.AlerterOpts{
 		Port:             ctx.Int("port"),
@@ -82,10 +135,15 @@ func realMain(ctx *cli.Context) error {
 	svcCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if ctx.String("lint-dir") != "" {
+		return alerter.Lint(svcCtx, opts, ctx.String("lint-dir"))
+	}
+
 	svc, err := alerter.NewService(opts)
 	if err != nil {
 		return err
 	}
+
 	if err := svc.Open(svcCtx); err != nil {
 		return err
 	}


### PR DESCRIPTION
To allow developers to iterate rapidly on alertrules we want them to be able to run new rules directly against kusto which they ususally have access to and just show them 
1) errors in syntax (both kusto and alertrule)
2) Latency of queries
3) alerts generated per correlation id (or per alertrule?)

Example usage
go run . lint  --kusto-endpoint "<db>=<urk>" --region uksouth --lint-dir ~/myrepo/alertrules

Can pass a directory or single file. Will recurse down 

Results should look like this for now

2023-03-29T06:03:39.439202Z INF Executing foo/bar.yaml on https:/<kustourl>/<kustodb>
2023-03-29T06:03:40.088139Z INF Completed foo/barrule in 648.934985ms
2023-03-29T06:11:53.105389Z INF Alert far/barrule://uksouth/sometherthing was sent 1 times
