### PR TITLE
Add explicit listen addr for collector in tests

### DIFF
--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -2,18 +2,22 @@ package collector_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/Azure/adx-mon/collector"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
-	"time"
 )
+
+const MetricListenAddr = ":9090"
 
 func TestService_Open(t *testing.T) {
 	cli := fake.NewSimpleClientset()
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		ScrapeInterval: 10 * time.Second,
 	})
@@ -27,6 +31,7 @@ func TestService_Open(t *testing.T) {
 func TestService_Open_Static(t *testing.T) {
 	cli := fake.NewSimpleClientset()
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		Targets:        []string{"http://localhost:8080/metrics"},
 		ScrapeInterval: 10 * time.Second,
@@ -41,6 +46,7 @@ func TestService_Open_Static(t *testing.T) {
 func TestService_Open_NoMatchingHost(t *testing.T) {
 	cli := fake.NewSimpleClientset(fakePod("default", "pod1", map[string]string{"app": "test"}, "node1"))
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		NodeName:       "ks8-master-123",
 		Targets:        []string{"http://localhost:8080/metrics"},
@@ -56,6 +62,7 @@ func TestService_Open_NoMatchingHost(t *testing.T) {
 func TestService_Open_NoMetricsAnnotations(t *testing.T) {
 	cli := fake.NewSimpleClientset(fakePod("default", "pod1", map[string]string{"app": "test"}, "ks8-master-123"))
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		NodeName:       "ks8-master-123",
 		Targets:        []string{"http://localhost:8080/metrics"},
@@ -76,6 +83,7 @@ func TestService_Open_Matching(t *testing.T) {
 	pod.Status.PodIP = "172.31.1.18"
 	cli := fake.NewSimpleClientset(pod)
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		NodeName:       "ks8-master-123",
 		Targets:        []string{"http://localhost:8080/metrics"},
@@ -100,6 +108,7 @@ func TestService_Open_MatchingPort(t *testing.T) {
 	pod.Status.PodIP = "172.31.1.18"
 	cli := fake.NewSimpleClientset(pod)
 	s, err := collector.NewService(&collector.ServiceOpts{
+		ListentAddr:    MetricListenAddr,
 		K8sCli:         cli,
 		NodeName:       "ks8-master-123",
 		Targets:        []string{"http://localhost:8080/metrics"},


### PR DESCRIPTION
The start process for the collector service includes a goroutine that binds to a configured port to expose prometheus metrics. The default value is an empty string, causing the Go http server to try binding to :80. This makes some of the service tests flaky as it sometimes manages to run the server bind goroutine before the test finishes, leading to a permission denied error.