### PR TITLE
Ensure __name__ label is always first

### DIFF
--- a/collector/series.go
+++ b/collector/series.go
@@ -12,14 +12,7 @@ type seriesCreator struct {
 }
 
 func (s *seriesCreator) newSeries(name string, scrapeTarget scrapeTarget, m *io_prometheus_client.Metric) prompb.TimeSeries {
-	ts := prompb.TimeSeries{
-		Labels: []prompb.Label{
-			{
-				Name:  []byte("__name__"),
-				Value: []byte(name),
-			},
-		},
-	}
+	ts := prompb.TimeSeries{}
 
 	if scrapeTarget.Namespace != "" {
 		ts.Labels = append(ts.Labels, prompb.Label{
@@ -72,5 +65,9 @@ func (s *seriesCreator) newSeries(name string, scrapeTarget scrapeTarget, m *io_
 	sort.Slice(ts.Labels, func(i, j int) bool {
 		return string(ts.Labels[i].Name) < string(ts.Labels[j].Name)
 	})
+
+	// Ensure that the __name__ label is the first label
+	ts.Labels = append([]prompb.Label{{Name: []byte("__name__"), Value: []byte(name)}}, ts.Labels...)
+
 	return ts
 }

--- a/collector/series_test.go
+++ b/collector/series_test.go
@@ -25,6 +25,25 @@ func TestSeriesCreator(t *testing.T) {
 	require.Equal(t, "value1", string(series.Labels[1].Value))
 }
 
+func TestSeriesCreator_MixedCase(t *testing.T) {
+	sc := seriesCreator{}
+
+	m := &io_prometheus_client.Metric{
+		Label: []*io_prometheus_client.LabelPair{
+			{
+				Name:  strPtr("Capital"),
+				Value: strPtr("value1"),
+			},
+		},
+	}
+	series := sc.newSeries("test", scrapeTarget{}, m)
+	require.Equal(t, 2, len(series.Labels))
+	require.Equal(t, "__name__", string(series.Labels[0].Name))
+	require.Equal(t, "test", string(series.Labels[0].Value))
+	require.Equal(t, "Capital", string(series.Labels[1].Name))
+	require.Equal(t, "value1", string(series.Labels[1].Value))
+}
+
 func TestSeriesCreator_PodMetadata(t *testing.T) {
 	sc := seriesCreator{}
 


### PR DESCRIPTION
__name__ label should always be first before shipping to the ingestor. Noticed a case where capital labels ended up in the front after sorting.