### PR TITLE
Add query execution context

### DIFF
--- a/alerter/engine/client.go
+++ b/alerter/engine/client.go
@@ -2,12 +2,10 @@ package engine
 
 import (
 	"context"
-
-	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
 )
 
 type Client interface {
 	Endpoint(db string) string
-	Query(ctx context.Context, r rules.Rule, fn func(endpoint string, rule rules.Rule, row *table.Row) error) error
+	Query(ctx context.Context, qc *QueryContext, fn func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error) error
 }

--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"fmt"
+	"github.com/Azure/adx-mon/alerter/rules"
+	"github.com/Azure/azure-kusto-go/kusto"
+	kustotypes "github.com/Azure/azure-kusto-go/kusto/data/types"
+	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+	"strings"
+	"time"
+)
+
+type QueryContext struct {
+	Rule      *rules.Rule
+	Query     string
+	Stmt      kusto.Stmt
+	Params    kusto.Parameters
+	Region    string
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*QueryContext, error) {
+	qc := &QueryContext{
+		Rule:      rule,
+		Region:    region,
+		StartTime: endTime.Add(-rule.Interval),
+		EndTime:   endTime,
+	}
+	err := qc.wrapStmt()
+	return qc, err
+}
+
+func (q *QueryContext) wrapStmt() error {
+	q.Query = q.Rule.Query
+	q.Stmt = q.Rule.Stmt
+
+	if q.Rule.IsMgmtQuery {
+		return nil
+	}
+
+	query := fmt.Sprintf(`
+let _startTime = _adxmonStartTime;
+let _endTime = _adxmonEndTime;
+let _region = _adxmonRegion;
+%s
+`, strings.TrimSpace(q.Rule.Query))
+
+	stmt := kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(query)
+
+	// Setup the query execution parameters that can be reference in the query
+	var err error
+	def := kusto.NewDefinitions()
+	def, err = def.With(kusto.ParamTypes{
+		"_adxmonStartTime": kusto.ParamType{Type: kustotypes.DateTime},
+		"_adxmonEndTime":   kusto.ParamType{Type: kustotypes.DateTime},
+		"_adxmonRegion":    kusto.ParamType{Type: kustotypes.String},
+		"ParamRegion":      kusto.ParamType{Type: kustotypes.String}, // This is a deprecated parameter
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create query definitions: %w", err)
+	}
+
+	stmt, err = stmt.WithDefinitions(def)
+	if err != nil {
+		return fmt.Errorf("failed to create query statement: %w", err)
+	}
+
+	qv := kusto.QueryValues{}
+	qv["_adxmonStartTime"] = q.StartTime
+	qv["_adxmonEndTime"] = q.EndTime
+	qv["_adxmonRegion"] = q.Region
+	qv["ParamRegion"] = q.Region
+
+	for k, v := range qv {
+		switch vv := v.(type) {
+		case string:
+			query = strings.Replace(query, k, fmt.Sprintf("\"%s\"", vv), -1)
+		case time.Time:
+			query = strings.Replace(query, k, fmt.Sprintf("datetime(%s)", vv.Format("2006-01-02T15:04:05.999999Z")), -1)
+		default:
+			panic(fmt.Sprintf("unimplemented query type: %v", vv))
+		}
+	}
+
+	params, err := kusto.NewParameters().With(qv)
+	if err != nil {
+		return fmt.Errorf("failed to create kusto parameters: %w", err)
+	}
+
+	stmt, err = stmt.WithParameters(params)
+	if err != nil {
+		return fmt.Errorf("failed to create kusto statement: %w", err)
+	}
+
+	q.Query = query
+	q.Params = params
+	q.Stmt = stmt
+
+	return nil
+}

--- a/alerter/engine/context_test.go
+++ b/alerter/engine/context_test.go
@@ -1,0 +1,37 @@
+package engine
+
+import (
+	"github.com/Azure/adx-mon/alerter/rules"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestNewQueryContext_MgmtQuery(t *testing.T) {
+	r := &rules.Rule{IsMgmtQuery: true, Query: "fake query unchanged"}
+	qc, err := NewQueryContext(r, time.Now(), "region")
+	require.NoError(t, err)
+	require.Equal(t, "fake query unchanged", qc.Query)
+}
+
+func TestNewQueryContext_QueryWrapped(t *testing.T) {
+
+	// write subtests for each of the following cases: "Foo | limit 1", "   Foo | limit 1"
+	for _, tt := range []struct {
+		query, exp string
+	}{
+		{
+			query: "Foo | limit 1",
+			exp:   "\nlet _startTime = datetime(2023-04-09T23:00:00Z);\nlet _endTime = datetime(2023-04-10T00:00:00Z);\nlet _region = \"region\";\nFoo | limit 1\n",
+		},
+		{
+			query: "    Foo | limit 1",
+			exp:   "\nlet _startTime = datetime(2023-04-09T23:00:00Z);\nlet _endTime = datetime(2023-04-10T00:00:00Z);\nlet _region = \"region\";\nFoo | limit 1\n",
+		},
+	} {
+		r := &rules.Rule{Query: tt.query, Interval: time.Hour}
+		qc, err := NewQueryContext(r, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "region")
+		require.NoError(t, err)
+		require.Equal(t, tt.exp, qc.Query)
+	}
+}

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -20,7 +20,10 @@ func TestExecutor_Handler_MissingTitle(t *testing.T) {
 		alertCli: &fakeAlertClient{},
 	}
 
-	rule := rules.Rule{}
+	rule := &rules.Rule{}
+	qc := &QueryContext{
+		Rule: rule,
+	}
 
 	iter := &kusto.RowIterator{}
 
@@ -40,7 +43,7 @@ func TestExecutor_Handler_MissingTitle(t *testing.T) {
 	require.NoError(t, iter.Mock(rows))
 
 	row, _, _ := iter.NextRowOrError()
-	require.ErrorContains(t, e.HandlerFn("http://endpoint", rule, row), "title must be between 1 and 512 chars")
+	require.ErrorContains(t, e.HandlerFn(context.Background(), "http://endpoint", qc, row), "title must be between 1 and 512 chars")
 }
 
 func TestExecutor_Handler_Severity(t *testing.T) {
@@ -125,9 +128,12 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 				alertCli: client,
 			}
 
-			rule := rules.Rule{}
+			rule := &rules.Rule{}
+			qc := &QueryContext{
+				Rule: rule,
+			}
 
-			err = e.HandlerFn("http://endpoint", rule, row)
+			err = e.HandlerFn(context.Background(), "http://endpoint", qc, row)
 			if tt.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, tt.severity, client.alert.Severity)

--- a/alerter/engine/fake.go
+++ b/alerter/engine/fake.go
@@ -3,8 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-
-	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/logger"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
 )
@@ -21,7 +19,7 @@ func (m *fakeKustoClient) Endpoint(db string) string {
 	return fmt.Sprintf("%s.mockcluster.kusto.windows.net", db)
 }
 
-func (m *fakeKustoClient) Query(ctx context.Context, r rules.Rule, fn func(string, rules.Rule, *table.Row) error) error {
-	m.log.Info("Executing rule %s", r.Database)
+func (m *fakeKustoClient) Query(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) error {
+	m.log.Info("Executing rule %s", qc.Rule.Database)
 	return nil
 }

--- a/alerter/engine/formattter.go
+++ b/alerter/engine/formattter.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// KustoDeepLink returns an encoded string that can be used to create a deep link to a Kusto query.
+func KustoDeepLink(q string) (string, error) {
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	if _, err := w.Write([]byte(q)); err != nil {
+		return "", err
+	}
+
+	if err := w.Flush(); err != nil {
+		return "", err
+	}
+
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
+}
+
+// KustoQueryLinks returns a string containing HTML links to the Kusto query in both the web and desktop UI.
+func KustoQueryLinks(preText, query, endpoint, database string) (string, error) {
+	url, err := KustoDeepLink(query)
+	if err != nil {
+		return "", fmt.Errorf("failed to create kusto deep link: %w", err)
+	}
+
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint = endpoint + "/"
+	}
+
+	// Setup the Kusto query deep links
+	link := "Execute in "
+	link += fmt.Sprintf(`<a href="%s%s?query=%s">[Web]</a> `, endpoint, database, url)
+	link += fmt.Sprintf(`<a href="%s%s?query=%s&web=0">[Desktop]</a>`, endpoint, database, url)
+
+	summary := fmt.Sprintf("%s<br/><br/>%s</br><pre>%s</pre>", preText, link, query)
+	summary = strings.TrimSpace(summary)
+	return summary, nil
+}


### PR DESCRIPTION
This adds query execution context to queries that can be referenced in queries will be part of deep links to kusto.  The parameters added are:

let _startTime = datetime(...);
let _endTime = datetime(...);
let _region = "...";

These are injected as variables to the beginning of the each query.  The existing `ParamRegion` query is still used as well, but will be deprecated and remove in the future.