### PR TITLE
Don't send notification for non-user errors

### DIFF
--- a/alerter/engine/worker_test.go
+++ b/alerter/engine/worker_test.go
@@ -1,0 +1,134 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/Azure/adx-mon/alert"
+	"github.com/Azure/adx-mon/alerter/rules"
+	"github.com/Azure/adx-mon/logger"
+	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestWorker_ServerError(t *testing.T) {
+	kcli := &fakeKustoClient{
+		log:      logger.Default,
+		queryErr: fmt.Errorf("Request aborted due to an internal service error"),
+	}
+
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			t.Logf("Create alert should not be called")
+			t.Fail()
+			return nil
+		},
+	}
+
+	w := &worker{
+		rule: &rules.Rule{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+		Region:      "eastus",
+		kustoClient: kcli,
+		AlertAddr:   "",
+		AlertCli:    alertCli,
+		HandlerFn:   nil,
+	}
+
+	w.ExecuteQuery(context.Background())
+}
+
+func TestWorker_ConnectionReset(t *testing.T) {
+	kcli := &fakeKustoClient{
+		log:      logger.Default,
+		queryErr: kerrors.ES(kerrors.OpQuery, kerrors.KHTTPError, "Post \"https://kusto.fqdn/v2/rest/query\": read tcp 1.2.3.4:56140->5.6.7.8:443: read: connection reset by peer"),
+	}
+
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			t.Logf("Create alert should not be called")
+			t.Fail()
+			return nil
+		},
+	}
+
+	w := &worker{
+		rule: &rules.Rule{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+		Region:      "eastus",
+		kustoClient: kcli,
+		AlertAddr:   "",
+		AlertCli:    alertCli,
+		HandlerFn:   nil,
+	}
+
+	w.ExecuteQuery(context.Background())
+}
+
+func TestWorker_ContextTimeout(t *testing.T) {
+	kcli := &fakeKustoClient{
+		log: logger.Default,
+	}
+
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			t.Logf("Create alert should not be called")
+			t.Fail()
+			return nil
+		},
+	}
+
+	w := &worker{
+		rule: &rules.Rule{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+		Region:      "eastus",
+		kustoClient: kcli,
+		AlertAddr:   "",
+		AlertCli:    alertCli,
+		HandlerFn:   nil,
+	}
+
+	ctx, _ := context.WithDeadline(context.Background(), time.Now())
+
+	w.ExecuteQuery(ctx)
+}
+
+func TestWorker_RequestInvalid(t *testing.T) {
+	kcli := &fakeKustoClient{
+		log:      logger.Default,
+		queryErr: kerrors.HTTP(kerrors.OpQuery, "Bad Request", http.StatusBadRequest, io.NopCloser(bytes.NewBufferString("query")), "Request is invalid and cannot be processed: Semantic error: SEM0001: Arithmetic expression cannot be carried-out between DateTime and StringBuffer"),
+	}
+
+	var createCalled bool
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			createCalled = true
+			return nil
+		},
+	}
+
+	w := &worker{
+		rule: &rules.Rule{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+		Region:      "eastus",
+		kustoClient: kcli,
+		AlertAddr:   "",
+		AlertCli:    alertCli,
+		HandlerFn:   nil,
+	}
+
+	w.ExecuteQuery(context.Background())
+	require.True(t, createCalled, "Create alert should be called")
+}

--- a/alerter/service.go
+++ b/alerter/service.go
@@ -251,12 +251,12 @@ func (c extendedKustoClient) Query(ctx context.Context, qc *engine.QueryContext,
 	if qc.Rule.IsMgmtQuery {
 		iter, err = c.client.Mgmt(ctx, qc.Rule.Database, qc.Stmt)
 		if err != nil {
-			return fmt.Errorf("failed to execute management kusto query=%s/%s: %s", qc.Rule.Namespace, qc.Rule.Name, err)
+			return fmt.Errorf("failed to execute management kusto query=%s/%s: %w", qc.Rule.Namespace, qc.Rule.Name, err)
 		}
 	} else {
 		iter, err = c.client.Query(ctx, qc.Rule.Database, qc.Stmt, kusto.ResultsProgressiveDisable())
 		if err != nil {
-			return fmt.Errorf("failed to execute kusto query=%s/%s: %s, %s", qc.Rule.Namespace, qc.Rule.Name, err, qc.Stmt)
+			return fmt.Errorf("failed to execute kusto query=%s/%s: %w, %s", qc.Rule.Namespace, qc.Rule.Name, err, qc.Stmt)
 		}
 	}
 


### PR DESCRIPTION
Some errors are transient or operator related and should not trigger notification for users creating alerts since they can't do anything with them.  This changes the failure notification to only send them if it's a user query error that they can resolve.

Other errors log and increment metrics indicating problems exist.