### PR TITLE
Use TLS by default

### DIFF
--- a/cluster/client.go
+++ b/cluster/client.go
@@ -15,13 +15,14 @@ type Client struct {
 	httpClient *http.Client
 }
 
-func NewClient(timeout time.Duration) (*Client, error) {
+func NewClient(timeout time.Duration, insecureSkipVerify bool) (*Client, error) {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.MaxIdleConns = 100
 	t.MaxConnsPerHost = 100
 	t.MaxIdleConnsPerHost = 100
 	t.ResponseHeaderTimeout = timeout
 	t.IdleConnTimeout = time.Minute
+	t.TLSClientConfig.InsecureSkipVerify = insecureSkipVerify
 
 	httpClient := &http.Client{
 		Timeout: timeout,

--- a/cluster/replicator.go
+++ b/cluster/replicator.go
@@ -14,6 +14,9 @@ import (
 type ReplicatorOpts struct {
 	// Partitioner is used to determine which node owns a given metric.
 	Partitioner MetricPartitioner
+
+	// InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name.
+	InsecureSkipVerify bool
 }
 
 // Replicator manages the transfer of local segments to other nodes.
@@ -36,7 +39,7 @@ type replicator struct {
 }
 
 func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
-	cli, err := NewClient(30 * time.Second)
+	cli, err := NewClient(30*time.Second, opts.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -29,6 +29,7 @@ func main() {
 			&cli.StringFlag{Name: "hostname", Usage: "Hostname filter override"},
 			&cli.StringSliceFlag{Name: "target", Usage: "Static Prometheus scrape target in the format of <host regex>=<url>.  Host names that match the regex will scrape the target url"},
 			&cli.StringSliceFlag{Name: "endpoints", Usage: "Prometheus remote write endpoint URLs"},
+			&cli.BoolFlag{Name: "insecure-skip-verify", Usage: "Skip TLS verification of remote write endpoints"},
 			&cli.StringFlag{Name: "listen-addr", Usage: "Address to listen on for Prometheus scrape requests", Value: ":8080"},
 			&cli.DurationFlag{Name: "scrape-interval", Usage: "Scrape interval", Value: 30 * time.Second},
 			&cli.StringSliceFlag{Name: "add-labels", Usage: "Label in the format of <name>=<value>.  These are added to all metrics collected by this agent"},
@@ -115,15 +116,16 @@ func realMain(ctx *cli.Context) error {
 	}
 
 	opts := &collector.ServiceOpts{
-		K8sCli:         k8scli,
-		ListentAddr:    ctx.String("listen-addr"),
-		ScrapeInterval: ctx.Duration("scrape-interval"),
-		NodeName:       hostname,
-		Targets:        staticTargets,
-		Endpoints:      endpoints,
-		DropMetrics:    dropMetrics,
-		AddLabels:      addLabels,
-		DropLabels:     dropLabels,
+		K8sCli:             k8scli,
+		ListentAddr:        ctx.String("listen-addr"),
+		ScrapeInterval:     ctx.Duration("scrape-interval"),
+		NodeName:           hostname,
+		Targets:            staticTargets,
+		Endpoints:          endpoints,
+		DropMetrics:        dropMetrics,
+		AddLabels:          addLabels,
+		DropLabels:         dropLabels,
+		InsecureSkipVerify: ctx.Bool("insecure-skip-verify"),
 	}
 
 	svcCtx, cancel := context.WithCancel(context.Background())

--- a/collector/service.go
+++ b/collector/service.go
@@ -51,6 +51,9 @@ type ServiceOpts struct {
 	DropLabels     map[string]struct{}
 	ScrapeInterval time.Duration
 	DropMetrics    map[string]struct{}
+
+	// InsecureSkipVerify skips the verification of the remote write endpoint certificate chain and host name.
+	InsecureSkipVerify bool
 }
 
 type scrapeTarget struct {
@@ -83,7 +86,7 @@ func (s *Service) Open(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	var err error
-	s.remoteClient, err = promremote.NewClient(10 * time.Second)
+	s.remoteClient, err = promremote.NewClient(10*time.Second, s.opts.InsecureSkipVerify)
 	if err != nil {
 		return fmt.Errorf("failed to create prometheus remote client: %w", err)
 	}

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -55,6 +55,9 @@ type ServiceOpts struct {
 	// Dimensions is a slice of column=value elements where each element will be added all rows.
 	Dimensions []string
 	K8sCli     *kubernetes.Clientset
+
+	// InsecureSkipVerify disables TLS certificate verification.
+	InsecureSkipVerify bool
 }
 
 func NewService(opts ServiceOpts) (*Service, error) {

--- a/pkg/tls/cert.go
+++ b/pkg/tls/cert.go
@@ -1,0 +1,79 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+)
+
+// NewFakeTLSCredentials generates a self-signed certificate and private key for testing.
+func NewFakeTLSCredentials() ([]byte, []byte, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization:  []string{"Fake Org"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Fake City"},
+			StreetAddress: []string{"Fake Address"},
+			PostalCode:    []string{"12345"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2023),
+		Subject: pkix.Name{
+			Organization:  []string{"Fake Org"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Fake City"},
+			StreetAddress: []string{"Fake Address"},
+			PostalCode:    []string{"94016"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	return certPEM.Bytes(), certPrivKeyPEM.Bytes(), nil
+}

--- a/pkg/tls/cert_test.go
+++ b/pkg/tls/cert_test.go
@@ -1,0 +1,16 @@
+package tls
+
+import (
+	"crypto/tls"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewCACert(t *testing.T) {
+	cert, key, err := NewFakeTLSCredentials()
+	require.NoError(t, err)
+
+	// Validate that the cert and key are valid
+	_, err = tls.X509KeyPair(cert, key)
+	require.NoError(t, err)
+}

--- a/promremote/client.go
+++ b/promremote/client.go
@@ -16,13 +16,14 @@ type Client struct {
 	httpClient *http.Client
 }
 
-func NewClient(timeout time.Duration) (*Client, error) {
+func NewClient(timeout time.Duration, insecureSkipVerify bool) (*Client, error) {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.MaxIdleConns = 100
 	t.MaxConnsPerHost = 100
 	t.MaxIdleConnsPerHost = 100
 	t.ResponseHeaderTimeout = timeout
 	t.IdleConnTimeout = time.Minute
+	t.TLSClientConfig.InsecureSkipVerify = insecureSkipVerify
 
 	httpClient := &http.Client{
 		Timeout: timeout,

--- a/tools/cmd/write-load/main.go
+++ b/tools/cmd/write-load/main.go
@@ -132,7 +132,7 @@ func reportStats(ctx context.Context, stats *stats, batches chan *prompb.WriteRe
 }
 
 func writer(ctx context.Context, endpoint string, stats *stats, ch chan *prompb.WriteRequest) {
-	cli, err := promremote.NewClient(30 * time.Second)
+	cli, err := promremote.NewClient(30*time.Second, true)
 	if err != nil {
 		logger.Fatal("prom client: %w", err)
 	}


### PR DESCRIPTION
This switches the ingestor listeners to use TLS by default and
removes support for non-TLS connectivity.  To keep local development
simple, we'll generate a self-signed cert automatically.  For production
setups, a cert and key need to exist on disk that can be loaded.