### PR TITLE
fix creation of multiple kusto clients

### DIFF
--- a/alerter/multikustoclient/mulikistoclient.go
+++ b/alerter/multikustoclient/mulikistoclient.go
@@ -16,7 +16,7 @@ type multiKustoClient struct {
 }
 
 func New(endpoints map[string]string, missid string, max int) (multiKustoClient, error) {
-	var clients map[string]*kusto.Client
+	clients := make(map[string]*kusto.Client)
 	for name, endpoint := range endpoints {
 		kcsb := kusto.NewConnectionStringBuilder(endpoint).WithAzCli()
 		if missid == "" {


### PR DESCRIPTION
Before we assign kusto clients to a map, we need to create the map.