### PR TITLE
linter fails on query errors

### DIFF
--- a/alerter/service.go
+++ b/alerter/service.go
@@ -181,9 +181,11 @@ func Lint(ctx context.Context, opts *AlerterOpts, path string) error {
 	}()
 
 	executor.RunOnce(ctx)
+	if lint.HasFailedQueries() {
+		return fmt.Errorf("failed to lint rules")
+	}
 	lint.Log(log)
 	return nil
-
 }
 
 func (l *Alerter) Open(ctx context.Context) error {


### PR DESCRIPTION
Query-errors are generated with a CorrelationID with the prefix "alert-failure". If the alert handler used within the linter gets an error with this CorrelationID, keep track of that fact and error out the linting process to make it clear that something failed linting.