### PR TITLE
UnmarshalStrict local yaml rule definitions

### DIFF
--- a/alerter/rules/localStore_test.go
+++ b/alerter/rules/localStore_test.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,10 +29,84 @@ spec:
   destination: "peoplewhocare"
 `
 
+var multiRule = `apiVersion: adx-mon.azure.com/v1
+kind: AlertRule
+metadata:
+  name: alertRuleOne
+  namespace: namespaceOne
+spec:
+  database: SomeDB
+  interval: 1h
+  query: |
+    BadThings
+    | where stuff  > 1
+    | summarize count() by region
+    | extend Severity=3
+    | extend  Title = "Bad Things!"
+    | extend  Summary  =  "Bad Things! Oh no"
+    | extend CorrelationId = region
+    | extend TSG="http://gofixit.com"
+  autoMitigateAfter: 2h
+  destination: "peoplewhocare"
+
+---
+
+apiVersion: adx-mon.azure.com/v1
+kind: AlertRule
+metadata:
+  name: alertRuleTwo
+  namespace: namespaceTwo
+spec:
+  database: SomeDB
+  interval: 1h
+  query: |
+    BadThings
+    | where stuff  > 1
+    | summarize count() by region
+    | extend Severity=3
+    | extend  Title = "Bad Things!"
+    | extend  Summary  =  "Bad Things! Oh no"
+    | extend CorrelationId = region
+    | extend TSG="http://gofixit.com"
+  autoMitigateAfter: 2h
+  destination: "peoplewhocare"
+`
+
+// has incorrect indentation, which leads to unknown field errors
+var invalidRuleExample = `apiVersion: adx-mon.azure.com/v1
+kind: AlertRule
+metadata:
+  name: bar
+  namespace: foo
+spec:
+  database: SomeDB
+  interval: 1h
+  query: |
+    BadThings
+    | where stuff  > 1
+    | summarize count() by region
+    | extend Severity=3
+    | extend  Title = "Bad Things!"
+    | extend  Summary  =  "Bad Things! Oh no"
+    | extend CorrelationId = region
+    | extend TSG="http://gofixit.com"
+autoMitigateAfter: 2h
+  destination: "peoplewhocare"
+`
+
 func TestFromPath(t *testing.T) {
-	testdir := t.TempDir()
-	testfile := filepath.Join(testdir, "test.yaml")
-	err := ioutil.WriteFile(testfile, []byte(alertruleExample), 0644)
+	validFileDirectory := t.TempDir()
+	testfile := filepath.Join(validFileDirectory, "test.yaml")
+	err := os.WriteFile(testfile, []byte(alertruleExample), 0644)
+	require.NoError(t, err)
+
+	multiTestfile := filepath.Join(validFileDirectory, "zmultitest.yaml")
+	err = os.WriteFile(multiTestfile, []byte(multiRule), 0644)
+	require.NoError(t, err)
+
+	invalidFileDirectory := t.TempDir()
+	invalidTestfile := filepath.Join(invalidFileDirectory, "invalid.yaml")
+	err = os.WriteFile(invalidTestfile, []byte(invalidRuleExample), 0644)
 	require.NoError(t, err)
 
 	type testcase struct {
@@ -44,11 +118,16 @@ func TestFromPath(t *testing.T) {
 	testcases := []testcase{
 		{
 			name:      "valid directory",
-			path:      testdir,
+			path:      validFileDirectory,
 			expectErr: false,
 		},
 		{
-			name:      "invalid directory",
+			name:      "invalid yaml in directory should return error",
+			path:      invalidFileDirectory,
+			expectErr: true,
+		},
+		{
+			name:      "non-existant directory",
 			path:      "/tmp/doesnotexist",
 			expectErr: true,
 		},
@@ -61,8 +140,13 @@ func TestFromPath(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, 3, len(store.rules))
 				require.Equal(t, "foo", store.rules[0].Namespace)
 				require.Equal(t, "bar", store.rules[0].Name)
+				require.Equal(t, "namespaceOne", store.rules[1].Namespace)
+				require.Equal(t, "alertRuleOne", store.rules[1].Name)
+				require.Equal(t, "namespaceTwo", store.rules[2].Namespace)
+				require.Equal(t, "alertRuleTwo", store.rules[2].Name)
 			}
 		})
 	}


### PR DESCRIPTION
When unmarshalling rule definitions from disk, we should ensure that unexpected fields are not present to help catch formatting errors. This only affects the path where rules are loaded from disk. The format and contents of rules are already validated when being added to Kubernetes with openapi validation.