### PR TITLE
Change alert rule matching criteria

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@
 
 build-alerter:
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/alerter cmd/alerter/main.go
+	CGO_ENABLED=0 go build -o bin/alerter ./cmd/alerter/...
 .PHONY: build
 
 build-ingestor:
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/ingestor cmd/ingestor/main.go
+	CGO_ENABLED=0 go build -o bin/ingestor ./cmd/ingestor/...
 .PHONY: build
 
 build-collector:
 	mkdir -p bin
-	CGO_ENABLED=0 go build -o bin/collector cmd/collector/main.go
+	CGO_ENABLED=0 go build -o bin/collector ./cmd/collector/...
 .PHONY: build
 
 

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -79,9 +79,13 @@ func (e *Executor) workerKey(rule *rules.Rule) string {
 }
 
 func (e *Executor) newWorker(rule *rules.Rule) *worker {
+	lowerTags := make(map[string]string, len(e.tags))
+	for k, v := range e.tags {
+		lowerTags[strings.ToLower(k)] = strings.ToLower(v)
+	}
 	return &worker{
 		rule:        rule,
-		tags:        e.tags,
+		tags:        lowerTags,
 		kustoClient: e.kustoClient,
 		Region:      e.region,
 		HandlerFn:   e.HandlerFn,

--- a/api/v1/alertrule_types.go
+++ b/api/v1/alertrule_types.go
@@ -37,7 +37,7 @@ type AlertRuleSpec struct {
 	// Key/Value pairs used to determine when an alert can execute.  If empty, always execute.  Keys and values
 	// are deployment specific and configured on alerter instances.  For example, an alerter instance may be
 	// started with `--tag cloud=public`. If an AlertRule has `criteria: {cloud: public}`, then the rule will only
-	// execute on that alerter. All key/values pairs must match (case-insensitive) for the rule to execute.
+	// execute on that alerter. Any key/values pairs must match (case-insensitive) for the rule to execute.
 	Criteria map[string]string `json:"criteria,omitempty"`
 }
 


### PR DESCRIPTION
Matchig all tags is too restrictive and prevents some use-cases that were intended to be supportable.  This changes the matching criteria to match at least one tag if any tags are defined.