### PR TITLE
Fix cardinality collection sampling

### DIFF
--- a/metrics/service.go
+++ b/metrics/service.go
@@ -55,7 +55,7 @@ func (s *service) AddSeries(key string, id uint64) {
 }
 
 func (s *service) collect(ctx context.Context) {
-	t := time.NewTicker(10 * time.Second)
+	t := time.NewTicker(time.Minute)
 	defer t.Stop()
 
 	var lastCount float64

--- a/pkg/counter/multi_test.go
+++ b/pkg/counter/multi_test.go
@@ -1,6 +1,7 @@
 package counter
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,4 +30,20 @@ func TestMultiEstimator(t *testing.T) {
 	require.Equal(t, uint64(0), est.Count("foo"))
 	require.Equal(t, uint64(0), est.Count("bar"))
 	require.Equal(t, uint64(0), est.Count("baz"))
+}
+
+func TestMultiEstimator_HighCount(t *testing.T) {
+	samples := 1000000
+	est := NewMultiEstimator()
+	require.Equal(t, uint64(0), est.Count("foo"))
+
+	for i := 0; i < samples; i++ {
+		u := rand.Uint64()
+		est.Add("foo", u)
+	}
+	require.True(t, float64(samples-int(est.Count("foo")))/float64(samples) < 0.01)
+	est.Roll()
+	require.True(t, float64(samples-int(est.Count("foo")))/float64(samples) < 0.01)
+	est.Roll()
+	require.Equal(t, uint64(0), est.Count("foo"))
 }


### PR DESCRIPTION
The sampling was every 30s, but we rolled over every 10s so we are under counting cardinality.