### PR TITLE
Fix criteria to support multiple values for a tag

### DIFF
--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -59,8 +59,15 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 	var matched bool
 	for k, v := range e.rule.Criteria {
 		lowerKey := strings.ToLower(k)
-		if vv, ok := e.tags[lowerKey]; ok && strings.ToLower(vv) == strings.ToLower(v) {
-			matched = true
+		if vv, ok := e.tags[lowerKey]; ok {
+			for _, value := range v {
+				if strings.ToLower(vv) == strings.ToLower(value) {
+					matched = true
+					break
+				}
+			}
+		}
+		if matched {
 			break
 		}
 	}

--- a/alerter/rules/store.go
+++ b/alerter/rules/store.go
@@ -160,7 +160,7 @@ type Rule struct {
 	Destination       string
 
 	// Criteria is a map of key-value pairs that are used to determine where an alert can execute.
-	Criteria map[string]string
+	Criteria map[string][]string
 
 	// Management queries (starts with a dot) have to call a different
 	// query API in the Kusto Go SDK.

--- a/api/v1/alertrule_types_test.go
+++ b/api/v1/alertrule_types_test.go
@@ -1,0 +1,35 @@
+package v1_test
+
+import (
+	"testing"
+
+	v1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertRuleSpec_UnmarshalJSON_CriteriaList(t *testing.T) {
+	data := `{"autoMitigateAfter":"1h","criteria":{"cloud":["AzureCloud","AGC"]},"database":"DB","destination":"Destination","interval":"5m","query":"Query\n"}`
+	a := &v1.AlertRuleSpec{}
+	err := a.UnmarshalJSON([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, "1h0m0s", a.AutoMitigateAfter.Duration.String())
+	require.Equal(t, "DB", a.Database)
+	require.Equal(t, "Destination", a.Destination)
+	require.Equal(t, "5m0s", a.Interval.Duration.String())
+	require.Equal(t, "Query\n", a.Query)
+	require.Equal(t, map[string][]string{"cloud": {"AzureCloud", "AGC"}}, a.Criteria)
+}
+
+func TestAlertRuleSpec_UnmarshalJSON_CriteriaString(t *testing.T) {
+	// This is an example of the old format for the Criteria field.  It is a map[string]string instead of a map[string][]string.
+	data := `{"autoMitigateAfter":"1h","criteria":{"cloud":"AzureCloud"},"database":"DB","destination":"Destination","interval":"5m","query":"Query\n"}`
+	a := &v1.AlertRuleSpec{}
+	err := a.UnmarshalJSON([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, "1h0m0s", a.AutoMitigateAfter.Duration.String())
+	require.Equal(t, "DB", a.Database)
+	require.Equal(t, "Destination", a.Destination)
+	require.Equal(t, "5m0s", a.Interval.Duration.String())
+	require.Equal(t, "Query\n", a.Query)
+	require.Equal(t, map[string][]string{"cloud": {"AzureCloud"}}, a.Criteria)
+}

--- a/kustomize/bases/alertrules_crd.yaml
+++ b/kustomize/bases/alertrules_crd.yaml
@@ -47,7 +47,9 @@ spec:
                   type: string
                 criteria:
                   additionalProperties:
-                    type: string
+                    type: array
+                    items:
+                      type: string
                   description: Free form key value pairs
                   type: object
               type: object


### PR DESCRIPTION
The criteria spec field was a map[string]string, which doesn't let you do something like:

spec:
  cloud:
    - Public
    - Private

This fixes the criteria to support multiple values for a key and support backwards compatibility with the prior format for now.