### PR TITLE
alerter lint now supports tags

### DIFF
--- a/alerter/service.go
+++ b/alerter/service.go
@@ -189,6 +189,7 @@ func Lint(ctx context.Context, opts *AlerterOpts, path string) error {
 		KustoClient: kclient,
 		RuleStore:   ruleStore,
 		Region:      opts.Region,
+		Tags:        opts.Tags,
 	})
 
 	go func() {

--- a/cmd/alerter/lint.go
+++ b/cmd/alerter/lint.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/adx-mon/alerter"
 	alertrulev1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/urfave/cli/v2"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -21,7 +22,9 @@ func NewLintCommand() *cli.Command {
 			&cli.StringFlag{Name: "auth-msi-id", Usage: "MSI client ID for authentication to Kusto"},
 			&cli.StringFlag{Name: "auth-token", Usage: "Application token for authentication to Kusto"},
 			&cli.IntFlag{Name: "max-notifications", Value: 25, Usage: "Maximum number of notifications to send per rule"},
+			&cli.StringFlag{Name: "cloud", Usage: "Azure cloud"},
 			&cli.StringFlag{Name: "region", Usage: "Current region"},
+			&cli.StringSliceFlag{Name: "tag", Usage: "Tag in the format of <key>=<value> that applies to execution context"},
 		},
 		Action: lintMain,
 	}
@@ -46,12 +49,32 @@ func lintMain(ctx *cli.Context) error {
 		return err
 	}
 
+	tags := make(map[string]string)
+	tagsArg := ctx.StringSlice("tag")
+	for _, v := range tagsArg {
+		parts := strings.Split(v, "=")
+		if len(parts) != 2 {
+			return cli.Exit("Invalid tag format, expected <key>=<value>", 1)
+		}
+		tags[strings.ToLower(parts[0])] = strings.ToLower(parts[1])
+	}
+
+	// Always add region and cloud tags which are required params for alerter currently.
+	tags["region"] = strings.ToLower(ctx.String("region"))
+	tags["cloud"] = strings.ToLower(ctx.String("cloud"))
+
+	for k, v := range tags {
+		logger.Info("Using tag %s=%s", k, v)
+	}
+
 	opts := &alerter.AlerterOpts{
 		KustoEndpoints:   endpoints,
 		Port:             4023, // needs to be adjustable?Failed to create Notification
+		Cloud:            ctx.String("cloud"),
 		Region:           ctx.String("region"),
 		MaxNotifications: ctx.Int("max-notifications"),
 		KustoToken:       ctx.String("auth-token"),
+		Tags:             tags,
 	}
 
 	lintCtx, cancel := context.WithCancel(ctx.Context)


### PR DESCRIPTION
Region, Cloud, and other tags are a standard mechanism used within rules for evaluating criteria. Configure the linter like the main alerter process to allow evaluating rules with criteria in them.