### PR TITLE
Collect and expose metrics for OTLP logs handler

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -72,4 +72,26 @@ var (
 		Name:      "notification_unhealthy",
 		Help:      "Gauge indicating if a notification is healthy or not",
 	}, []string{"namespace", "name"})
+
+	// Collector metrics
+	LogsProxyReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_received",
+		Help:      "Counter of the number of logs received by the proxy",
+	})
+
+	LogsProxyFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_failures",
+		Help:      "Counter of the number of failures when proxying logs to the OTLP endpoints",
+	}, []string{"endpoint"})
+
+	LogsProxyPartialFailures = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_partial_failures",
+		Help:      "Counter of the number of partial failures when proxying logs to the OTLP endpoints",
+	}, []string{"endpoint"})
 )

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -38,7 +38,7 @@ services:
     # While the _endpoints_ URI doesn't match the expected OTLP syntax, keep in
     # mind that _Collector_ is currently configured to connect to _Ingestor_, so we
     # just modify the _endpoints_ in pkg/otlp/proxy to be OTLP compliant.
-    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --endpoints http://otel:4317 --insecure-skip-verify
+    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --endpoints http://otel:4317 --insecure-skip-verify --target=.*=http://localhost:8080/metrics:adx-mon/collector/collector
     depends_on:
       - ingestor
       - otel


### PR DESCRIPTION
Metrics emitted by the OTLP logs handler are gathered and sent upstream as part of Collector's existing scrape interval.

By running the integration test `docker compose -f tools/otlp/logs/compose.yaml up` we can observe the metrics being collected and sent 

```diff
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_frees_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 69213.000000","ts":"2023-08-07T16:46:35.909826Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_objects,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 52388.000000","ts":"2023-08-07T16:46:35.909955Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_mspan_inuse_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 221904.000000","ts":"2023-08-07T16:46:35.909973Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_threads,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 16.000000","ts":"2023-08-07T16:46:35.910000Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_resident_memory_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 70918144.000000","ts":"2023-08-07T16:46:35.910031Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_start_time_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1691426764.600000","ts":"2023-08-07T16:46:35.910036Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_buck_hash_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1632190.000000","ts":"2023-08-07T16:46:35.910044Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 55948552.000000","ts":"2023-08-07T16:46:35.910051Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_virtual_memory_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 772231168.000000","ts":"2023-08-07T16:46:35.910055Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_inuse_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 36544512.000000","ts":"2023-08-07T16:46:35.910059Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_cpu_seconds_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 0.690000","ts":"2023-08-07T16:46:35.910063Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_max_fds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1048576.000000","ts":"2023-08-07T16:46:35.910067Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_virtual_memory_max_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 18446744073709551616.000000","ts":"2023-08-07T16:46:35.910095Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_mcache_inuse_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 19200.000000","ts":"2023-08-07T16:46:35.910125Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_stack_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1507328.000000","ts":"2023-08-07T16:46:35.910139Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=promhttp_metric_handler_requests_in_flight,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1.000000","ts":"2023-08-07T16:46:35.910142Z"}
+ logs-collector-1  | {"lvl":"DBG","msg":"__name__=adxmon_ingestor_requests_received_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,code=200,path=/logs  1691426795909 29.000000","ts":"2023-08-07T16:46:35.910147Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_last_gc_time_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1691426765.907566","ts":"2023-08-07T16:46:35.910161Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_mallocs_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 121601.000000","ts":"2023-08-07T16:46:35.910186Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_alloc_bytes_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 48456464.000000","ts":"2023-08-07T16:46:35.910193Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_goroutines,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 26.000000","ts":"2023-08-07T16:46:35.910199Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_alloc_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 33647472.000000","ts":"2023-08-07T16:46:35.910266Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 40435712.000000","ts":"2023-08-07T16:46:35.910278Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=promhttp_metric_handler_requests_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,code=200  1691426795909 0.000000","ts":"2023-08-07T16:46:35.910282Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=promhttp_metric_handler_requests_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,code=500  1691426795909 0.000000","ts":"2023-08-07T16:46:35.910286Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=promhttp_metric_handler_requests_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,code=503  1691426795909 0.000000","ts":"2023-08-07T16:46:35.910290Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,quantile=0.000000  1691426795909 0.000046","ts":"2023-08-07T16:46:35.910307Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,quantile=0.250000  1691426795909 0.000151","ts":"2023-08-07T16:46:35.910315Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,quantile=0.500000  1691426795909 0.000200","ts":"2023-08-07T16:46:35.910379Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,quantile=0.750000  1691426795909 0.000327","ts":"2023-08-07T16:46:35.910386Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,quantile=1.000000  1691426795909 0.001527","ts":"2023-08-07T16:46:35.910390Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds_sum,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 0.003192","ts":"2023-08-07T16:46:35.910423Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds_count,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 9.000000","ts":"2023-08-07T16:46:35.910432Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_gc_duration_seconds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 0.000000","ts":"2023-08-07T16:46:35.910437Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_alloc_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 33647472.000000","ts":"2023-08-07T16:46:35.910487Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_idle_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 3891200.000000","ts":"2023-08-07T16:46:35.910493Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_heap_released_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 3629056.000000","ts":"2023-08-07T16:46:35.910504Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_lookups_total,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 0.000000","ts":"2023-08-07T16:46:35.910511Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_mcache_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 31200.000000","ts":"2023-08-07T16:46:35.910516Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_mspan_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 227808.000000","ts":"2023-08-07T16:46:35.910564Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=process_open_fds,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 14.000000","ts":"2023-08-07T16:46:35.910570Z"}
+ logs-collector-1  | {"lvl":"DBG","msg":"__name__=adxmon_collector_logs_received,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 29.000000","ts":"2023-08-07T16:46:35.910585Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_gc_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 9746832.000000","ts":"2023-08-07T16:46:35.910633Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_next_gc_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 62903544.000000","ts":"2023-08-07T16:46:35.910649Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_other_sys_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 2367482.000000","ts":"2023-08-07T16:46:35.910658Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_memstats_stack_inuse_bytes,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector  1691426795909 1507328.000000","ts":"2023-08-07T16:46:35.910686Z"}
logs-collector-1  | {"lvl":"DBG","msg":"__name__=go_info,adxmon_container=collector,adxmon_namespace=adx-mon,adxmon_pod=collector,version=go1.19.4  1691426795909 1.000000","ts":"2023-08-07T16:46:35.910699Z"}
```