### PR TITLE
Create an OTLP/logs CSV Marshaler

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -179,7 +179,7 @@ func realMain(ctx *cli.Context) error {
 		logger.Fatal("--storage-dir is required")
 	}
 
-	defaultMapping := storage.NewSchema()
+	defaultMapping := storage.NewMetricsSchema()
 	for _, v := range ctx.StringSlice("add-labels") {
 		fields := strings.Split(v, "=")
 		if len(fields) != 2 {

--- a/ingestor/storage/schema.go
+++ b/ingestor/storage/schema.go
@@ -6,7 +6,10 @@ import (
 	"github.com/Azure/adx-mon/ingestor/transform"
 )
 
-var DefaultMapping SchemaMapping = NewSchema()
+var (
+	DefaultMetricsMapping SchemaMapping = NewMetricsSchema()
+	DefaultLogsMapping    SchemaMapping = NewLogsSchema()
+)
 
 type SchemaMapping []CSVMapping
 
@@ -19,7 +22,7 @@ type CSVMapping struct {
 	} `json:"Properties"`
 }
 
-func NewSchema() SchemaMapping {
+func NewMetricsSchema() SchemaMapping {
 	var (
 		mapping SchemaMapping
 		idx     int
@@ -68,6 +71,114 @@ func NewSchema() SchemaMapping {
 			Ordinal: strconv.Itoa(idx),
 		},
 	})
+	return mapping
+}
+
+func NewLogsSchema() SchemaMapping {
+	// https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition
+	var (
+		mapping SchemaMapping
+		idx     int
+	)
+	mapping = append(mapping, CSVMapping{
+		Column:   "Timestamp",
+		DataType: "datetime",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "ObservedTimestamp",
+		DataType: "datetime",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "TraceId",
+		DataType: "string",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "SpanId",
+		DataType: "string",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "SeverityText",
+		DataType: "string",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "SeverityNumber",
+		DataType: "int",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "Body",
+		DataType: "dynamic",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "Resource",
+		DataType: "dynamic",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
+	mapping = append(mapping, CSVMapping{
+		Column:   "Attributes",
+		DataType: "dynamic",
+		Properties: struct {
+			Ordinal    string `json:"Ordinal,omitempty"`
+			ConstValue string `json:"ConstValue,omitempty"`
+		}{
+			Ordinal: strconv.Itoa(idx),
+		},
+	})
+	idx += 1
 	return mapping
 }
 

--- a/ingestor/storage/schema_test.go
+++ b/ingestor/storage/schema_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewSchema_NoLabels(t *testing.T) {
-	mapping := storage.NewSchema()
+	mapping := storage.NewMetricsSchema()
 	_, err := json.Marshal(mapping)
 	require.NoError(t, err)
 
@@ -32,7 +32,7 @@ func TestNewSchema_NoLabels(t *testing.T) {
 }
 
 func TestNewSchema_AddConstMapping(t *testing.T) {
-	mapping := storage.NewSchema()
+	mapping := storage.NewMetricsSchema()
 	mapping = mapping.AddConstMapping("Region", "eastus")
 
 	_, err := json.Marshal(mapping)
@@ -63,7 +63,7 @@ func TestNewSchema_AddConstMapping(t *testing.T) {
 }
 
 func TestNewSchema_AddLiftedMapping(t *testing.T) {
-	mapping := storage.NewSchema()
+	mapping := storage.NewMetricsSchema()
 
 	mapping = mapping.AddStringMapping("Region")
 	mapping = mapping.AddStringMapping("Host")

--- a/ingestor/transform/csv_test.go
+++ b/ingestor/transform/csv_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	"github.com/Azure/adx-mon/pkg/prompb"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestMarshalCSV(t *testing.T) {
@@ -54,6 +56,52 @@ func TestMarshalCSV(t *testing.T) {
 2022-11-22T10:22:06.003Z,-9070404444212865161,"{""measurement"":""used_cpu_user_children"",""hostname"":""host_1"",""region"":""eastus""}",2.000000000
 `, string(w.Bytes()))
 
+}
+
+func BenchmarkMarshalCSV(b *testing.B) {
+	ts := prompb.TimeSeries{
+		Labels: []prompb.Label{
+			{
+				Name:  []byte("__name__"),
+				Value: []byte("__redis__"),
+			},
+			{
+				Name:  []byte("measurement"),
+				Value: []byte("used_cpu_user_children"),
+			},
+			{
+				Name:  []byte("hostname"),
+				Value: []byte("host_1"),
+			},
+			{
+				Name:  []byte("region"),
+				Value: []byte("eastus"),
+			},
+		},
+
+		Samples: []prompb.Sample{
+			{
+				Timestamp: 1669112524001,
+				Value:     0,
+			},
+			{
+				Timestamp: 1669112525002,
+				Value:     1,
+			},
+			{
+				Timestamp: 1669112526003,
+				Value:     2,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	w := NewCSVWriter(&buf, nil)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		w.MarshalCSV(ts)
+	}
 }
 
 func TestMarshalCSV_LiftLabel(t *testing.T) {
@@ -111,3 +159,233 @@ func TestNormalize(t *testing.T) {
 	require.Equal(t, "Region", string(Normalize([]byte("region"))))
 
 }
+
+func TestMarshalCSV_OTLPLog(t *testing.T) {
+	rawlog := []byte(`{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "RPTenant",
+                        "value": {
+                            "stringValue": "eastus"
+                        }
+                    },
+					{
+                        "key": "UnderlayName",
+                        "value": {
+                            "stringValue": "hcp-underlay-eastus-cx-test"
+                        }
+                    }
+                ],
+                "droppedAttributesCount": 1
+            },
+            "scopeLogs": [
+                {
+                    "scope": {
+                        "name": "name",
+                        "version": "version",
+                        "droppedAttributesCount": 1
+                    },
+                    "logRecords": [
+                        {
+                            "timeUnixNano": "1669112524001",
+                            "observedTimeUnixNano": "1669112524001",
+                            "severityNumber": 17,
+                            "severityText": "Error",
+                            "body": {
+                                "stringValue": "{\"msg\":\"something happened\"}"
+                            },
+                            "attributes": [
+                                {
+                                    "key": "kusto.table",
+                                    "value": {
+                                        "stringValue": "ATable"
+                                    }
+                                },
+								{
+                                    "key": "kusto.database",
+                                    "value": {
+                                        "stringValue": "ADatabase"
+                                    }
+                                }
+                            ],
+                            "droppedAttributesCount": 1,
+                            "flags": 1,
+                            "traceId": "",
+                            "spanId": ""
+                        }
+                    ],
+                    "schemaUrl": "scope_schema"
+                }
+            ],
+            "schemaUrl": "resource_schema"
+        }
+    ]
+}`)
+	var log v1.ExportLogsServiceRequest
+	if err := protojson.Unmarshal(rawlog, &log); err != nil {
+		t.Fatal(err)
+	}
+	var b bytes.Buffer
+	w := NewCSVWriter(&b, nil)
+
+	err := w.MarshalCSV(&log)
+	require.NoError(t, err)
+	require.Equal(t, `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,"{""msg"":""something happened""}","{""RPTenant"":""eastus"",""UnderlayName"":""hcp-underlay-eastus-cx-test""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
+`, b.String())
+}
+
+func BenchmarkMarshalCSV_OTLPLog(b *testing.B) {
+	rawlog := []byte(`{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "RPTenant",
+                        "value": {
+                            "stringValue": "eastus"
+                        }
+                    },
+					{
+                        "key": "UnderlayName",
+                        "value": {
+                            "stringValue": "hcp-underlay-eastus-cx-test"
+                        }
+                    }
+                ],
+                "droppedAttributesCount": 1
+            },
+            "scopeLogs": [
+                {
+                    "scope": {
+                        "name": "name",
+                        "version": "version",
+                        "droppedAttributesCount": 1
+                    },
+                    "logRecords": [
+                        {
+                            "timeUnixNano": "1669112524001",
+                            "observedTimeUnixNano": "1669112524001",
+                            "severityNumber": 17,
+                            "severityText": "Error",
+                            "body": {
+                                "stringValue": "{\"msg\":\"something happened\"}"
+                            },
+                            "attributes": [
+                                {
+                                    "key": "kusto.table",
+                                    "value": {
+                                        "stringValue": "ATable"
+                                    }
+                                },
+								{
+                                    "key": "kusto.database",
+                                    "value": {
+                                        "stringValue": "ADatabase"
+                                    }
+                                }
+                            ],
+                            "droppedAttributesCount": 1,
+                            "flags": 1,
+                            "traceId": "",
+                            "spanId": ""
+                        }
+                    ],
+                    "schemaUrl": "scope_schema"
+                }
+            ],
+            "schemaUrl": "resource_schema"
+        }
+    ]
+}`)
+	var log v1.ExportLogsServiceRequest
+	protojson.Unmarshal(rawlog, &log)
+	var buf bytes.Buffer
+	w := NewCSVWriter(&buf, nil)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.MarshalCSV(&log)
+	}
+}
+
+// Benchmark ways of making CSVWriter compatible with Metrics and Logs
+
+type writerType int
+
+const (
+	metricWriter writerType = iota
+	logWriter
+)
+
+type writer struct {
+	wType writerType
+}
+
+func (w writer) WriteInterface(t interface{}) {
+	switch t := t.(type) {
+	case prompb.TimeSeries:
+		w.writeMetric(t)
+	case *v1.ExportLogsServiceRequest:
+		w.writeLog(t)
+	}
+}
+
+func (w writer) WriteType(t interface{}) {
+	switch w.wType {
+	case metricWriter:
+		w.writeMetric(t.(prompb.TimeSeries))
+	case logWriter:
+		w.writeLog(t.(*v1.ExportLogsServiceRequest))
+	}
+}
+
+func (w writer) writeMetric(t prompb.TimeSeries) {
+	// do nothing
+}
+
+func (w writer) writeLog(t *v1.ExportLogsServiceRequest) {
+	// do nothing
+}
+
+func BenchmarkMethod(b *testing.B) {
+	w := writer{}
+	for i := 0; i < b.N; i++ {
+		w.writeMetric(prompb.TimeSeries{})
+	}
+}
+
+func BenchmarkInterface(b *testing.B) {
+	w := writer{}
+	for i := 0; i < b.N; i++ {
+		w.WriteInterface(prompb.TimeSeries{})
+	}
+}
+
+func BenchmarkType(b *testing.B) {
+	w := writer{wType: metricWriter}
+	for i := 0; i < b.N; i++ {
+		w.WriteType(prompb.TimeSeries{})
+	}
+}
+
+/*
+Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^(BenchmarkMethod|BenchmarkInterface|BenchmarkType)$ github.com/Azure/adx-mon/ingestor/transform
+
+goos: linux
+goarch: amd64
+pkg: github.com/Azure/adx-mon/ingestor/transform
+cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+BenchmarkMethod-16       	1000000000	         0.2971 ns/op	       0 B/op	       0 allocs/op
+BenchmarkInterface-16    	1000000000	         0.2929 ns/op	       0 B/op	       0 allocs/op
+BenchmarkType-16         	1000000000	         0.2916 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/Azure/adx-mon/ingestor/transform	0.992s
+
+Conclusion, since there's no meaningful difference between these approaches, the easiest
+solution from the caller's perspective, which requires the least amount of upstream changes,
+is to perform the type assertion against the interface{} and call the method directly.
+*/


### PR DESCRIPTION
Pave the way to support OTLP/logs in Ingestor by creating a compatible CSV marshaler. Also introduced are several benchmarks to ensure the CSV writer performance, both for metrics and logs, are able to be compared.

Our existing metrics CSV marshaler benchmarks as 

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkMarshalCSV$ github.com/Azure/adx-mon/ingestor/transform

goos: linux
goarch: amd64
pkg: github.com/Azure/adx-mon/ingestor/transform
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
BenchmarkMarshalCSV-16    	  329416	      4370 ns/op	    2141 B/op	      17 allocs/op
PASS
ok  	github.com/Azure/adx-mon/ingestor/transform	1.495s
```

Our new OTLP/logs CSV marshaler benchmarks as 

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkMarshalCSV_OTLPLog$ github.com/Azure/adx-mon/ingestor/transform

goos: linux
goarch: amd64
pkg: github.com/Azure/adx-mon/ingestor/transform
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
BenchmarkMarshalCSV_OTLPLog-16    	  527484	      2546 ns/op	    1553 B/op	      19 allocs/op
PASS
ok  	github.com/Azure/adx-mon/ingestor/transform	1.381s
```

