### PR TITLE
Replace type-specific Writer definitions with an Interface

### DIFF
--- a/ingestor/cluster/coordinator_test.go
+++ b/ingestor/cluster/coordinator_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
@@ -76,7 +76,6 @@ func TestCoordinator_NewPeer(t *testing.T) {
 	kcli := fakek8s.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*self}})
 
 	c, err := NewCoordinator(&CoordinatorOpts{
-		WriteTimeSeriesFn:  nil,
 		K8sCli:             kcli,
 		Namespace:          "adx-mon",
 		Hostname:           "ingestor-0",
@@ -132,7 +131,6 @@ func TestCoordinator_DiscoveryDisabled(t *testing.T) {
 
 	// Test with no namespace or hostname, that discovery is disabled
 	c, err := NewCoordinator(&CoordinatorOpts{
-		WriteTimeSeriesFn:  nil,
 		K8sCli:             kcli,
 		Namespace:          "",
 		Hostname:           "ingestor-0",
@@ -213,7 +211,6 @@ func TestCoordinator_LostPeer(t *testing.T) {
 	kcli := fakek8s.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*self, *newPeer}})
 
 	c, err := NewCoordinator(&CoordinatorOpts{
-		WriteTimeSeriesFn:  nil,
 		K8sCli:             kcli,
 		Namespace:          "adx-mon",
 		Hostname:           "ingestor-0",

--- a/ingestor/metrics/fake.go
+++ b/ingestor/metrics/fake.go
@@ -2,15 +2,22 @@ package metrics
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/pkg/samples"
 )
 
 type FakeRequestWriter struct {
+	samples.Writer
 }
 
-func (f *FakeRequestWriter) Write(ctx context.Context, wr prompb.WriteRequest) error {
+func (f *FakeRequestWriter) Write(ctx context.Context, s interface{}) error {
+	wr, ok := s.(prompb.WriteRequest)
+	if !ok {
+		return errors.New("invalid type")
+	}
 	logger.Info("Received %d samples. Dropping", len(wr.Timeseries))
 	return nil
 }

--- a/ingestor/metrics/handler.go
+++ b/ingestor/metrics/handler.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/pool"
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/pkg/samples"
 	"github.com/cespare/xxhash"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,11 +37,6 @@ type SeriesCounter interface {
 	AddSeries(key string, id uint64)
 }
 
-type RequestWriter interface {
-	// Write writes the time series to the correct peer.
-	Write(ctx context.Context, wr prompb.WriteRequest) error
-}
-
 type HandlerOpts struct {
 	// DropLabels is a map of metric names regexes to label name regexes.  When both match, the label will be dropped.
 	DropLabels map[*regexp.Regexp]*regexp.Regexp
@@ -54,7 +49,7 @@ type HandlerOpts struct {
 	SeriesCounter SeriesCounter
 
 	// RequestWriter is the interface that writes the time series to a destination.
-	RequestWriter RequestWriter
+	RequestWriter samples.Writer
 }
 
 type Handler struct {
@@ -71,7 +66,7 @@ type Handler struct {
 
 	seriesCounter SeriesCounter
 
-	requestWriter RequestWriter
+	requestWriter samples.Writer
 }
 
 func (s *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -94,10 +94,10 @@ func NewService(opts ServiceOpts) (*Service, error) {
 	})
 
 	coord, err := cluster.NewCoordinator(&cluster.CoordinatorOpts{
-		WriteTimeSeriesFn: store.WriteTimeSeries,
-		K8sCli:            opts.K8sCli,
-		Hostname:          opts.Hostname,
-		Namespace:         opts.Namespace,
+		Writer:    store,
+		K8sCli:    opts.K8sCli,
+		Hostname:  opts.Hostname,
+		Namespace: opts.Namespace,
 	})
 	if err != nil {
 		return nil, err

--- a/ingestor/storage/store_test.go
+++ b/ingestor/storage/store_test.go
@@ -33,19 +33,19 @@ func TestStore_Open(t *testing.T) {
 	w, err := s.GetWAL(ctx, ts.Labels)
 	require.NoError(t, err)
 	require.NotNil(t, w)
-	require.NoError(t, s.WriteTimeSeries(context.Background(), []prompb.TimeSeries{ts}))
+	require.NoError(t, s.Write(context.Background(), []prompb.TimeSeries{ts}))
 
 	ts = newTimeSeries("foo", nil, 1, 1)
 	w, err = s.GetWAL(ctx, ts.Labels)
 	require.NoError(t, err)
 	require.NotNil(t, w)
-	require.NoError(t, s.WriteTimeSeries(context.Background(), []prompb.TimeSeries{ts}))
+	require.NoError(t, s.Write(context.Background(), []prompb.TimeSeries{ts}))
 
 	ts = newTimeSeries("bar", nil, 0, 0)
 	w, err = s.GetWAL(ctx, ts.Labels)
 	require.NoError(t, err)
 	require.NotNil(t, w)
-	require.NoError(t, s.WriteTimeSeries(context.Background(), []prompb.TimeSeries{ts}))
+	require.NoError(t, s.Write(context.Background(), []prompb.TimeSeries{ts}))
 
 	path := w.Path()
 
@@ -69,7 +69,7 @@ func TestStore_Open(t *testing.T) {
 	require.Equal(t, 2, s.WALCount())
 }
 
-func TestLocalStore_WriteTimeSeries(t *testing.T) {
+func TestLocalStore_Write(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	s := storage.NewLocalStore(storage.StoreOpts{
@@ -86,7 +86,7 @@ func TestLocalStore_WriteTimeSeries(t *testing.T) {
 	w, err := s.GetWAL(ctx, ts.Labels)
 	require.NoError(t, err)
 	require.NotNil(t, w)
-	require.NoError(t, s.WriteTimeSeries(context.Background(), []prompb.TimeSeries{ts}))
+	require.NoError(t, s.Write(context.Background(), []prompb.TimeSeries{ts}))
 
 	path := w.Path()
 

--- a/pkg/samples/io.go
+++ b/pkg/samples/io.go
@@ -1,0 +1,7 @@
+package samples
+
+import "context"
+
+type Writer interface {
+	Write(ctx context.Context, samples interface{}) error
+}


### PR DESCRIPTION
Instead of several packages defining their own Write function that takes a concrete Prometheus type, we introduce a common Write interface in a new package, samples, that accepts an interface type that can be type-cast to support any number of observability types. This is an important step towards supporting OTLP logs. 