### PR TITLE
Add Collector parameter to add common metadata to OTLP

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -31,7 +31,7 @@ Static Targets:
 Static targets can be specified with the --target flag.  The format is <host regex>=<url>,namespace/pod/container.
 This is intended to support non-kubernetes workloads.  The host regex is matched against the hostname of the node
 to determine if the target will be scraped.  To scrape all nodes, use .* as the host regex.  The namespace/pod/container
-is used to label metrics with a namespace, pod and container name.  This value must have two slashes.  
+is used to label metrics with a namespace, pod and container name.  This value must have two slashes.
 Multiple targets can be specified by repeating the --target flag.
 
 Scrape port 9100 on all nodes:
@@ -50,6 +50,7 @@ Add a static pod scrape for etcd pods running outside of Kubernetes on masters a
 			&cli.StringFlag{Name: "listen-addr", Usage: "Address to listen on for Prometheus scrape requests", Value: ":8080"},
 			&cli.DurationFlag{Name: "scrape-interval", Usage: "Scrape interval", Value: 30 * time.Second},
 			&cli.StringSliceFlag{Name: "add-labels", Usage: "Label in the format of <name>=<value>.  These are added to all metrics collected by this agent"},
+			&cli.StringSliceFlag{Name: "add-attributes", Usage: "Attributes in the format of <name>=<value>.  These are added to all logs collected by this agent"},
 			&cli.StringSliceFlag{Name: "drop-labels", Usage: "Labels to drop if they match a metrics regex in the format <metrics regex=<label name>.  These are dropped from all metrics collected by this agent"},
 			&cli.StringSliceFlag{Name: "drop-metrics", Usage: "Metrics to drop if they match the regex."},
 			&cli.IntFlag{Name: "max-batch-size", Usage: "Maximum number of samples to send in a single batch", Value: 5000},
@@ -75,13 +76,13 @@ func realMain(ctx *cli.Context) error {
 		return err
 	}
 
-	addLabels := make(map[string]string)
-	for _, tag := range ctx.StringSlice("add-labels") {
-		split := strings.Split(tag, "=")
-		if len(split) != 2 {
-			return fmt.Errorf("invalid tag %s", tag)
-		}
-		addLabels[split[0]] = split[1]
+	addLabels, err := parseKeyPairs(ctx.StringSlice("add-labels"))
+	if err != nil {
+		logger.Fatal("invalid labels: %s", ctx.StringSlice("add-labels"))
+	}
+	addAttributes, err := parseKeyPairs(ctx.StringSlice("add-attributes"))
+	if err != nil {
+		logger.Fatal("invalid attributes: %s", ctx.StringSlice("add-attributes"))
 	}
 
 	dropLabels := make(map[*regexp.Regexp]*regexp.Regexp)
@@ -184,6 +185,7 @@ func realMain(ctx *cli.Context) error {
 		Endpoints:          endpoints,
 		DropMetrics:        dropMetrics,
 		AddLabels:          addLabels,
+		AddAttributes:      addAttributes,
 		DropLabels:         dropLabels,
 		InsecureSkipVerify: ctx.Bool("insecure-skip-verify"),
 		MaxBatchSize:       ctx.Int("max-batch-size"),
@@ -240,4 +242,18 @@ func newKubeClient(cCtx *cli.Context) (dynamic.Interface, *kubernetes.Clientset,
 	}
 
 	return dyCli, client, ctrlCli, nil
+}
+
+// parseKeyPairs parses a list of key pairs in the form of key=value,key=value
+// and returns them as a map.
+func parseKeyPairs(kp []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, encoded := range kp {
+		split := strings.Split(encoded, "=")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("invalid key-pair %s", encoded)
+		}
+		m[split[0]] = split[1]
+	}
+	return m, nil
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -49,12 +49,13 @@ type Service struct {
 }
 
 type ServiceOpts struct {
-	ListentAddr string
-	K8sCli      kubernetes.Interface
-	NodeName    string
-	Targets     []ScrapeTarget
-	Endpoints   []string
-	AddLabels   map[string]string
+	ListentAddr   string
+	K8sCli        kubernetes.Interface
+	NodeName      string
+	Targets       []ScrapeTarget
+	Endpoints     []string
+	AddLabels     map[string]string
+	AddAttributes map[string]string
 	// DropLabels is a map of metric names regexes to label name regexes.  When both match, the label will be dropped.
 	DropLabels map[*regexp.Regexp]*regexp.Regexp
 
@@ -163,7 +164,7 @@ func (s *Service) Open(ctx context.Context) error {
 		SeriesCounter: s.metricsSvc,
 		RequestWriter: &metricsHandler.FakeRequestWriter{},
 	}))
-	mux.Handle("/logs", otlp.LogsProxyHandler(ctx, s.opts.Endpoints, s.opts.InsecureSkipVerify))
+	mux.Handle("/logs", otlp.LogsProxyHandler(ctx, s.opts.Endpoints, s.opts.InsecureSkipVerify, s.opts.AddAttributes))
 	s.srv = &http.Server{Addr: s.opts.ListentAddr, Handler: mux}
 
 	go func() {

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -38,7 +38,7 @@ services:
     # While the _endpoints_ URI doesn't match the expected OTLP syntax, keep in
     # mind that _Collector_ is currently configured to connect to _Ingestor_, so we
     # just modify the _endpoints_ in pkg/otlp/proxy to be OTLP compliant.
-    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --endpoints http://otel:4317 --insecure-skip-verify --target=.*=http://localhost:8080/metrics:adx-mon/collector/collector
+    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --endpoints http://otel:4317 --insecure-skip-verify --target=.*=http://localhost:8080/metrics:adx-mon/collector/collector --add-attributes Environment=dev
     depends_on:
       - ingestor
       - otel


### PR DESCRIPTION
A common use-case is for all logs on a host to contain metadata, or attributes, about their environment. By adding a new command-line parameter, --add-attributes, much like our parameter --add-labels, collector will add common metadata to each OTLP log event it receives.

By running the integration test `docker compose -f tools/otlp/logs/compose.yaml up`, we can see attributes being added to our OTLP logging events.

```diff
logs-otel-1       | 2023-08-03T14:29:32.212Z    info    LogsExporter    {"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 1, "log records": 1}
logs-otel-1       | 2023-08-03T14:29:32.212Z    info    ResourceLog #0
logs-otel-1       | Resource SchemaURL: 
logs-otel-1       | Resource attributes:
+ logs-otel-1       |      -> Environment: Str(dev)
logs-otel-1       | ScopeLogs #0
logs-otel-1       | ScopeLogs SchemaURL: 
logs-otel-1       | InstrumentationScope  
logs-otel-1       | LogRecord #0
logs-otel-1       | ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
logs-otel-1       | Timestamp: 2023-08-03 14:29:31.1994291 +0000 UTC
logs-otel-1       | SeverityText: 
logs-otel-1       | SeverityNumber: Unspecified(0)
logs-otel-1       | Body: Map({"message":"dummy"})
logs-otel-1       | Trace ID: 
logs-otel-1       | Span ID: 
logs-otel-1       | Flags: 0
logs-otel-1       |     {"kind": "exporter", "data_type": "logs", "name": "logging"}
```

When specified by `--add-attributes`

```diff
  collector:
    build:
      dockerfile: tools/otlp/logs/Dockerfile
      context: ../../..
    volumes:
      - ~/.kube/config:/root/.kube/config
    ports:
      - 8080:8080
    # While the _endpoints_ URI doesn't match the expected OTLP syntax, keep in
    # mind that _Collector_ is currently configured to connect to _Ingestor_, so we
    # just modify the _endpoints_ in pkg/otlp/proxy to be OTLP compliant.
    command: --kubeconfig /root/.kube/config \
                      --endpoints http://otel:4317/receive \
                      --insecure-skip-verify \
+                      --add-attributes Environment=dev
    depends_on:
      - otel
    environment:
      - LOG_LEVEL=DEBUG
```