### PR TITLE
Create TLV for use as a metadata envelope for WAL payloads

### DIFF
--- a/pkg/tlv/tlv_test.go
+++ b/pkg/tlv/tlv_test.go
@@ -10,35 +10,6 @@ import (
 )
 
 func TestTLV(t *testing.T) {
-	// Create our TLVs
-	t1k := tlv.Tag(0x01)
-	t1v := "Tag1Value"
-
-	t2k := tlv.Tag(0x11)
-	t2v := "Tag2Value"
-
-	tlv1 := tlv.New(t1k, []byte(t1v))
-	tlv2 := tlv.New(t2k, []byte(t2v))
-
-	// Encode our 2 TLVs, which will apply our control header
-	b := tlv.Encode(tlv1, tlv2)
-
-	// Append some random bytes to the end to make sure we can decode
-	// only the bytes specified in our TLV header
-	b = append(b, []byte("foo bar baz")...)
-
-	// Decode and test
-	tlvs := tlv.Decode(b)
-	require.Equal(t, 2, len(tlvs))
-
-	require.Equal(t, t1k, tlvs[0].Tag)
-	require.Equal(t, t1v, string(tlvs[0].Value))
-
-	require.Equal(t, t2k, tlvs[1].Tag)
-	require.Equal(t, t2v, string(tlvs[1].Value))
-}
-
-func TestSeeker(t *testing.T) {
 	// Setup our file
 	dir := t.TempDir()
 	f, err := os.CreateTemp(dir, "")
@@ -59,7 +30,7 @@ func TestSeeker(t *testing.T) {
 	require.NoError(t, err)
 	defer tf.Close()
 
-	tlvs, err := tlv.DecodeSeeker(tf)
+	tlvs, err := tlv.Decode(tf)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(tlvs))
 	require.Equal(t, v, string(tlvs[0].Value))


### PR DESCRIPTION
This PR introduces a TLV primitive for use by our Storage tier that enables us to embed Kusto routing metadata into our WAL payloads. This structure is utilized in a different branch and is dead code in this branch, but I want to break up these PRs as much as possible so I'm starting with just the smallest unit of work.