### PR TITLE
Order batches by age

### DIFF
--- a/ingestor/cluster/batcher_test.go
+++ b/ingestor/cluster/batcher_test.go
@@ -1,14 +1,17 @@
 package cluster
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/davidnarayan/go-flake"
 	"github.com/stretchr/testify/require"
 )
 
-func TestArchiver_ClosedSegments(t *testing.T) {
+func TestBatcher_ClosedSegments(t *testing.T) {
 	dir := t.TempDir()
 
 	f, err := os.Create(filepath.Join(dir, "Cpu_aaaa.wal"))
@@ -31,27 +34,62 @@ func TestArchiver_ClosedSegments(t *testing.T) {
 	require.Equal(t, 0, len(notOwned))
 }
 
-func TestArchiver_NodeOwned(t *testing.T) {
+func TestBatcher_NodeOwned(t *testing.T) {
 	dir := t.TempDir()
 
-	f, err := os.Create(filepath.Join(dir, "Cpu_aaaa.wal"))
+	idgen, err := flake.New()
+	require.NoError(t, err)
+	now := idgen.NextId()
+
+	fName := fmt.Sprintf("Cpu_%s.wal", now.String())
+	f, err := os.Create(filepath.Join(dir, fName))
 	require.NoError(t, err)
 	defer f.Close()
 
-	f1, err := os.Create(filepath.Join(dir, "Cpu_bbbb.wal"))
+	now = idgen.NextId()
+	f1Name := fmt.Sprintf("Cpu_%s.wal", now.String())
+	f1, err := os.Create(filepath.Join(dir, f1Name))
+	require.NoError(t, err)
+	defer f1.Close()
+
+	a := &batcher{
+		hostname:       "node1",
+		storageDir:     dir,
+		maxSegmentAge:  30 * time.Second,
+		maxSegmentSize: 100 * 1024 * 1024,
+		Partitioner:    &fakePartitioner{owner: "node2"},
+		Segmenter:      &fakeSegmenter{active: "Memory_aaaa.wal"},
+	}
+	owner, notOwned, err := a.processSegments()
+	require.NoError(t, err)
+	require.Equal(t, 0, len(owner))
+	require.Equal(t, []string{filepath.Join(dir, fName), filepath.Join(dir, f1Name)}, notOwned[0])
+}
+
+func TestBatcher_OldestFirst(t *testing.T) {
+	dir := t.TempDir()
+
+	f, err := os.Create(filepath.Join(dir, "Cpu_2359cdac7d6f0001.wal"))
+	require.NoError(t, err)
+	defer f.Close()
+
+	// This segment is older, but lexicographically greater.  It should be the in the first batch.
+	f1, err := os.Create(filepath.Join(dir, "Disk_2359cd7e3aef0001.wal"))
 	require.NoError(t, err)
 	defer f1.Close()
 
 	a := &batcher{
 		hostname:    "node1",
 		storageDir:  dir,
-		Partitioner: &fakePartitioner{owner: "node2"},
+		Partitioner: &fakePartitioner{owner: "node1"},
 		Segmenter:   &fakeSegmenter{active: "Memory_aaaa.wal"},
 	}
 	owner, notOwned, err := a.processSegments()
 	require.NoError(t, err)
-	require.Equal(t, 0, len(owner))
-	require.Equal(t, []string{filepath.Join(dir, "Cpu_aaaa.wal"), filepath.Join(dir, "Cpu_bbbb.wal")}, notOwned[0])
+	require.Equal(t, 2, len(owner))
+	require.Equal(t, 0, len(notOwned))
+	require.Equal(t, []string{filepath.Join(dir, "Disk_2359cd7e3aef0001.wal")}, owner[0])
+	require.Equal(t, []string{filepath.Join(dir, "Cpu_2359cdac7d6f0001.wal")}, owner[1])
 }
 
 type fakePartitioner struct {

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -113,11 +113,13 @@ func NewService(opts ServiceOpts) (*Service, error) {
 	}
 
 	batcher := cluster.NewBatcher(cluster.BatcherOpts{
-		StorageDir:    opts.StorageDir,
-		Partitioner:   coord,
-		Segmenter:     store,
-		UploadQueue:   opts.Uploader.UploadQueue(),
-		TransferQueue: repl.TransferQueue(),
+		StorageDir:     opts.StorageDir,
+		MaxSegmentAge:  opts.MaxSegmentAge,
+		MaxSegmentSize: opts.MaxSegmentSize,
+		Partitioner:    coord,
+		Segmenter:      store,
+		UploadQueue:    opts.Uploader.UploadQueue(),
+		TransferQueue:  repl.TransferQueue(),
 	})
 
 	metricsSvc := metrics.NewService(metrics.ServiceOpts{})


### PR DESCRIPTION
The upload batches were orderd by name which can cause some data to lag base on the shape of metrics name being upload.  This orders batches by oldest segments first so older data is prioritized for upload over newer data.