### PR TITLE
Introduce an upload coordinator to support multiple uploaders

### DIFF
--- a/ingestor/adx/coordinator.go
+++ b/ingestor/adx/coordinator.go
@@ -1,0 +1,167 @@
+package adx
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/adx-mon/pkg/wal"
+)
+
+type Coordinator interface {
+	UploadQueue() chan []string
+	Open(ctx context.Context) error
+	Close() error
+}
+
+type SegmentReader func(path string) (io.ReadCloser, error)
+
+type coordinator struct {
+	uploaders map[string]Uploader
+	queue     chan []string
+	cancel    context.CancelFunc
+	reader    SegmentReader
+
+	mu          sync.Mutex
+	activeFiles map[string]struct{}
+}
+
+func NewCoordinator(uploaders []Uploader, fn SegmentReader, concurrentUploads int) *coordinator {
+	c := &coordinator{
+		uploaders:   make(map[string]Uploader),
+		queue:       make(chan []string, concurrentUploads),
+		activeFiles: make(map[string]struct{}),
+		reader:      fn,
+	}
+
+	for _, uploader := range uploaders {
+		c.uploaders[uploader.Database()] = uploader
+	}
+
+	return c
+}
+
+func (c *coordinator) Open(ctx context.Context) error {
+	cctx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+
+	for i := 0; i < cap(c.queue); i++ {
+		go c.handler(cctx)
+	}
+	return nil
+}
+
+func (c *coordinator) Close() error {
+	c.cancel()
+	for _, uploader := range c.uploaders {
+		go uploader.Close()
+	}
+	return nil
+}
+
+func (c *coordinator) UploadQueue() chan []string {
+	return c.queue
+}
+
+type streams struct {
+	readers map[string][]io.Reader
+	closers map[string][]io.Closer
+	paths   map[string][]string
+}
+
+func (c *coordinator) handler(ctx context.Context) {
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case paths := <-c.queue:
+			c.handlePaths(ctx, paths)
+		}
+	}
+}
+
+func (c *coordinator) handlePaths(ctx context.Context, paths []string) {
+	var (
+		// groups are a map of database to tables of readers and closers.
+		groups          = make(map[string]streams)
+		ok              bool
+		database, table string
+	)
+
+	// Group paths based on database and table.
+	for _, path := range paths {
+
+		// Ignore any files that are already being uploaded.
+		c.mu.Lock()
+		if _, ok = c.activeFiles[path]; ok {
+			c.mu.Unlock()
+			continue
+		}
+		c.mu.Unlock()
+
+		// TODO: wal.NewSegmentReader(path)
+		f, err := c.reader(path)
+
+		if os.IsNotExist(err) {
+			// batches are not disjoint, so the same segments could be included in multiple batches.
+			continue
+		} else if err != nil {
+			logger.Error("Failed to open file: %s", err.Error())
+			continue
+		}
+
+		database, table, _, err = wal.ParseFilename(path)
+		if err != nil {
+			logger.Error("Failed to parse file: %s", err.Error())
+			f.Close()
+			continue
+		}
+		if _, ok = c.uploaders[database]; !ok {
+			logger.Error("No uploader for database: %s", database)
+			f.Close()
+			continue
+		}
+
+		c.mu.Lock()
+		if _, ok = c.activeFiles[path]; ok {
+			c.mu.Unlock()
+			f.Close()
+			continue
+		}
+		c.activeFiles[path] = struct{}{}
+		c.mu.Unlock()
+
+		_, ok = groups[database]
+		if !ok {
+			groups[database] = streams{
+				readers: make(map[string][]io.Reader),
+				closers: make(map[string][]io.Closer),
+				paths:   make(map[string][]string),
+			}
+		}
+		groups[database].readers[table] = append(groups[database].readers[table], f)
+		groups[database].closers[table] = append(groups[database].closers[table], f)
+		groups[database].paths[table] = append(groups[database].paths[table], path)
+	}
+
+	// Now upload each group.
+	for database, group := range groups {
+		for table, readers := range group.readers {
+			if err := c.uploaders[database].Upload(ctx, database, table, io.MultiReader(readers...)); err != nil {
+				logger.Error("Failed to upload file: %s", err.Error())
+			}
+			for _, closer := range group.closers[table] {
+				closer.Close()
+			}
+
+			c.mu.Lock()
+			for _, path := range group.paths[table] {
+				delete(c.activeFiles, path)
+			}
+			c.mu.Unlock()
+		}
+	}
+}

--- a/ingestor/adx/coordinator_test.go
+++ b/ingestor/adx/coordinator_test.go
@@ -1,0 +1,107 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/adx-mon/pkg/wal"
+	"github.com/davidnarayan/go-flake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploader(t *testing.T) {
+	// Create some mocks
+	idgent, err := flake.New()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	segmentReader := func(path string) (io.ReadCloser, error) {
+		return os.Open(path)
+	}
+
+	// Set the stage
+	var (
+		scenario = map[string]map[string]int{
+			"database1": {
+				"table1": 2,
+				"table2": 1,
+			},
+			"database2": {
+				"table1": 1,
+			},
+		}
+		paths       []string
+		uploaders   []Uploader
+		concurrency = 1
+	)
+	for database, tables := range scenario {
+		uploaders = append(uploaders, NewFakeUploader(database))
+		for table, count := range tables {
+			for i := 0; i < count; i++ {
+				now := idgent.NextId()
+				path := filepath.Join(dir, wal.Filename(database, table, now.String()))
+				f, err := os.Create(path)
+				require.NoError(t, err)
+				f.WriteString(fmt.Sprintf("%s,%s,%d\n", database, table, i))
+				err = f.Close()
+				require.NoError(t, err)
+				paths = append(paths, path)
+			}
+		}
+	}
+
+	// Run the test
+	ctx := context.Background()
+	coordinator := NewCoordinator(uploaders, segmentReader, concurrency)
+	err = coordinator.Open(ctx)
+	require.NoError(t, err)
+
+	// Process our paths
+	coordinator.handlePaths(ctx, paths)
+	// We expect all files to be uploaded
+	require.Equal(t, 0, len(coordinator.activeFiles))
+	// Ensure all database::table combinations were uploaded
+	have := make(map[string]map[string]int)
+	for _, uploader := range uploaders {
+		u := uploader.(*fakeUploader)
+		for db, tb := range u.observer {
+			have[db] = tb
+		}
+	}
+	require.Equal(t, len(scenario), len(have))
+	for database, tables := range have {
+		require.Equal(t, len(scenario[database]), len(tables))
+	}
+}
+
+func BenchmarkUploader(b *testing.B) {
+	idgent, err := flake.New()
+	require.NoError(b, err)
+	uploader := NewFakeUploader("database")
+	dir := b.TempDir()
+	segmentReader := func(path string) (io.ReadCloser, error) {
+		return os.Open(path)
+	}
+	now := idgent.NextId()
+	path := filepath.Join(dir, wal.Filename("database", "table", now.String()))
+	f, err := os.Create(path)
+	require.NoError(b, err)
+	f.WriteString("database,table")
+	err = f.Close()
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	coordinator := NewCoordinator([]Uploader{uploader}, segmentReader, 1)
+	err = coordinator.Open(ctx)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		coordinator.handlePaths(ctx, []string{path})
+	}
+}

--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -2,6 +2,7 @@ package adx
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -20,6 +21,7 @@ type Uploader interface {
 	service.Component
 
 	Database() string
+	Upload(ctx context.Context, database, table string, reader io.Reader) error
 
 	// UploadQueue returns a channel that can be used to upload files to kusto.
 	UploadQueue() chan []string
@@ -93,6 +95,10 @@ func (n *uploader) Close() error {
 	n.ingestors = nil
 
 	return nil
+}
+
+func (n *uploader) Upload(ctx context.Context, database, table string, reader io.Reader) error {
+	return errors.New("not implemented")
 }
 
 func (n *uploader) UploadQueue() chan []string {


### PR DESCRIPTION
This is intentionally dead code but provides a working upload coordinator that's easy to review. A subsequent PR, after addressing any feedback, will plumb the coordinator through Ingestor.

The intent is to modify our existing Uploaders by removing the UploadQueue, which is exposed by the Coordinator. We'll then have 1 uploader per Kusto Database and each of these Uploaders will know about their corresponding storage schemas (one of prom/metrics or otlp/logs). Since the interface for Coordinator comports to Uploader, only the main/loader code will have to change.