### PR TITLE
Replace cardinality counts with kusto queries

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -252,7 +252,25 @@ func realMain(ctx *cli.Context) error {
 		dropMetrics = append(dropMetrics, metricRegex)
 	}
 
-	uploader, err := newUploader(kustoEndpoint, storageDir, concurrentUploads, defaultMapping)
+	var (
+		client   ingest.QueryClient
+		database string
+	)
+	if kustoEndpoint != "" {
+		var (
+			err  error
+			addr string
+		)
+		addr, database, err = parseKustoEndpoint(kustoEndpoint)
+		if err != nil {
+			logger.Fatal("Failed to parse kusto endpoint: %s", err)
+		}
+
+		client, err = newKustoClient(addr)
+		defer client.Close()
+	}
+
+	uploader, err := newUploader(client, database, storageDir, concurrentUploads, defaultMapping)
 	if err != nil {
 		logger.Fatal("Failed to create uploader: %s", err)
 	}
@@ -260,6 +278,8 @@ func realMain(ctx *cli.Context) error {
 
 	svc, err := promingest.NewService(promingest.ServiceOpts{
 		K8sCli:               k8scli,
+		MetricsKustoCli:      client,
+		MetricsDatabase:      database,
 		Namespace:            namespace,
 		Hostname:             hostname,
 		StorageDir:           storageDir,
@@ -404,38 +424,34 @@ func newKustoClient(endpoint string) (ingest.QueryClient, error) {
 	return kusto.New(kcsb)
 }
 
-func newUploader(kustoEndpoint, storageDir string, concurrentUploads int, defaultMapping storage.SchemaMapping) (adx.Uploader, error) {
-	if kustoEndpoint == "" {
+func newUploader(kustoCli ingest.QueryClient, database, storageDir string, concurrentUploads int, defaultMapping storage.SchemaMapping) (adx.Uploader, error) {
+	if kustoCli == nil {
 		logger.Warn("No kusto endpoint provided, using fake uploader")
 		return adx.NewFakeUploader(), nil
 	}
 
-	if kustoEndpoint == "" {
-		return nil, fmt.Errorf("-kusto-endpoint is required")
-	}
-
-	if !strings.Contains(kustoEndpoint, "=") {
-		return nil, fmt.Errorf("invalid kusto endpoint: %s", kustoEndpoint)
-	}
-
-	split := strings.Split(kustoEndpoint, "=")
-	database := split[0]
-	kustoEndpoint = split[1]
-
-	if database == "" {
-		return nil, fmt.Errorf("-db is required")
-	}
-
-	client, err := newKustoClient(kustoEndpoint)
-	defer client.Close()
-
-	uploader := adx.NewUploader(client, adx.UploaderOpts{
+	uploader := adx.NewUploader(kustoCli, adx.UploaderOpts{
 		StorageDir:        storageDir,
 		Database:          database,
 		ConcurrentUploads: concurrentUploads,
 		DefaultMapping:    defaultMapping,
 	})
-	return uploader, err
+	return uploader, nil
+}
+
+func parseKustoEndpoint(kustoEndpoint string) (string, string, error) {
+	if !strings.Contains(kustoEndpoint, "=") {
+		return "", "", fmt.Errorf("invalid kusto endpoint: %s", kustoEndpoint)
+	}
+
+	split := strings.Split(kustoEndpoint, "=")
+	database := split[0]
+	addr := split[1]
+
+	if database == "" {
+		return "", "", fmt.Errorf("-db is required")
+	}
+	return addr, database, nil
 }
 
 func newLogger() *log.Logger {

--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -277,6 +277,18 @@ func (s *Syncer) ensureFunctions(ctx context.Context) error {
 			| extend Value=case(h == prev(h), case(diff < 0, next(Value)-Value, diff), real(0))
 			| project-away prevVal, diff, h
 		)}`},
+		{
+
+			name: "CountCardinality",
+			body: `.create-or-alter function CountCardinality () {
+				union withsource=table *
+				| where Timestamp >= ago(1h) and Timestamp < ago(5m)
+				| summarize Value=toreal(dcount(SeriesId)) by table
+				| extend SeriesId=hash_xxhash64(table)
+				| extend Timestamp=bin(now(), 1m)
+				| extend Labels=bag_pack_columns(table)
+				| project Timestamp, SeriesId, Labels, Value
+		}`},
 	}
 
 	for _, fn := range functions {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -51,13 +51,6 @@ var (
 		Help:      "Counter of metrics droopped for an ingestor instance",
 	}, []string{"metric"})
 
-	IngestorMetricsCardinality = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: Namespace,
-		Subsystem: "ingestor",
-		Name:      "metrics_cardinality_count",
-		Help:      "Cardinality of metrics ingested",
-	}, []string{"metric"})
-
 	// Alerting metrics
 	QueryHealth = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,


### PR DESCRIPTION
The cardinality counting approach doesn't work with multiple counters as the counts are not mergeable.  We would need to insert the kusto HLL format and merge that at query time.  Since that format is not docuemented publicly nor is the specific implementation available to be used like this, we have to rework how counts are tallied.

Instead, just run a function that dcounts all series IDs on all tables and store that as a new metric.  Only one ingestor will run this query periodically.