### PR TITLE
Log attributes should be added at to LogRecords instead of resources

### DIFF
--- a/collector/otlp/logs.go
+++ b/collector/otlp/logs.go
@@ -15,7 +15,6 @@ import (
 	"buf.build/gen/go/opentelemetry/opentelemetry/bufbuild/connect-go/opentelemetry/proto/collector/logs/v1/logsv1connect"
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
-	resourcev1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/resource/v1"
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/pool"
@@ -220,23 +219,20 @@ func modifyAttributes(msg *v1.ExportLogsServiceRequest, add []*commonv1.KeyValue
 			// This is a parculiar case, but it can happen if the client sends an empty request.
 			break
 		}
-		if msg.ResourceLogs[i].Resource == nil {
-			msg.ResourceLogs[i].Resource = &resourcev1.Resource{}
-		}
-
-		// Add any additional columns to the logs
-		msg.ResourceLogs[i].Resource.Attributes = append(
-			msg.ResourceLogs[i].Resource.Attributes,
-			add...,
-		)
 
 		for j := range msg.ResourceLogs[i].ScopeLogs {
 			numLogs += len(msg.ResourceLogs[i].ScopeLogs[j].LogRecords)
 
-			// Now lift attributes from the body of the log message
-			if len(lift) > 0 {
-				for k := range msg.ResourceLogs[i].ScopeLogs[j].LogRecords {
+			for k := range msg.ResourceLogs[i].ScopeLogs[j].LogRecords {
 
+				// Add any additional columns to the logs
+				msg.ResourceLogs[i].ScopeLogs[j].LogRecords[k].Attributes = append(
+					msg.ResourceLogs[i].ScopeLogs[j].LogRecords[k].Attributes,
+					add...,
+				)
+
+				// Now lift attributes from the body of the log message
+				if len(lift) > 0 {
 					var deleted int
 					for idx, v := range msg.ResourceLogs[i].ScopeLogs[j].LogRecords[k].Body.GetKvlistValue().GetValues() {
 						_, ok = lift[v.GetKey()]

--- a/collector/otlp/logs_test.go
+++ b/collector/otlp/logs_test.go
@@ -36,15 +36,14 @@ func TestAttributes(t *testing.T) {
 	require.Equal(t, 1, len(modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Body.GetKvlistValue().Values))
 	require.Equal(t, "message", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Body.GetKvlistValue().Values[0].Key)
 
-	require.Equal(t, "source", modified.ResourceLogs[0].Resource.Attributes[0].Key)
-	require.Equal(t, "hostname", modified.ResourceLogs[0].Resource.Attributes[0].Value.GetStringValue())
-	require.Equal(t, "SomeAttribute", modified.ResourceLogs[0].Resource.Attributes[1].Key)
-	require.Equal(t, "SomeValue", modified.ResourceLogs[0].Resource.Attributes[1].Value.GetStringValue())
+	require.Equal(t, "SomeAttribute", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[0].Key)
+	require.Equal(t, "SomeValue", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[0].Value.GetStringValue())
 
-	require.Equal(t, "kusto.table", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[0].Key)
-	require.Equal(t, "ATable", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[0].Value.GetStringValue())
-	require.Equal(t, "kusto.database", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[1].Key)
-	require.Equal(t, "ADatabase", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[1].Value.GetStringValue())
+	require.Equal(t, "kusto.table", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[1].Key)
+	require.Equal(t, "ATable", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[1].Value.GetStringValue())
+
+	require.Equal(t, "kusto.database", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[2].Key)
+	require.Equal(t, "ADatabase", modified.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Attributes[2].Value.GetStringValue())
 }
 
 func BenchmarkModifyAttributes(b *testing.B) {


### PR DESCRIPTION
When attributes are specified to _Collector_ via `--add-attributes`, they should be stored at the `LogRecord` scope since that's what we ultimately store in Kusto.