### PR TITLE
Revent CountCardinality back to original version

### DIFF
--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -303,8 +303,8 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 			body: `.create-or-alter function CountCardinality () {
 				union withsource=table *
 				| where Timestamp >= ago(1h) and Timestamp < ago(5m)
+				| summarize Value=toreal(dcount(SeriesId)) by table
 				| extend SeriesId=hash_xxhash64(table)
-				| summarize Value=toreal(dcount(SeriesId)) by table, SeriesId
 				| extend Timestamp=bin(now(), 1m)
 				| extend Labels=bag_pack_columns(table)
 				| project Timestamp, SeriesId, Labels, Value


### PR DESCRIPTION
Current version doesn't work correctly and return a count of one for every table.