### PR TITLE
Delete old segments that do not have a known destination

### DIFF
--- a/ingestor/cluster/batcher.go
+++ b/ingestor/cluster/batcher.go
@@ -267,7 +267,7 @@ func (a *batcher) processSegments() ([]*Batch, []*Batch, error) {
 				continue
 			}
 
-			createdAt, err := segmentCreationTime(path)
+			createdAt, err := SegmentCreationTime(path)
 			if err != nil {
 				logger.Warnf("failed to determine segment creation time: %s", err)
 			}
@@ -349,7 +349,7 @@ func prioritizeOldest(a []*Batch) []*Batch {
 func maxCreated(batch []string) time.Time {
 	var maxTime time.Time
 	for _, v := range batch {
-		createdAt, err := segmentCreationTime(v)
+		createdAt, err := SegmentCreationTime(v)
 		if err != nil {
 			logger.Warnf("Invalid file name: %s: %s", v, err)
 			continue
@@ -362,7 +362,7 @@ func maxCreated(batch []string) time.Time {
 	return maxTime
 }
 
-func segmentCreationTime(filename string) (time.Time, error) {
+func SegmentCreationTime(filename string) (time.Time, error) {
 	_, _, epoch, err := wal.ParseFilename(filename)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("invalid file name: %s: %w", filename, err)


### PR DESCRIPTION
In cases such as OLTP logs, the sender defines the destination database. Due to misconfiguration or badly-behaved clients, sometimes ingestor may receive traffic destined for ADX clusters that have not been configured in ingestor. We will retain these segments and keep attempting to upload them in cases where we may receive data for a destination prior to ingestor being configured for it.

In the face of continuous inability to find a destination for these logs, we need to expire them so they do not continue to grow or throw off metrics for max segment ages.