### PR TITLE
Creating initial log collection framework

### DIFF
--- a/collector/logs/service.go
+++ b/collector/logs/service.go
@@ -1,0 +1,108 @@
+package logs
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/Azure/adx-mon/metrics"
+	"github.com/Azure/adx-mon/pkg/logger"
+)
+
+type Service struct {
+	Source     types.Source
+	Transforms []types.Transformer
+	Sink       types.Sink
+
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+}
+
+func (s *Service) Open(ctx context.Context) error {
+	ctx, close := context.WithCancel(ctx)
+	s.cancel = close
+	// Start from end to front, so that we can close in reverse order.
+	if err := s.Sink.Open(ctx); err != nil {
+		return err
+	}
+	defer s.Sink.Close()
+
+	for i := len(s.Transforms) - 1; i >= 0; i-- {
+		if err := s.Transforms[i].Open(ctx); err != nil {
+			return err
+		}
+		defer s.Transforms[i].Close()
+	}
+
+	if err := s.Source.Open(ctx); err != nil {
+		return err
+	}
+
+	s.wg.Add(1)
+	go s.process(ctx)
+	return nil
+}
+
+func (s *Service) Close() error {
+	if err := s.Source.Close(); err != nil {
+		logger.Warnf("Failed to close source: %s", err)
+	}
+	s.cancel()
+	s.wg.Wait()
+	for _, transform := range s.Transforms {
+		if err := transform.Close(); err != nil {
+			logger.Warnf("Failed to close transform: %s", err)
+		}
+	}
+	if err := s.Sink.Close(); err != nil {
+		logger.Warnf("Failed to close sink: %s", err)
+	}
+
+	return nil
+}
+
+func (s *Service) process(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			// TODO ensure we have flushed.
+			return
+		case batch := <-s.Source.Queue():
+			// TODO curry labels?
+			metrics.LogsCollectorLogsCollected.WithLabelValues(s.Source.Name()).Add(float64(len(batch.Logs)))
+			s.processBatch(ctx, batch)
+		}
+	}
+}
+
+func (s *Service) processBatch(ctx context.Context, batch *types.LogBatch) {
+	var err error
+	for _, transform := range s.Transforms {
+		batch, err = transform.Transform(ctx, batch)
+		if err != nil {
+			metrics.LogsCollectorLogsDropped.WithLabelValues(s.Source.Name(), transform.Name()).Add(float64(len(batch.Logs)))
+			s.disposeBatch(batch)
+			// TODO skip batch if error is not recoverable
+			// Nack batch?
+			return
+		}
+	}
+	err = s.Sink.Send(ctx, batch)
+	if err != nil {
+		metrics.LogsCollectorLogsDropped.WithLabelValues(s.Source.Name(), s.Sink.Name()).Add(float64(len(batch.Logs)))
+		s.disposeBatch(batch)
+		// TODO skip batch if error is not recoverable
+		// Nack batch?
+		return
+	}
+	metrics.LogsCollectorLogsSent.WithLabelValues(s.Source.Name(), s.Sink.Name()).Add(float64(len(batch.Logs)))
+	s.disposeBatch(batch)
+}
+
+func (s *Service) disposeBatch(batch *types.LogBatch) {
+	for _, log := range batch.Logs {
+		types.LogPool.Put(log)
+	}
+	types.LogBatchPool.Put(batch)
+}

--- a/collector/logs/service_test.go
+++ b/collector/logs/service_test.go
@@ -1,0 +1,28 @@
+package logs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/adx-mon/collector/logs"
+	"github.com/Azure/adx-mon/collector/logs/sinks"
+	"github.com/Azure/adx-mon/collector/logs/sources"
+)
+
+func BenchmarkPipeline(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		source := sources.NewConstSource("test-val", 1*time.Second, 1000)
+		sink := sinks.NewCountingSink(10000)
+
+		service := &logs.Service{
+			Source: source,
+			Sink:   sink,
+		}
+		context := context.Background()
+
+		service.Open(context)
+		<-sink.DoneChan()
+		service.Close()
+	}
+}

--- a/collector/logs/sinks/counting.go
+++ b/collector/logs/sinks/counting.go
@@ -1,0 +1,53 @@
+package sinks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+type CountingSink struct {
+	expectedCount int64
+	currentCount  int64
+
+	lock        sync.Mutex
+	done        bool
+	doneChannel chan struct{}
+}
+
+func NewCountingSink(expectedCount int64) *CountingSink {
+	return &CountingSink{
+		expectedCount: expectedCount,
+		currentCount:  0,
+		done:          false,
+		doneChannel:   make(chan struct{}),
+	}
+}
+
+func (s *CountingSink) Open(ctx context.Context) error {
+	return nil
+}
+
+func (s *CountingSink) Send(ctx context.Context, batch *types.LogBatch) error {
+	s.lock.Lock()
+	s.currentCount += int64(len(batch.Logs))
+	if !s.done && s.currentCount >= s.expectedCount {
+		s.done = true
+		close(s.doneChannel)
+	}
+	s.lock.Unlock()
+	return nil
+}
+
+func (s *CountingSink) Close() error {
+	return nil
+}
+
+func (s *CountingSink) Name() string {
+	return "CountingSink"
+}
+
+func (s *CountingSink) DoneChan() chan struct{} {
+	return s.doneChannel
+}

--- a/collector/logs/sources/const.go
+++ b/collector/logs/sources/const.go
@@ -1,0 +1,102 @@
+package sources
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+type ConstSource struct {
+	Value         string
+	FlushDuration time.Duration
+	MaxBatchSize  int
+
+	outputQueue   chan *types.LogBatch
+	internalQueue chan string
+	closeFn       context.CancelFunc
+
+	wg sync.WaitGroup
+}
+
+// TODO more variety of source values
+func NewConstSource(value string, flushDuration time.Duration, maxBatchSize int) *ConstSource {
+	return &ConstSource{
+		Value:         value,
+		FlushDuration: flushDuration,
+		MaxBatchSize:  maxBatchSize,
+		outputQueue:   make(chan *types.LogBatch, 1),
+		internalQueue: make(chan string, 1000),
+	}
+}
+
+func (s *ConstSource) Open(ctx context.Context) error {
+	ctx, closeFn := context.WithCancel(ctx)
+	s.closeFn = closeFn
+	s.wg.Add(1)
+	go s.generate(ctx)
+	s.wg.Add(1)
+	go s.batch(ctx)
+
+	return nil
+}
+
+func (s *ConstSource) Close() error {
+	s.closeFn()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *ConstSource) Name() string {
+	return "ConstSource"
+}
+
+func (s *ConstSource) Queue() <-chan *types.LogBatch {
+	return s.outputQueue
+}
+
+func (s *ConstSource) generate(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case s.internalQueue <- s.Value:
+		}
+	}
+}
+
+func (s *ConstSource) batch(ctx context.Context) {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.FlushDuration)
+	defer ticker.Stop()
+
+	currentBatch := types.LogBatchPool.Get(1024).(*types.LogBatch)
+	currentBatch.Reset()
+	for {
+		select {
+		case <-ctx.Done():
+			s.outputQueue <- currentBatch
+			return
+		case <-ticker.C:
+			s.outputQueue <- currentBatch
+			currentBatch = types.LogBatchPool.Get(1024).(*types.LogBatch)
+			currentBatch.Reset()
+			ticker.Reset(s.FlushDuration)
+		case msg := <-s.internalQueue:
+			log := types.LogPool.Get(1).(*types.Log)
+			log.Reset()
+			log.Timestamp = uint64(time.Now().UnixNano())
+			log.ObservedTimestamp = uint64(time.Now().UnixNano())
+			log.Body["message"] = msg
+			currentBatch.Logs = append(currentBatch.Logs, log)
+			if len(currentBatch.Logs) > s.MaxBatchSize {
+				s.outputQueue <- currentBatch
+				currentBatch = types.LogBatchPool.Get(1024).(*types.LogBatch)
+				currentBatch.Reset()
+				ticker.Reset(s.FlushDuration)
+			}
+		}
+	}
+}

--- a/collector/logs/types/logs.go
+++ b/collector/logs/types/logs.go
@@ -1,0 +1,54 @@
+package types
+
+// Log represents a single log entry
+type Log struct {
+	// Timestamp of the event in nanoseconds since the unix epoch
+	Timestamp uint64
+	// Timestamp when this event was ingested in nanoseconds since the unix epoch
+	ObservedTimestamp uint64
+
+	// Body of the log entry
+	Body map[string]any
+
+	// Attributes of the log entry, not included in the log body.
+	Attributes map[string]any
+}
+
+func NewLog() *Log {
+	return &Log{
+		Body:       map[string]any{},
+		Attributes: map[string]any{},
+	}
+}
+
+func (l *Log) Reset() {
+	clear(l.Body)
+	clear(l.Attributes)
+}
+
+// Copy returns a distinct copy of the log. This is useful for splitting logs.
+func (l *Log) Copy() *Log {
+	copy := LogPool.Get(1).(*Log)
+	copy.Reset()
+	copy.Timestamp = l.Timestamp
+	copy.ObservedTimestamp = l.ObservedTimestamp
+	for k, v := range l.Attributes {
+		copy.Attributes[k] = v
+	}
+	for k, v := range l.Body {
+		copy.Body[k] = v
+	}
+	return copy
+}
+
+// LogBatch represents a batch of logs
+type LogBatch struct {
+	Logs []*Log
+}
+
+func (l *LogBatch) Reset() {
+	for i := range l.Logs {
+		l.Logs[i] = nil
+	}
+	l.Logs = l.Logs[:0]
+}

--- a/collector/logs/types/logs_test.go
+++ b/collector/logs/types/logs_test.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopy(t *testing.T) {
+	log := &Log{
+		Timestamp:         1,
+		ObservedTimestamp: 2,
+		Body: map[string]any{
+			"key": "value",
+			"complicated": map[string]any{
+				"hello": "world",
+			},
+		},
+		Attributes: map[string]any{
+			"destination": "first_destination",
+			"k8s.pod.labels": map[string]string{
+				"app": "myapp",
+			},
+		},
+	}
+
+	copy := log.Copy()
+	copy.Attributes["destination"] = "second_destination"
+
+	require.Equal(t, "first_destination", log.Attributes["destination"])
+	require.Equal(t, "myapp", log.Attributes["k8s.pod.labels"].(map[string]string)["app"])
+	require.Equal(t, "second_destination", copy.Attributes["destination"])
+	require.Equal(t, "myapp", copy.Attributes["k8s.pod.labels"].(map[string]string)["app"])
+	require.Equal(t, "value", copy.Body["key"].(string))
+	require.Equal(t, "world", copy.Body["complicated"].(map[string]any)["hello"])
+}

--- a/collector/logs/types/pool.go
+++ b/collector/logs/types/pool.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"github.com/Azure/adx-mon/pkg/pool"
+)
+
+var (
+	// TODO - consider using internal impl if easy to vendor.
+	// LogBatchPool = sync.Pool{
+	// 	New: func() interface{} {
+	// 		return &LogBatch{
+	// 			Logs: make([]*Log, 0, 1024),
+	// 		}
+	// 	},
+	// }
+	LogBatchPool = pool.NewGeneric(200, func(sz int) interface{} {
+		return &LogBatch{
+			Logs: make([]*Log, 0, sz),
+		}
+	})
+	LogPool = pool.NewGeneric(1024, func(sz int) interface{} {
+		return NewLog()
+	})
+)

--- a/collector/logs/types/processors.go
+++ b/collector/logs/types/processors.go
@@ -1,0 +1,27 @@
+package types
+
+import "context"
+
+// Source is a component that produces *LogBatch instances into the channel provided by Queue.
+type Source interface {
+	Open(context.Context) error
+	Close() error
+	Queue() <-chan *LogBatch
+	Name() string
+}
+
+// Transformer is a component that transforms a LogBatch. Transform is potentially called by multiple goroutines concurrently.
+type Transformer interface {
+	Open(context.Context) error
+	Transform(context.Context, *LogBatch) (*LogBatch, error)
+	Close() error
+	Name() string
+}
+
+// Sink is a component that receives a LogBatch. Send is potentially called by multiple goroutines concurrently.
+type Sink interface {
+	Open(context.Context) error
+	Send(context.Context, *LogBatch) error
+	Close() error
+	Name() string
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -115,4 +115,25 @@ var (
 		Name:      "logs_partial_failures",
 		Help:      "Counter of the number of partial failures when proxying logs to the OTLP endpoints",
 	}, []string{"endpoint"})
+
+	LogsCollectorLogsCollected = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_collected",
+		Help:      "Counter of the number of logs collected by the collector",
+	}, []string{"source"})
+
+	LogsCollectorLogsSent = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_sent",
+		Help:      "Counter of the number of logs successfully sent by the collector",
+	}, []string{"source", "sink"})
+
+	LogsCollectorLogsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "collector",
+		Name:      "logs_dropped",
+		Help:      "Counter of the number of logs dropped due to errors",
+	}, []string{"source", "stage"})
 )


### PR DESCRIPTION
This creates some scaffolding for log collection in collector. This implementation is intended to collect from one or several sources and feed them to ingestor via otel.

The collector/logs/types package is intended as a library that can be vendored into later Go-based plugins. As a result, it is intended to be relatively independent and require a minimum of other dependencies.