### PR TITLE
Use pod service token if one exists for scraping

### DIFF
--- a/collector/client_test.go
+++ b/collector/client_test.go
@@ -3,11 +3,12 @@ package collector_test
 import (
 	"compress/gzip"
 	"fmt"
-	"github.com/Azure/adx-mon/collector"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/Azure/adx-mon/collector"
+	"github.com/stretchr/testify/require"
 )
 
 func TestService_Client(t *testing.T) {
@@ -19,7 +20,7 @@ func TestService_Client(t *testing.T) {
 		if r.Header.Get("Accept-Encoding") != "gzip" {
 			t.Errorf("Expected gzip Accept-Encoding, got %s", r.Header.Get("Accept-Encoding"))
 		}
-		
+
 		fmt.Fprintf(w, `
 # HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary
@@ -34,7 +35,11 @@ go_gc_duration_seconds_count 8452
 	}))
 	defer svr.Close()
 
-	m, err := collector.FetchMetrics(svr.URL)
+	client, err := collector.NewMetricsClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	m, err := client.FetchMetrics(svr.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(m))
 }
@@ -70,7 +75,11 @@ go_gc_duration_seconds_count 8452
 	}))
 	defer svr.Close()
 
-	m, err := collector.FetchMetrics(svr.URL)
+	client, err := collector.NewMetricsClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	m, err := client.FetchMetrics(svr.URL)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(m))
 }

--- a/collector/service.go
+++ b/collector/service.go
@@ -40,6 +40,7 @@ type Service struct {
 
 	requestTransformer *transform.RequestTransformer
 	remoteClient       *promremote.Client
+	metricsClient      *MetricsClient
 	watcher            watch.Interface
 
 	mu            sync.RWMutex
@@ -113,6 +114,12 @@ func (s *Service) Open(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	var err error
+
+	s.metricsClient, err = NewMetricsClient()
+	if err != nil {
+		return fmt.Errorf("failed to create metrics client: %w", err)
+	}
+
 	s.remoteClient, err = promremote.NewClient(
 		promremote.ClientOpts{
 			Timeout:            20 * time.Second,
@@ -207,6 +214,7 @@ func (s *Service) Open(ctx context.Context) error {
 }
 
 func (s *Service) Close() error {
+	s.metricsClient.Close()
 	s.metricsSvc.Close()
 	s.cancel()
 	s.srv.Shutdown(s.ctx)
@@ -240,7 +248,7 @@ func (s *Service) scrapeTargets() {
 
 	wr := &prompb.WriteRequest{}
 	for _, target := range targets {
-		fams, err := FetchMetrics(target.Addr)
+		fams, err := s.metricsClient.FetchMetrics(target.Addr)
 		if err != nil {
 			logger.Errorf("Failed to scrape metrics for %s: %s", target, err.Error())
 			continue


### PR DESCRIPTION
Allows for scraping k8s api server or pods utilizing RBAC.