### PR TITLE
Handle metrics with special characters

### DIFF
--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -26,6 +26,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// invalidEntityCharacters is a regex that matches invalid characters for Kusto entities and segment files.
+// This is a subset of the invalid characters for Kusto entities and segment files naming patterns.  This should
+// match tranform.Normalize.
+var invalidEntityCharacters = regexp.MustCompile(`[^a-zA-Z0-9]`)
+
 type Service struct {
 	walOpts wal.WALOpts
 	opts    ServiceOpts
@@ -366,6 +371,10 @@ func (s *Service) validateFileName(filename string) string {
 	epoch := parts[2]
 
 	if db == "" || table == "" || epoch == "" {
+		return ""
+	}
+
+	if invalidEntityCharacters.MatchString(db) || invalidEntityCharacters.MatchString(table) || invalidEntityCharacters.MatchString(epoch) {
 		return ""
 	}
 

--- a/ingestor/service_test.go
+++ b/ingestor/service_test.go
@@ -2,10 +2,15 @@ package ingestor
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Azure/adx-mon/pkg/otlp"
+	"github.com/Azure/adx-mon/pkg/prompb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,38 +41,20 @@ func TestService_HandleTransfer_InvalidFilename(t *testing.T) {
 		name     string
 		filename string
 	}{
-		{
-			name:     "missing extension",
-			filename: "foo",
-		},
-		{
-			name:     "invalid extension",
-			filename: "foo.bar",
-		},
-		{
-			name:     "invalid separators",
-			filename: "foo.bar.wal",
-		},
-		{
-			name:     "too many separators",
-			filename: "foo_bar_baz_bip.wal",
-		},
-		{
-			name:     "not enough separators",
-			filename: "foo_bar.wal",
-		},
-		{
-			name:     "no filename",
-			filename: "",
-		},
-		{
-			name:     "path traversal",
-			filename: "../../foo_bar_baz.wal",
-		},
+		{name: "missing extension", filename: "foo"},
+		{name: "invalid extension", filename: "foo.bar"},
+		{name: "invalid separators", filename: "foo.bar.wal"},
+		{name: "too many separators", filename: "foo_bar_baz_bip.wal"},
+		{name: "not enough separators", filename: "foo_bar.wal"},
+		{name: "no filename", filename: ""},
+		{name: "path traversal", filename: "../../foo_bar_baz.wal"},
+		{name: "colon", filename: "DB_Metric:avg_123.wal"},
+		{name: "period", filename: "DB.wal_Metricavg_123.wal"},
 	}
 
 	s := &Service{
 		health: &fakeHealthChecker{healthy: true},
+		store:  &fakeStore{},
 	}
 
 	for _, tt := range tests {
@@ -86,4 +73,30 @@ func TestService_HandleTransfer_InvalidFilename(t *testing.T) {
 		})
 	}
 
+}
+
+type fakeStore struct{}
+
+func (f fakeStore) Open(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (f fakeStore) Close() error {
+	panic("implement me")
+}
+
+func (f fakeStore) WriteTimeSeries(ctx context.Context, database string, ts []prompb.TimeSeries) error {
+	panic("implement me")
+}
+
+func (f fakeStore) WriteOTLPLogs(ctx context.Context, database, table string, logs *otlp.Logs) error {
+	panic("implement me")
+}
+
+func (f fakeStore) IsActiveSegment(path string) bool {
+	panic("implement me")
+}
+
+func (f fakeStore) Import(filename string, body io.ReadCloser) (int, error) {
+	return 0, fmt.Errorf("Import should not be called")
 }

--- a/ingestor/transform/csv.go
+++ b/ingestor/transform/csv.go
@@ -291,8 +291,9 @@ func Normalize(s []byte) []byte {
 // AppendNormalize converts a metrics name to a ProperCase table name and appends it to dst.
 func AppendNormalize(dst, s []byte) []byte {
 	for i := 0; i < len(s); i++ {
-		// Skip _, but capitalize the first letter after an _
-		if s[i] == '_' {
+		// Skip any non-alphanumeric characters, but capitalize the first letter after it
+		allowedChar := s[i] >= 'a' && s[i] <= 'z' || s[i] >= '0' && s[i] <= '9' || s[i] >= 'A' && s[i] <= 'Z'
+		if !allowedChar {
 			if i+1 < len(s) {
 				if s[i+1] >= 'a' && s[i+1] <= 'z' {
 					dst = append(dst, byte(unicode.ToUpper(rune(s[i+1]))))

--- a/ingestor/transform/csv_test.go
+++ b/ingestor/transform/csv_test.go
@@ -149,7 +149,9 @@ func TestNormalize(t *testing.T) {
 	require.Equal(t, "UsedCpuUserChildren", string(Normalize([]byte("used_cpu_user_children"))))
 	require.Equal(t, "Host1", string(Normalize([]byte("host_1"))))
 	require.Equal(t, "Region", string(Normalize([]byte("region"))))
-
+	require.Equal(t, "JobEtcdRequestLatency75pctlrate5m", string(Normalize([]byte("Job:etcdRequestLatency:75pctlrate5m"))))
+	require.Equal(t, "TestLimit", string(Normalize([]byte("Test$limit"))))
+	require.Equal(t, "TestRateLimit", string(Normalize([]byte("Test::Rate$limit"))))
 }
 
 func TestTimeConversionForOTLPLogs(t *testing.T) {


### PR DESCRIPTION
Some metrics may have : or other characters that are valid file names, but not legal Kusto entity name characters.  When these are sent, ingestor gets stuck with the segments on disk and can never complete the upload.

This fixes the Normalize function to strip out all invalid characters so that only [a-zA-Z0-9] are present.  For importing segments, the segemnt file will be rejected so that ingestor doesn't get into this state.  On the collection side, the metric names will be normalized to allowed naming conventions before storing in the WAL.