### PR TITLE
Fix nil pointer panic in batch release

### DIFF
--- a/ingestor/cluster/batcher.go
+++ b/ingestor/cluster/batcher.go
@@ -308,6 +308,7 @@ func (b *batcher) processSegments() ([]*Batch, []*Batch, error) {
 				batch = &Batch{
 					Database: db,
 					Table:    table,
+					batcher:  b,
 				}
 				batchSize = 0
 				directUpload = false

--- a/ingestor/cluster/batcher_test.go
+++ b/ingestor/cluster/batcher_test.go
@@ -33,6 +33,9 @@ func TestBatcher_ClosedSegments(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{filepath.Join(dir, wal.Filename("db", "Cpu", "aaaa"))}, owner[0].Paths)
 	require.Equal(t, 0, len(notOwned))
+
+	requireValidBatch(t, owner)
+	requireValidBatch(t, notOwned)
 }
 
 func TestBatcher_NodeOwned(t *testing.T) {
@@ -68,6 +71,9 @@ func TestBatcher_NodeOwned(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(owner))
 	require.Equal(t, []string{filepath.Join(dir, fName), filepath.Join(dir, f1Name)}, notOwned[0].Paths)
+
+	requireValidBatch(t, owner)
+	requireValidBatch(t, notOwned)
 }
 
 func TestBatcher_NewestFirst(t *testing.T) {
@@ -101,6 +107,8 @@ func TestBatcher_NewestFirst(t *testing.T) {
 	require.Equal(t, "db", owner[1].Database)
 	require.Equal(t, "Disk", owner[1].Table)
 
+	requireValidBatch(t, owner)
+	requireValidBatch(t, notOwned)
 }
 
 func TestBatcher_BigFileBatch(t *testing.T) {
@@ -148,6 +156,8 @@ func TestBatcher_BigFileBatch(t *testing.T) {
 	require.Equal(t, []string{f.Name()}, owned[1].Paths)
 	require.Equal(t, []string{filepath.Join(dir, wal.Filename("db", "Disk", "2359cd7e3aef0001"))}, owned[2].Paths)
 
+	requireValidBatch(t, owned)
+	requireValidBatch(t, notOwned)
 }
 
 func TestBatcher_BigBatch(t *testing.T) {
@@ -198,6 +208,18 @@ func TestBatcher_BigBatch(t *testing.T) {
 	require.Equal(t, []string{f2.Name()}, owned[0].Paths)
 	require.Equal(t, []string{f.Name(), f1.Name()}, owned[1].Paths)
 	require.Equal(t, []string{filepath.Join(dir, wal.Filename("db", "Disk", "2359cd7e3aef0001"))}, owned[2].Paths)
+
+	requireValidBatch(t, owned)
+	requireValidBatch(t, notOwned)
+}
+
+func requireValidBatch(t *testing.T, batch []*Batch) {
+	for _, o := range batch {
+		require.NotEmptyf(t, o.Table, "batch segment %v has no ID", o)
+		require.NotEmptyf(t, o.Database, "batch segment %v has no ID", o)
+		require.NotNilf(t, o.batcher, "batch segment %v has no batcher", o)
+		require.True(t, len(o.Paths) > 0, "batch segment %v has no paths", o)
+	}
 }
 
 type fakePartitioner struct {


### PR DESCRIPTION
Fixes panic

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0x1770fd5]

 

goroutine 471 [running]:
github.com/Azure/adx-mon/ingestor/cluster.(*batcher).release(0x0, 0x0?)
        /app/3rdparty/adx-mon/ingestor/cluster/batcher.go:396 +0x35
github.com/Azure/adx-mon/ingestor/cluster.(*Batch).Release(0x0?)
        /app/3rdparty/adx-mon/ingestor/cluster/batcher.go:49 +0x1d
```