### PR TITLE
Add ingestor support for multiple metrics databases

### DIFF
--- a/cmd/collector/config.go
+++ b/cmd/collector/config.go
@@ -230,7 +230,7 @@ func (c *Config) processStringFields(v reflect.Value, f func(string) string) {
 			value := v.MapIndex(key)
 			if value.Kind() == reflect.String {
 				v.SetMapIndex(key, reflect.ValueOf(f(value.String())))
-				return
+				continue
 			}
 
 			c.processStringFields(v.MapIndex(key), f)

--- a/cmd/collector/config_test.go
+++ b/cmd/collector/config_test.go
@@ -241,6 +241,7 @@ func TestConfig_ReplaceVariables(t *testing.T) {
 	c := &Config{
 		AddLabels: map[string]string{
 			"foo": "$(HOSTNAME)_bar",
+			"bar": "bar",
 		},
 		PrometheusRemoteWrite: []*PrometheusRemoteWrite{
 			{

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -143,13 +143,6 @@ func realMain(ctx *cli.Context) error {
 		logger.Infof("Using storage dir: %s", cfg.StorageDir)
 	}
 
-	// Add this pods identity for all metrics received
-	addLabels = mergeMaps(addLabels, map[string]string{
-		"adxmon_namespace": k8s.Instance.Namespace,
-		"adxmon_pod":       k8s.Instance.Pod,
-		"adxmon_container": k8s.Instance.Container,
-	})
-
 	var scraperOpts *collector.ScraperOpts
 	if cfg.PrometheusScrape != nil {
 
@@ -227,8 +220,12 @@ func realMain(ctx *cli.Context) error {
 	}
 
 	for _, v := range cfg.PrometheusRemoteWrite {
+		// Add this pods identity for all metrics received
 		writeLabels := mergeMaps(addLabels, map[string]string{
-			"adxmon_database": v.Database,
+			"adxmon_namespace": k8s.Instance.Namespace,
+			"adxmon_pod":       k8s.Instance.Pod,
+			"adxmon_container": k8s.Instance.Container,
+			"adxmon_database":  v.Database,
 		})
 
 		dropLabels := make(map[*regexp.Regexp]*regexp.Regexp)

--- a/ingestor/adx/dispatcher.go
+++ b/ingestor/adx/dispatcher.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/adx-mon/ingestor/cluster"
 	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/azure-kusto-go/kusto"
 )
 
 type dispatcher struct {
@@ -53,6 +54,11 @@ func (d *dispatcher) UploadQueue() chan *cluster.Batch {
 
 func (d *dispatcher) Database() string {
 	return ""
+}
+
+func (d *dispatcher) Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+	// Not implemented.  Should this fanout to all uploaders?
+	return nil, nil
 }
 
 func (d *dispatcher) upload(ctx context.Context) {

--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/tlv"
 	"github.com/Azure/adx-mon/pkg/wal"
 	"github.com/Azure/adx-mon/pkg/wal/file"
+	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/ingest"
 )
 
@@ -27,6 +28,9 @@ type Uploader interface {
 
 	// UploadQueue returns a channel that can be used to upload files to kusto.
 	UploadQueue() chan *cluster.Batch
+
+	// Mgmt executes a management query against the database.
+	Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
 type uploader struct {
@@ -106,6 +110,10 @@ func (n *uploader) UploadQueue() chan *cluster.Batch {
 
 func (n *uploader) Database() string {
 	return n.database
+}
+
+func (n *uploader) Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+	return n.KustoCli.Mgmt(ctx, n.database, query, options...)
 }
 
 func (n *uploader) uploadReader(reader io.Reader, database, table string) error {

--- a/ingestor/cluster/coordinator.go
+++ b/ingestor/cluster/coordinator.go
@@ -188,7 +188,7 @@ func (c *coordinator) Open(ctx context.Context) error {
 
 	hostName := c.opts.Hostname
 
-	hostEndpoint := fmt.Sprintf("https://%s:9090/transfer", myIP.To4().String())
+	hostEndpoint := fmt.Sprintf("https://%s:9090", myIP.To4().String())
 	c.hostEntpoint = hostEndpoint
 	c.hostname = hostName
 
@@ -264,7 +264,7 @@ func (c *coordinator) syncPeers() error {
 			continue
 		}
 
-		set[p.Name] = fmt.Sprintf("https://%s:9090/transfer", p.Status.PodIP)
+		set[p.Name] = fmt.Sprintf("https://%s:9090", p.Status.PodIP)
 
 		if p.Name < leastNode || leastNode == "" {
 			leastNode = p.Name

--- a/ingestor/metrics/handler.go
+++ b/ingestor/metrics/handler.go
@@ -78,7 +78,6 @@ type Handler struct {
 	}
 
 	requestWriter RequestWriter
-	database      string
 	health        HealthChecker
 }
 
@@ -92,7 +91,6 @@ func NewHandler(opts HandlerOpts) *Handler {
 		health:             opts.HealthChecker,
 		requestTransformer: opts.RequestTransformer,
 		requestWriter:      opts.RequestWriter,
-		database:           opts.Database,
 	}
 }
 

--- a/ingestor/otlp/logs.go
+++ b/ingestor/otlp/logs.go
@@ -22,21 +22,21 @@ import (
 
 var bytesPool = pool.NewBytes(1024)
 
-type logsServer struct {
+type logsServiceHandler struct {
 	w         cluster.OTLPLogsWriter
 	databases map[string]struct{}
 }
 
-func NewLogsServer(w cluster.OTLPLogsWriter, logsDatabases []string) logsv1connect.LogsServiceHandler {
-	logger.Infof("Initializing OTLP logs server with databases: %v", logsDatabases)
+func NewLogsServiceHandler(w cluster.OTLPLogsWriter, logsDatabases []string) logsv1connect.LogsServiceHandler {
+	logger.Infof("Initializing OTLP logs service with databases: %v", logsDatabases)
 	databases := make(map[string]struct{})
 	for _, d := range logsDatabases {
 		databases[d] = struct{}{}
 	}
-	return &logsServer{w: w, databases: databases}
+	return &logsServiceHandler{w: w, databases: databases}
 }
 
-func (srv *logsServer) Export(ctx context.Context, req *connect_go.Request[v1.ExportLogsServiceRequest]) (*connect_go.Response[v1.ExportLogsServiceResponse], error) {
+func (srv *logsServiceHandler) Export(ctx context.Context, req *connect_go.Request[v1.ExportLogsServiceRequest]) (*connect_go.Response[v1.ExportLogsServiceResponse], error) {
 	var (
 		m                  = metrics.RequestsReceived.MustCurryWith(prometheus.Labels{"path": logsv1connect.LogsServiceExportProcedure})
 		d, t               string

--- a/ingestor/otlp/logs_test.go
+++ b/ingestor/otlp/logs_test.go
@@ -31,7 +31,7 @@ func TestOTLP(t *testing.T) {
 	w := &writer{t: t}
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServer(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServiceHandler(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
 
 	srv := httptest.NewUnstartedServer(mux)
 	srv.EnableHTTP2 = true
@@ -58,7 +58,7 @@ func TestUnknownDestination(t *testing.T) {
 	w := &writer{t: t}
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServer(w.WriteLogRecords, []string{"ADatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServiceHandler(w.WriteLogRecords, []string{"ADatabase"})))
 
 	srv := httptest.NewUnstartedServer(mux)
 	srv.EnableHTTP2 = true
@@ -86,7 +86,7 @@ func TestUnconfiguredDestination(t *testing.T) {
 	w := &writer{t: t}
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServer(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServiceHandler(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
 
 	srv := httptest.NewUnstartedServer(mux)
 	srv.EnableHTTP2 = true
@@ -113,7 +113,7 @@ func TestOTLPWriterFailures(t *testing.T) {
 	w := &writer{t: t, err: errors.New("something happened")}
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServer(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(NewLogsServiceHandler(w.WriteLogRecords, []string{"ADatabase", "BDatabase"})))
 
 	srv := httptest.NewUnstartedServer(mux)
 	srv.EnableHTTP2 = true

--- a/tools/otlp/logs/e2e_test.go
+++ b/tools/otlp/logs/e2e_test.go
@@ -245,7 +245,7 @@ func NewIngestorHandler(t *testing.T, ctx context.Context, dir string) (string, 
 
 	svc, err := isvc.NewService(isvc.ServiceOpts{
 		StorageDir:      dir,
-		Uploader:        adx.NewFakeUploader(),
+		Uploader:        adx.NewFakeUploader("ADatabase"),
 		LogsDatabases:   []string{"ADatabase", "BDatabase"},
 		MaxSegmentCount: 100,
 		MaxDiskUsage:    10 * 1024 * 1024 * 1024,
@@ -253,7 +253,7 @@ func NewIngestorHandler(t *testing.T, ctx context.Context, dir string) (string, 
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(iotlp.NewLogsServer(writer, []string{"ADatabase", "BDatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(iotlp.NewLogsServiceHandler(writer, []string{"ADatabase", "BDatabase"})))
 	mux.HandleFunc("/transfer", svc.HandleTransfer)
 
 	srv := httptest.NewUnstartedServer(mux)

--- a/tools/otlp/logs/transport_test.go
+++ b/tools/otlp/logs/transport_test.go
@@ -135,14 +135,14 @@ func ingestor(b *testing.B, ctx context.Context) string {
 
 	svc, err := ingestorsvc.NewService(ingestorsvc.ServiceOpts{
 		StorageDir:      b.TempDir(),
-		Uploader:        adx.NewFakeUploader(),
+		Uploader:        adx.NewFakeUploader("ADatabase"),
 		MaxSegmentCount: int64(b.N) + 1,
 		MaxDiskUsage:    10 * 1024 * 1024 * 1024,
 	})
 	require.NoError(b, err)
 
 	mux := http.NewServeMux()
-	mux.Handle(logsv1connect.NewLogsServiceHandler(ingestorotlp.NewLogsServer(writer, []string{"ADatabase", "BDatabase"})))
+	mux.Handle(logsv1connect.NewLogsServiceHandler(ingestorotlp.NewLogsServiceHandler(writer, []string{"ADatabase", "BDatabase"})))
 	mux.HandleFunc("/transfer", svc.HandleTransfer)
 
 	srv := httptest.NewUnstartedServer(mux)


### PR DESCRIPTION
This switches ingestor to be able to use multiple metrics databases and requires the database that metrics should be uploaded to be part of the metrics labels.