### PR TITLE
Increase ingestor idle timeout to 5 mins

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -366,7 +366,7 @@ func realMain(ctx *cli.Context) error {
 		Handler: mux,
 		// Close idle connections fairly often to establish new connections through the load balancer
 		// so that long-lived connections don't stay pinned to the same node indefinitely.
-		IdleTimeout: 2 * time.Minute,
+		IdleTimeout: 5 * time.Minute,
 	}
 	srv.ErrorLog = newLogger()
 


### PR DESCRIPTION
Collector uses 90s and 2 minutes seems to be a little too short and causes transient HTTPS GOAWAY errors which can lead to collector re-sending data when it did not need to.