### PR TITLE
Add option to preserve TLV in the read stream

### DIFF
--- a/collector/otlp/logs_transfer.go
+++ b/collector/otlp/logs_transfer.go
@@ -114,17 +114,16 @@ func (s *LogsService) Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Serialize the logs into a WAL, grouped by Kusto destination database and table
 		grouped := otlp.Group(msg, s.staticAttributes, s.logger)
 		for _, group := range grouped {
 			err := func(g *otlp.Logs) error {
-				metrics.LogsProxyReceived.WithLabelValues(g.Database, g.Table).Add(float64(len(g.Logs)))
 				if err := s.store.WriteOTLPLogs(r.Context(), g.Database, g.Table, g); err != nil {
 					return fmt.Errorf("failed to write to store: %w", err)
 				}
 				return nil
 			}(group)
 
-			// Serialize the logs into a WAL, grouped by Kusto destination database and table
 			if isUserError(err) {
 				s.logger.Error("Failed to serialize logs with user error", "Error", err)
 				w.WriteHeader(http.StatusBadRequest)

--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/adx-mon/ingestor/cluster"
 	"github.com/Azure/adx-mon/ingestor/storage"
+	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/otlp"
 	"github.com/Azure/adx-mon/pkg/service"
@@ -162,7 +163,7 @@ func (n *uploader) uploadReader(reader io.Reader, database, table string) error 
 	defer cancel()
 
 	// Count the number of samples we are uploading.
-	tlvr := tlv.NewStreaming(reader)
+	tlvr := tlv.NewReader(reader)
 
 	// uploadReader our file WITHOUT status reporting.
 	// When completed, delete the file on local storage we are uploading.
@@ -178,7 +179,7 @@ func (n *uploader) uploadReader(reader io.Reader, database, table string) error 
 	}
 
 	if n.opts.SampleType == OTLPLogs {
-		otlp.EmitMetricsForTLV(tlvr.Header(), database, table)
+		otlp.EmitMetricsForTLV(tlvr.Header(), metrics.LogsUploaded, database, table)
 	}
 
 	// return os.Remove(file)

--- a/pkg/otlp/logs.go
+++ b/pkg/otlp/logs.go
@@ -7,8 +7,8 @@ import (
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
 	logsv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/logs/v1"
-	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/tlv"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Logs is a collection of logs and their resources.
@@ -27,11 +27,11 @@ const (
 	LogsTotalTag = tlv.Tag(0xAB)
 )
 
-func EmitMetricsForTLV(tlvs []tlv.TLV, database, table string) {
+func EmitMetricsForTLV(tlvs []tlv.TLV, counter *prometheus.CounterVec, database, table string) {
 	for _, t := range tlvs {
 		if t.Tag == LogsTotalTag {
 			if v, err := strconv.Atoi(string(t.Value)); err == nil {
-				metrics.LogsUploaded.WithLabelValues(database, table).Add(float64(v))
+				counter.WithLabelValues(database, table).Add(float64(v))
 			}
 		}
 	}

--- a/tools/otlp/logs/collector.toml
+++ b/tools/otlp/logs/collector.toml
@@ -1,0 +1,51 @@
+# Ingestor URL to send collected telemetry.
+endpoint = 'https://ingestor:9090'
+# Skip TLS verification.
+insecure-skip-verify = true
+# Address to listen on for endpoints.
+listen-addr = ':8080'
+# Maximum number of samples to send in a single batch.
+max-batch-size = 5000
+# Storage directory for the WAL.
+storage-dir = '/tmp/.adx-mon/collector'
+# Global Regexes of metrics to drop.
+drop-metrics = []
+# Disable metrics forwarding to endpoints.
+disable-metrics-forwarding = false
+# Attributes lifted from the Body and added to Attributes.
+lift-attributes = ['kusto.database', 'kusto.table']
+
+# Defines a prometheus scrape endpoint.
+[prometheus-scrape]
+  # Database to store metrics in.
+  database = 'AKSMetrics'
+  # Defines a static scrape target.
+  static-scrape-target = []
+  # Scrape interval in seconds.
+  scrape-interval = 30
+  # Disable metrics forwarding to endpoints.
+  disable-metrics-forwarding = false
+  # Regexes of metrics to drop.
+  drop-metrics = []
+
+# Defines a prometheus remote write endpoint.
+[[prometheus-remote-write]]
+  # Database to store metrics in.
+  database = 'AKSMetrics'
+  # The path to listen on for prometheus remote write requests.  Defaults to /receive.
+  path = '/remote_write'
+  # Regexes of metrics to drop.
+  drop-metrics = []
+  # Disable metrics forwarding to endpoints.
+  disable-metrics-forwarding = false
+
+  # Key/value pairs of labels to add to all metrics.
+  [prometheus-remote-write.add-labels]
+
+# Defines an OpenTelemetry log endpoint.
+[otel-log]
+  # Attributes lifted from the Body and added to Attributes.
+  lift-attributes = ['kusto.database', 'kusto.table']
+
+  # Key/value pairs of attributes to add to all logs.
+  [otel-log.add-attributes]

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -26,12 +26,13 @@ services:
       context: ../../..
     volumes:
       - ~/.kube/config:/root/.kube/config
+      - ${PWD}/tools/otlp/logs/collector.toml:/collector.toml
     ports:
       - 8080:8080
     # While the _endpoints_ URI doesn't match the expected OTLP syntax, keep in
     # mind that _Collector_ is currently configured to connect to _Ingestor_, so we
     # just modify the _endpoints_ in pkg/otlp/proxy to be OTLP compliant.
-    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --insecure-skip-verify --target=.*=http://localhost:8080/metrics:adx-mon/collector/collector --add-attributes Environment=dev --lift-attributes kusto.database --lift-attributes kusto.table --storage-dir /tmp
+    command: --kubeconfig /root/.kube/config --config /collector.toml
     depends_on:
       - ingestor
     environment:

--- a/tools/otlp/logs/e2e_test.go
+++ b/tools/otlp/logs/e2e_test.go
@@ -146,7 +146,7 @@ func VerifyStore(t *testing.T, dir string, expectTLV bool) {
 
 		s, err := wal.NewSegmentReader(filepath.Join(dir, entry.Name()), &file.DiskProvider{})
 		require.NoError(t, err)
-		tlvr := tlv.NewStreaming(s)
+		tlvr := tlv.NewReader(s)
 		b, err := io.ReadAll(tlvr)
 		require.NoError(t, err)
 

--- a/tools/otlp/logs/fluent.yaml
+++ b/tools/otlp/logs/fluent.yaml
@@ -1,13 +1,13 @@
 service:
   flush: 1
-  log_level: debug
+  log_level: error
 
 pipeline:
 
   inputs:
     - name: dummy
       tag: dummy
-      dummy: '{"message": "hello world", "kusto.database": "FakeDatabase", "kusto.table": "FakeTable"}'
+      dummy: '{"message": "hello world", "kusto.database": "FakeLogs", "kusto.table": "FakeTable"}'
 
   outputs:
     - Name: opentelemetry


### PR DESCRIPTION
Our TLV reader was originally setup to handle the Ingestor use-case, where TLV is read from segments as they're being uploaded to ADX. In this case, we want to read and remove TLV from the byte stream so it doesn't corrupt the CSV that ADX reads. Since we've modified Collector to write segments to disk for batching purposes, we want to read TLV when transferring segments from Collector to Ingestor so we can keep track of the number of logs transferred vs the number of logs uploaded to ADX. 

This new scenario requires a new reader option in TLV such that the TLV bits are retained as they're read, so as to convey their contents to Ingestor, thereby enabling Ingestor to also read the TLV when uploading to ADX. 