### PR TITLE
Support drop all metrics by default in collector

### DIFF
--- a/cmd/collector/config_test.go
+++ b/cmd/collector/config_test.go
@@ -237,6 +237,122 @@ func TestConfig_PromWrite_Database(t *testing.T) {
 	require.Equal(t, "prometheus-remote-write.database must be set", c.Validate().Error())
 }
 
+func TestConfig_Validate_PrometheusRemoteWrite(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PrometheusRemoteWrite
+		wantErr bool
+	}{
+		{
+			name: "Success_all_parameters_set",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				AddLabels: map[string]string{
+					"key1": "value1",
+				},
+				DropLabels: map[string]string{
+					"key2": "value2",
+				},
+				KeepMetricsWithLabelValue: []LabelMatcher{
+					{LabelRegex: "key3", ValueRegex: "value3"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Failure_empty_path",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_database",
+			config: PrometheusRemoteWrite{
+				Path: "/path",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_key_in_AddLabels",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				AddLabels: map[string]string{
+					"": "value",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_value_in_AddLabels",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				AddLabels: map[string]string{
+					"key": "",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_key_in_DropLabels",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				DropLabels: map[string]string{
+					"": "value",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_value_in_DropLabels",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				DropLabels: map[string]string{
+					"key": "",
+				},
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "Failure_empty_key_in_KeepMetricsWithLabelValue",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				KeepMetricsWithLabelValue: []LabelMatcher{
+					{LabelRegex: "", ValueRegex: "value"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failure_empty_value_in_KeepMetricsWithLabelValue",
+			config: PrometheusRemoteWrite{
+				Database: "db",
+				Path:     "/path",
+				KeepMetricsWithLabelValue: []LabelMatcher{
+					{LabelRegex: "key", ValueRegex: ""},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestConfig_ReplaceVariables(t *testing.T) {
 	c := &Config{
 		AddLabels: map[string]string{

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -53,6 +53,7 @@ func main() {
 					}
 
 					fmt.Println(buf.String())
+
 					return nil
 				},
 			},
@@ -192,17 +193,54 @@ func realMain(ctx *cli.Context) error {
 			dropMetrics = append(dropMetrics, metricRegex)
 		}
 
+		keepMetrics := []*regexp.Regexp{}
+		for _, v := range unionSlice(cfg.KeepMetrics, cfg.PrometheusScrape.KeepMetrics) {
+			metricRegex, err := regexp.Compile(v)
+			if err != nil {
+				logger.Fatalf("invalid metric regex: %s", err)
+			}
+
+			keepMetrics = append(keepMetrics, metricRegex)
+		}
+
+		keepMetricLabelValues := make(map[*regexp.Regexp]*regexp.Regexp)
+		for _, v := range append(cfg.KeepMetricsWithLabelValue, cfg.PrometheusScrape.KeepMetricsWithLabelValue...) {
+			lableRe, err := regexp.Compile(v.LabelRegex)
+			if err != nil {
+				logger.Fatalf("invalid metric regex: %s", err)
+			}
+
+			valueRe, err := regexp.Compile(v.ValueRegex)
+			if err != nil {
+				logger.Fatalf("invalid label regex: %s", err)
+			}
+
+			keepMetricLabelValues[lableRe] = valueRe
+		}
+
+		var defaultDropMetrics bool
+		if cfg.DefaultDropMetrics != nil {
+			defaultDropMetrics = *cfg.DefaultDropMetrics
+		}
+
+		if cfg.PrometheusScrape.DefaultDropMetrics != nil {
+			defaultDropMetrics = *cfg.PrometheusScrape.DefaultDropMetrics
+		}
+
 		scraperOpts = &collector.ScraperOpts{
-			NodeName:                 hostname,
-			K8sCli:                   k8scli,
-			Database:                 cfg.PrometheusScrape.Database,
-			AddLabels:                addLabels,
-			DropLabels:               dropLabels,
-			DropMetrics:              dropMetrics,
-			DisableMetricsForwarding: cfg.PrometheusScrape.DisableMetricsForwarding,
-			ScrapeInterval:           time.Duration(cfg.PrometheusScrape.ScrapeIntervalSeconds) * time.Second,
-			Targets:                  staticTargets,
-			MaxBatchSize:             cfg.MaxBatchSize,
+			NodeName:                  hostname,
+			K8sCli:                    k8scli,
+			Database:                  cfg.PrometheusScrape.Database,
+			AddLabels:                 addLabels,
+			DropLabels:                dropLabels,
+			DropMetrics:               dropMetrics,
+			KeepMetrics:               keepMetrics,
+			KeepMetricsWithLabelValue: keepMetricLabelValues,
+			DefaultDropMetrics:        defaultDropMetrics,
+			DisableMetricsForwarding:  cfg.PrometheusScrape.DisableMetricsForwarding,
+			ScrapeInterval:            time.Duration(cfg.PrometheusScrape.ScrapeIntervalSeconds) * time.Second,
+			Targets:                   staticTargets,
+			MaxBatchSize:              cfg.MaxBatchSize,
 		}
 	}
 
@@ -265,11 +303,48 @@ func realMain(ctx *cli.Context) error {
 			dropMetrics = append(dropMetrics, metricRegex)
 		}
 
+		keepMetrics := []*regexp.Regexp{}
+		for _, v := range unionSlice(cfg.KeepMetrics, cfg.PrometheusScrape.KeepMetrics) {
+			metricRegex, err := regexp.Compile(v)
+			if err != nil {
+				logger.Fatalf("invalid metric regex: %s", err)
+			}
+
+			keepMetrics = append(keepMetrics, metricRegex)
+		}
+
+		keepMetricLabelValues := make(map[*regexp.Regexp]*regexp.Regexp)
+		for _, v := range append(cfg.KeepMetricsWithLabelValue, cfg.PrometheusScrape.KeepMetricsWithLabelValue...) {
+			labelRe, err := regexp.Compile(v.LabelRegex)
+			if err != nil {
+				logger.Fatalf("invalid metric regex: %s", err)
+			}
+
+			valueRe, err := regexp.Compile(v.ValueRegex)
+			if err != nil {
+				logger.Fatalf("invalid label regex: %s", err)
+			}
+
+			keepMetricLabelValues[labelRe] = valueRe
+		}
+
+		var defaultDropMetrics bool
+		if cfg.DefaultDropMetrics != nil {
+			defaultDropMetrics = *cfg.DefaultDropMetrics
+		}
+
+		if v.DefaultDropMetrics != nil {
+			defaultDropMetrics = *v.DefaultDropMetrics
+		}
+
 		opts.MetricsHandlers = append(opts.MetricsHandlers, collector.MetricsHandlerOpts{
-			Path:        v.Path,
-			AddLabels:   addLabels,
-			DropMetrics: dropMetrics,
-			DropLabels:  dropLabels,
+			Path:                   v.Path,
+			DefaultDropMetrics:     defaultDropMetrics,
+			AddLabels:              addLabels,
+			DropMetrics:            dropMetrics,
+			DropLabels:             dropLabels,
+			KeepMetrics:            keepMetrics,
+			KeepMetricsLabelValues: keepMetricLabelValues,
 		})
 	}
 

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -27,6 +27,8 @@ import (
 type ScraperOpts struct {
 	NodeName string
 
+	DefaultDropMetrics bool
+
 	// AddLabels is a map of key/value pairs that will be added to all metrics.
 	AddLabels map[string]string
 
@@ -36,6 +38,10 @@ type ScraperOpts struct {
 	// DropMetrics is a slice of regexes that drops metrics when the metric name matches.  The metric name format
 	// should match the Prometheus naming style before the metric is translated to a Kusto table name.
 	DropMetrics []*regexp.Regexp
+
+	KeepMetricsWithLabelValue map[*regexp.Regexp]*regexp.Regexp
+
+	KeepMetrics []*regexp.Regexp
 
 	// Database is the name of the database to write metrics to.
 	Database string
@@ -60,7 +66,14 @@ type ScraperOpts struct {
 }
 
 func (s *ScraperOpts) RequestTransformer() *transform.RequestTransformer {
-	return transform.NewRequestTransformer(s.AddLabels, s.DropLabels, s.DropMetrics, nil)
+	return &transform.RequestTransformer{
+
+		AddLabels:                 s.AddLabels,
+		DropLabels:                s.DropLabels,
+		DropMetrics:               s.DropMetrics,
+		KeepMetrics:               s.KeepMetrics,
+		KeepMetricsWithLabelValue: s.KeepMetricsWithLabelValue,
+	}
 }
 
 type ScrapeTarget struct {

--- a/collector/service.go
+++ b/collector/service.go
@@ -114,12 +114,22 @@ type MetricsHandlerOpts struct {
 	// should match the Prometheus naming style before the metric is translated to a Kusto table name.
 	DropMetrics []*regexp.Regexp
 
+	KeepMetrics []*regexp.Regexp
+
+	KeepMetricsLabelValues map[*regexp.Regexp]*regexp.Regexp
+
 	// DisableMetricsForwarding disables the forwarding of metrics to the remote write endpoint.
 	DisableMetricsForwarding bool
+	DefaultDropMetrics       bool
 }
 
 func (o MetricsHandlerOpts) RequestTransformer() *transform.RequestTransformer {
-	return transform.NewRequestTransformer(o.AddLabels, o.DropLabels, o.DropMetrics, nil)
+	return &transform.RequestTransformer{
+		AddLabels:   o.AddLabels,
+		DropLabels:  o.DropLabels,
+		DropMetrics: o.DropMetrics,
+		KeepMetrics: o.KeepMetrics,
+	}
 }
 
 func NewService(opts *ServiceOpts) (*Service, error) {

--- a/ingestor/metrics/handler_test.go
+++ b/ingestor/metrics/handler_test.go
@@ -32,7 +32,7 @@ func TestHandler_HandleReceive(t *testing.T) {
 	}
 
 	h := NewHandler(HandlerOpts{
-		RequestTransformer: transform.NewRequestTransformer(nil, nil, nil, nil),
+		RequestTransformer: &transform.RequestTransformer{},
 		RequestWriter:      writer,
 		HealthChecker:      &fakeHealthChecker{healthy: true},
 		Database:           "adxmetrics",
@@ -84,10 +84,12 @@ func TestHandler_HandleReceive_Unhealthy(t *testing.T) {
 	}
 
 	h := NewHandler(HandlerOpts{
-		RequestTransformer: transform.NewRequestTransformer(nil, nil, nil, map[string]struct{}{"adxmetrics": {}}),
-		RequestWriter:      writer,
-		HealthChecker:      &fakeHealthChecker{healthy: false},
-		Database:           "adxmetrics",
+		RequestTransformer: &transform.RequestTransformer{
+			AllowedDatabase: map[string]struct{}{"adxmetrics": {}},
+		},
+		RequestWriter: writer,
+		HealthChecker: &fakeHealthChecker{healthy: false},
+		Database:      "adxmetrics",
 	})
 
 	wr := prompb.WriteRequest{
@@ -136,10 +138,12 @@ func TestHandler_HandleReceive_AllowedDBs(t *testing.T) {
 	}
 
 	h := NewHandler(HandlerOpts{
-		RequestTransformer: transform.NewRequestTransformer(nil, nil, nil, map[string]struct{}{"adxmetrics": {}}),
-		RequestWriter:      writer,
-		HealthChecker:      &fakeHealthChecker{healthy: true},
-		Database:           "adxmetrics",
+		RequestTransformer: &transform.RequestTransformer{
+			AllowedDatabase: map[string]struct{}{"adxmetrics": {}},
+		},
+		RequestWriter: writer,
+		HealthChecker: &fakeHealthChecker{healthy: true},
+		Database:      "adxmetrics",
 	})
 
 	wr := prompb.WriteRequest{

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -183,9 +183,13 @@ func NewService(opts ServiceOpts) (*Service, error) {
 	}
 
 	handler := metricsHandler.NewHandler(metricsHandler.HandlerOpts{
-		RequestTransformer: transform.NewRequestTransformer(nil, opts.DropLabels, opts.DropMetrics, dbs),
-		RequestWriter:      coord,
-		HealthChecker:      health,
+		RequestTransformer: &transform.RequestTransformer{
+			DropLabels:      opts.DropLabels,
+			DropMetrics:     opts.DropMetrics,
+			AllowedDatabase: dbs,
+		},
+		RequestWriter: coord,
+		HealthChecker: health,
 	})
 
 	_, l := logsv1connect.NewLogsServiceHandler(otlp.NewLogsServiceHandler(coord.WriteOTLPLogs, opts.LogsDatabases))


### PR DESCRIPTION
Currently, collector accepts all metrics and requires drop rules
to drop unwanted metrics.  It is sometimes desirable to invert this
and drop everything except metrics that are allowed.

This add supports for the latter case to allow metrics by regex as well
as subsets that may be interesting based on certain label key and
value paires.  For example, you might want to collect container
disk metrics but only for a specific container or volume and not all of them.