### PR TITLE
Run transforms and sends to sinks in parallel

### DIFF
--- a/collector/logs/service.go
+++ b/collector/logs/service.go
@@ -2,10 +2,8 @@ package logs
 
 import (
 	"context"
-	"sync"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
-	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
 )
 
@@ -14,7 +12,6 @@ type Service struct {
 	Transforms []types.Transformer
 	Sink       types.Sink
 
-	wg     sync.WaitGroup
 	cancel context.CancelFunc
 }
 
@@ -38,8 +35,6 @@ func (s *Service) Open(ctx context.Context) error {
 		return err
 	}
 
-	s.wg.Add(1)
-	go s.process(ctx)
 	return nil
 }
 
@@ -48,7 +43,6 @@ func (s *Service) Close() error {
 		logger.Warnf("Failed to close source: %s", err)
 	}
 	s.cancel()
-	s.wg.Wait()
 	for _, transform := range s.Transforms {
 		if err := transform.Close(); err != nil {
 			logger.Warnf("Failed to close transform: %s", err)
@@ -59,50 +53,4 @@ func (s *Service) Close() error {
 	}
 
 	return nil
-}
-
-func (s *Service) process(ctx context.Context) {
-	defer s.wg.Done()
-	for {
-		select {
-		case <-ctx.Done():
-			// TODO ensure we have flushed.
-			return
-		case batch := <-s.Source.Queue():
-			// TODO curry labels?
-			metrics.LogsCollectorLogsCollected.WithLabelValues(s.Source.Name()).Add(float64(len(batch.Logs)))
-			s.processBatch(ctx, batch)
-		}
-	}
-}
-
-func (s *Service) processBatch(ctx context.Context, batch *types.LogBatch) {
-	var err error
-	for _, transform := range s.Transforms {
-		batch, err = transform.Transform(ctx, batch)
-		if err != nil {
-			metrics.LogsCollectorLogsDropped.WithLabelValues(s.Source.Name(), transform.Name()).Add(float64(len(batch.Logs)))
-			s.disposeBatch(batch)
-			// TODO skip batch if error is not recoverable
-			// Nack batch?
-			return
-		}
-	}
-	err = s.Sink.Send(ctx, batch)
-	if err != nil {
-		metrics.LogsCollectorLogsDropped.WithLabelValues(s.Source.Name(), s.Sink.Name()).Add(float64(len(batch.Logs)))
-		s.disposeBatch(batch)
-		// TODO skip batch if error is not recoverable
-		// Nack batch?
-		return
-	}
-	metrics.LogsCollectorLogsSent.WithLabelValues(s.Source.Name(), s.Sink.Name()).Add(float64(len(batch.Logs)))
-	s.disposeBatch(batch)
-}
-
-func (s *Service) disposeBatch(batch *types.LogBatch) {
-	for _, log := range batch.Logs {
-		types.LogPool.Put(log)
-	}
-	types.LogBatchPool.Put(batch)
 }

--- a/collector/logs/service_test.go
+++ b/collector/logs/service_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/Azure/adx-mon/collector/logs"
 	"github.com/Azure/adx-mon/collector/logs/sinks"
 	"github.com/Azure/adx-mon/collector/logs/sources"
+	"github.com/Azure/adx-mon/collector/logs/types"
 )
 
 func BenchmarkPipeline(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		source := sources.NewConstSource("test-val", 1*time.Second, 1000)
 		sink := sinks.NewCountingSink(10000)
+		source := sources.NewConstSource("test-val", 1*time.Second, 1000, types.WorkerCreator(nil, sink))
 
 		service := &logs.Service{
 			Source: source,
@@ -29,8 +30,8 @@ func BenchmarkPipeline(b *testing.B) {
 
 func TestPipeline(t *testing.T) {
 	// Ensure we can send 10k logs through the pipeline.
-	source := sources.NewConstSource("test-val", 1*time.Second, 1000)
 	sink := sinks.NewCountingSink(10000)
+	source := sources.NewConstSource("test-val", 1*time.Second, 1000, types.WorkerCreator(nil, sink))
 
 	service := &logs.Service{
 		Source: source,

--- a/collector/logs/types/batch.go
+++ b/collector/logs/types/batch.go
@@ -25,6 +25,7 @@ func BatchLogs(ctx context.Context, config BatchConfig) error {
 			if len(currentBatch.Logs) != 0 {
 				flush(config, currentBatch)
 			}
+			close(config.OutputQueue)
 			return nil
 		case <-ticker.C:
 			if len(currentBatch.Logs) != 0 {

--- a/collector/logs/types/processors.go
+++ b/collector/logs/types/processors.go
@@ -6,7 +6,6 @@ import "context"
 type Source interface {
 	Open(context.Context) error
 	Close() error
-	Queue() <-chan *LogBatch
 	Name() string
 }
 

--- a/collector/logs/types/worker.go
+++ b/collector/logs/types/worker.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"context"
+
+	"github.com/Azure/adx-mon/metrics"
+)
+
+type worker struct {
+	SourceName string
+	Input      <-chan *LogBatch
+	Transforms []Transformer
+	Sink       Sink
+}
+
+type WorkerCreatorFunc func(string, <-chan *LogBatch) *worker
+
+func WorkerCreator(transforms []Transformer, sink Sink) func(string, <-chan *LogBatch) *worker {
+	return func(sourceName string, input <-chan *LogBatch) *worker {
+		return &worker{
+			SourceName: sourceName,
+			Input:      input,
+			Transforms: transforms,
+			Sink:       sink,
+		}
+	}
+}
+
+func (w *worker) Run() error {
+	for msg := range w.Input {
+		w.processBatch(context.Background(), msg)
+	}
+	return nil
+}
+
+func (w *worker) processBatch(ctx context.Context, batch *LogBatch) {
+	var err error
+	for _, transform := range w.Transforms {
+		batch, err = transform.Transform(ctx, batch)
+		if err != nil {
+			metrics.LogsCollectorLogsDropped.WithLabelValues(w.SourceName, transform.Name()).Add(float64(len(batch.Logs)))
+			disposeBatch(batch)
+			// TODO skip batch if error is not recoverable
+			// Nack batch?
+			return
+		}
+	}
+	err = w.Sink.Send(ctx, batch)
+	if err != nil {
+		metrics.LogsCollectorLogsDropped.WithLabelValues(w.SourceName, w.Sink.Name()).Add(float64(len(batch.Logs)))
+		disposeBatch(batch)
+		// TODO skip batch if error is not recoverable
+		// Nack batch?
+		return
+	}
+	metrics.LogsCollectorLogsSent.WithLabelValues(w.SourceName, w.Sink.Name()).Add(float64(len(batch.Logs)))
+	disposeBatch(batch)
+}
+
+func disposeBatch(batch *LogBatch) {
+	for _, log := range batch.Logs {
+		LogPool.Put(log)
+	}
+	LogBatchPool.Put(batch)
+}

--- a/collector/service.go
+++ b/collector/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/adx-mon/collector/logs"
 	"github.com/Azure/adx-mon/collector/logs/sinks"
 	"github.com/Azure/adx-mon/collector/logs/sources/tail"
+	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/Azure/adx-mon/collector/otlp"
 	"github.com/Azure/adx-mon/ingestor/cluster"
 	metricsHandler "github.com/Azure/adx-mon/ingestor/metrics"
@@ -276,9 +277,11 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 		if err := os.MkdirAll(cursorDirectory, 0755); err != nil {
 			return nil, fmt.Errorf("log-cursors mkdir: %w", err)
 		}
+		sink := sinks.NewStdoutSink()
 		source, err := tail.NewTailSource(tail.TailSourceConfig{
 			StaticTargets:   targets,
 			CursorDirectory: cursorDirectory,
+			WorkerCreator:   types.WorkerCreator(nil, sink),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create tail source: %w", err)
@@ -286,7 +289,7 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 
 		logsSvc := &logs.Service{
 			Source: source,
-			Sink:   sinks.NewStdoutSink(),
+			Sink:   sink,
 		}
 		svc.logsSvc = logsSvc
 	}


### PR DESCRIPTION
Each batcher has an independent worker that synchronously applies transforms and the send to the sink. This worker only consumes a new message when it has finished the prior one, ensuring we do not process messages out of order.