### PR TITLE
allow owners.txt and other hard coded ignores. 

### DIFF
--- a/alerter/rules/localStore.go
+++ b/alerter/rules/localStore.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	alertrulev1 "github.com/Azure/adx-mon/api/v1"
@@ -17,6 +18,9 @@ type fileStore struct {
 	rules []*Rule
 }
 
+// should we read this out of a .adxmonignore file?
+var ignores = []string{"owners.txt"}
+
 func FromPath(path, region string) (*fileStore, error) {
 	s := &fileStore{}
 	// walk files in directory
@@ -27,6 +31,10 @@ func FromPath(path, region string) (*fileStore, error) {
 		if info.IsDir() {
 			return nil
 		}
+		if slices.Contains(ignores, info.Name()) {
+			return nil
+		}
+
 		f, err := os.Open(path)
 		if err != nil {
 			return fmt.Errorf("failed to open file '%s': %w", path, err)

--- a/alerter/rules/localStore_test.go
+++ b/alerter/rules/localStore_test.go
@@ -104,6 +104,10 @@ func TestFromPath(t *testing.T) {
 	err = os.WriteFile(multiTestfile, []byte(multiRule), 0644)
 	require.NoError(t, err)
 
+	owners := filepath.Join(validFileDirectory, "owners.txt")
+	err = os.WriteFile(owners, []byte("eljefe"), 0644)
+	require.NoError(t, err)
+
 	invalidFileDirectory := t.TempDir()
 	invalidTestfile := filepath.Join(invalidFileDirectory, "invalid.yaml")
 	err = os.WriteFile(invalidTestfile, []byte(invalidRuleExample), 0644)


### PR DESCRIPTION
allow owners.txt and other hard coded ignores. Open to pulling from ingore file if desired or we leave it hardcoded. 