### PR TITLE
Samples stored in segments are additive in metadata

### DIFF
--- a/pkg/wal/iterator.go
+++ b/pkg/wal/iterator.go
@@ -97,7 +97,9 @@ func (b *segmentIterator) Next() (bool, error) {
 	}
 
 	if HasSampleMetadata(b.decodeBuf) {
-		b.sampleType, b.sampleCount = SampleMetadata(b.decodeBuf[3:8])
+		st, sc := SampleMetadata(b.decodeBuf[3:8])
+		b.sampleType = st
+		b.sampleCount += sc
 		b.value = b.decodeBuf[8:]
 	} else {
 		b.value = b.decodeBuf


### PR DESCRIPTION
If in a WAL we have 2 segments each containing 1 sample, the WAL has 2 samples, not 1. 