### PR TITLE
Add collector max connection limit option

### DIFF
--- a/cmd/collector/config.go
+++ b/cmd/collector/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	InsecureSkipVerify bool   `toml:"insecure-skip-verify" comment:"Skip TLS verification."`
 	ListenAddr         string `toml:"listen-addr" comment:"Address to listen on for endpoints."`
 
+	MaxConnections       int   `toml:"max-connections" comment:"Maximum number of connections to accept."`
 	MaxBatchSize         int   `toml:"max-batch-size" comment:"Maximum number of samples to send in a single batch."`
 	MaxSegmentAgeSeconds int   `toml:"max-segment-age-seconds" comment:"Max segment agent in seconds."`
 	MaxSegmentSize       int64 `toml:"max-segment-size" comment:"Maximum segment size in bytes."`

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -257,6 +257,7 @@ func realMain(ctx *cli.Context) error {
 		AddAttributes:      addAttributes,
 		LiftAttributes:     liftAttributes,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		MaxConnections:     cfg.MaxConnections,
 		MaxBatchSize:       cfg.MaxBatchSize,
 		MaxSegmentAge:      time.Duration(cfg.MaxSegmentAgeSeconds) * time.Second,
 		MaxSegmentSize:     cfg.MaxSegmentSize,

--- a/collector/service.go
+++ b/collector/service.go
@@ -105,6 +105,8 @@ type ServiceOpts struct {
 
 	// EnablePprof enables pprof endpoints.
 	EnablePprof bool
+
+	MaxConnections int
 }
 
 type MetricsHandlerOpts struct {
@@ -368,6 +370,7 @@ func (s *Service) Open(ctx context.Context) error {
 
 	s.http = http.NewServer(&http.ServerOpts{
 		ListenAddr: s.opts.ListenAddr,
+		MaxConns:   s.opts.MaxConnections,
 	})
 
 	if s.opts.EnablePprof {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -3,10 +3,12 @@ package http
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/net/netutil"
 )
 
 type HttpHandler struct {
@@ -15,7 +17,13 @@ type HttpHandler struct {
 }
 
 type ServerOpts struct {
+	// MaxConns is the maximum number of connections the server will accept.  This value is only respected if
+	// Listener is nil.
+	MaxConns   int
 	ListenAddr string
+
+	// Listener is the listener to use.  If nil, a new listener will be created.
+	Listener net.Listener
 }
 
 // HttpServer is a http server that is preconfigured with a prometheus metrics handler.  Additional handlers can be
@@ -25,6 +33,7 @@ type HttpServer struct {
 	opts *ServerOpts
 	srv  *http.Server
 
+	listener net.Listener
 	cancelFn context.CancelFunc
 }
 
@@ -39,10 +48,22 @@ func NewServer(opts *ServerOpts) *HttpServer {
 
 // Open starts the http server.
 func (s *HttpServer) Open(ctx context.Context) error {
+	s.listener = s.opts.Listener
+	if s.opts.Listener == nil {
+		var err error
+		s.listener, err = net.Listen("tcp", s.opts.ListenAddr)
+		if err != nil {
+			return err
+		}
+		if s.opts.MaxConns > 0 {
+			s.listener = netutil.LimitListener(s.listener, s.opts.MaxConns)
+		}
+	}
+
 	s.srv = &http.Server{Addr: s.opts.ListenAddr, Handler: s.mux}
 
 	go func() {
-		if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.srv.Serve(s.listener); err != nil && err != http.ErrServerClosed {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
This adds a max connections option to limit how many concurrent connectiosn will be accepted by the collector http endpoint.