### PR TITLE
Fix keeping multiple metrics

### DIFF
--- a/ingestor/transform/transformer.go
+++ b/ingestor/transform/transformer.go
@@ -174,17 +174,16 @@ func (f *RequestTransformer) TransformTimeSeries(v prompb.TimeSeries) prompb.Tim
 
 func (f *RequestTransformer) ShouldKeepTimeSeries(v prompb.TimeSeries) bool {
 	if len(f.KeepMetricsWithLabelValue) > 0 {
-		var matchCount int
 		for _, label := range v.Labels {
 			// Keep metrics that have a certain label
 			for lableRe, valueRe := range f.KeepMetricsWithLabelValue {
 				if lableRe.Match(label.Name) && valueRe.Match(label.Value) {
-					matchCount++
+					return true
 				}
 			}
 		}
 
-		return matchCount == len(f.KeepMetricsWithLabelValue)
+		return false
 	}
 
 	return !f.DefaultDropMetrics

--- a/ingestor/transform/transformer_test.go
+++ b/ingestor/transform/transformer_test.go
@@ -454,7 +454,7 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDropLabelValue(t
 				Labels: []prompb.Label{
 					{
 						Name:  []byte("__name__"),
-						Value: []byte("cpu"),
+						Value: []byte("mem"),
 					},
 					{
 						Name:  []byte("region"),
@@ -466,7 +466,7 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDropLabelValue(t
 				Labels: []prompb.Label{
 					{
 						Name:  []byte("__name__"),
-						Value: []byte("mem"),
+						Value: []byte("disk"),
 					},
 				},
 			},


### PR DESCRIPTION
The logic for determining if a metric was just wrong.  It worked if you had one regex, but not if there were many.