### PR TITLE
Fix dropping metrics after allow

### DIFF
--- a/ingestor/transform/transformer.go
+++ b/ingestor/transform/transformer.go
@@ -190,11 +190,9 @@ func (f *RequestTransformer) ShouldKeepTimeSeries(v prompb.TimeSeries) bool {
 }
 
 func (f *RequestTransformer) ShouldDropMetric(name []byte) bool {
-	if !f.DefaultDropMetrics {
-		for _, r := range f.DropMetrics {
-			if r.Match(name) {
-				return true
-			}
+	for _, r := range f.DropMetrics {
+		if r.Match(name) {
+			return true
 		}
 	}
 	return false

--- a/ingestor/transform/transformer_test.go
+++ b/ingestor/transform/transformer_test.go
@@ -334,8 +334,11 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetrics(t *testing.T) {
 func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDrop(t *testing.T) {
 	f := &transform.RequestTransformer{
 		DefaultDropMetrics: true,
-		KeepMetrics:        []*regexp.Regexp{regexp.MustCompile("cpu|mem")},
-		DropMetrics:        []*regexp.Regexp{regexp.MustCompile("cpu|mem")},
+		KeepMetrics: []*regexp.Regexp{
+			regexp.MustCompile("^cpu"),
+			regexp.MustCompile("^mem"),
+		},
+		DropMetrics: []*regexp.Regexp{regexp.MustCompile("^mem_load")},
 	}
 
 	req := prompb.WriteRequest{
@@ -361,6 +364,14 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDrop(t *testing.
 					{
 						Name:  []byte("__name__"),
 						Value: []byte("net"),
+					},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{
+						Name:  []byte("__name__"),
+						Value: []byte("mem_load"),
 					},
 				},
 			},
@@ -433,7 +444,7 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDropLabelValue(t
 			regexp.MustCompile("__name__"): regexp.MustCompile("cpu"),
 			regexp.MustCompile("region"):   regexp.MustCompile("eastus"),
 		},
-		DropMetrics: []*regexp.Regexp{regexp.MustCompile("cpu|mem")},
+		DropMetrics: []*regexp.Regexp{regexp.MustCompile("mem")},
 	}
 
 	req := prompb.WriteRequest{


### PR DESCRIPTION
The DefaultDropmetrics flag was short circuting dropping specific metrics after a group is allowed.

The use case is:
1) Default drop all metrics scraped
2) Allow all foo_* metrics through
3) Drop foo_bar metric because it's expensive and not needed.

The last part was not working because DefaultDrop was skipping the drop rules.