### PR TITLE
Fix batching with filtering metrics

### DIFF
--- a/collector/scraper_test.go
+++ b/collector/scraper_test.go
@@ -76,7 +76,8 @@ func TestScraper_sendBatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewScraper(tt.opts)
-			err := s.sendBatch(context.Background(), tt.writeRequest)
+			wr := s.flushBatchIfNecessary(context.Background(), tt.writeRequest)
+			err := s.sendBatch(context.Background(), wr)
 			require.NoError(t, err)
 			if tt.opts.RemoteClient.(*fakeClient).expectedSamples > 0 {
 				require.True(t, tt.opts.RemoteClient.(*fakeClient).called)


### PR DESCRIPTION
When default drop all and allow/drop rules are in place, the batches can be smaller than the mast batch size and we end up sending multiple smaller request to ingestor.  This fixes that case and fills up each batch to the max batch size as before resulting in few requests that are generally the same size.