### PR TITLE
Write an e2e test for sample metadata

### DIFF
--- a/collector/otlp/logs_transfer.go
+++ b/collector/otlp/logs_transfer.go
@@ -105,10 +105,10 @@ func (s *LogsService) Handler(w http.ResponseWriter, r *http.Request) {
 		grouped := otlp.Group(msg, s.staticAttributes, s.logger)
 		for _, group := range grouped {
 			err := func(g *otlp.Logs) error {
-				metrics.LogsProxyReceived.WithLabelValues(g.Database, g.Table).Add(float64(len(g.Logs)))
 				if err := s.store.WriteOTLPLogs(r.Context(), g.Database, g.Table, g); err != nil {
 					return fmt.Errorf("failed to write to store: %w", err)
 				}
+				metrics.LogsProxyReceived.WithLabelValues(g.Database, g.Table).Add(float64(len(g.Logs)))
 				return nil
 			}(group)
 


### PR DESCRIPTION
Introduce a testcase that exercises the code paths a log would take from receiving by the Collector, then written to disk, batched, replicated and sent to Ingestor, then written back to disk before being pulled into a multi-reader stopping just short of uploading to Kusto. The intent is to ensure sample metadata is correctly added and fully conveyed to the point of upload into Kusto.