### PR TITLE
Tail source handles partial lines

### DIFF
--- a/collector/logs/sources/tail/docker.go
+++ b/collector/logs/sources/tail/docker.go
@@ -2,10 +2,19 @@ package tail
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/pquerna/ffjson/ffjson"
+)
+
+var (
+	// At the end of the "log" field, this signifies that the log line is complete without further splits.
+	dockerCompleteLogSuffix = "\n"
+
+	// Length of the suffix
+	dockerCompleteLogSuffixLength = len(dockerCompleteLogSuffix)
 )
 
 // DockerLog is the format from docker json logs
@@ -15,11 +24,38 @@ type DockerLog struct {
 	Time   string `json:"time"`
 }
 
-func parseDockerLog(line string, log *types.Log) error {
+type DockerParser struct {
+	streamPartials map[string]string
+}
+
+func NewDockerParser() *DockerParser {
+	return &DockerParser{
+		streamPartials: make(map[string]string),
+	}
+}
+
+func (p *DockerParser) Parse(line string, log *types.Log) (isPartial bool, err error) {
 	parsed := DockerLog{}
-	err := ffjson.Unmarshal([]byte(line), &parsed)
+	err = ffjson.Unmarshal([]byte(line), &parsed)
 	if err != nil {
-		return fmt.Errorf("parseDockerLog: %w", err)
+		return false, fmt.Errorf("parseDockerLog: %w", err)
+	}
+
+	// Docker json logs are always terminated by a newline.
+	// If they are not, the log is a partial one within that given stream. Docker splits logs at 16k.
+	isPartial = !strings.HasSuffix(parsed.Log, dockerCompleteLogSuffix)
+	currentLogMsg := parsed.Log
+
+	previousLog, hasPreviousLog := p.streamPartials[parsed.Stream]
+	if hasPreviousLog { //combine
+		currentLogMsg = previousLog + currentLogMsg
+	}
+
+	if isPartial {
+		p.streamPartials[parsed.Stream] = currentLogMsg
+		return true, nil
+	} else if hasPreviousLog {
+		delete(p.streamPartials, parsed.Stream)
 	}
 
 	parsedTime, err := time.Parse(time.RFC3339Nano, parsed.Time)
@@ -28,8 +64,9 @@ func parseDockerLog(line string, log *types.Log) error {
 	}
 	log.Timestamp = uint64(parsedTime.UnixNano())
 	log.ObservedTimestamp = uint64(time.Now().UnixNano())
-	log.Body[types.BodyKeyMessage] = parsed.Log
 	log.Body["stream"] = parsed.Stream
+	// Strip trailing newline
+	log.Body[types.BodyKeyMessage] = currentLogMsg[:len(currentLogMsg)-dockerCompleteLogSuffixLength]
 
-	return nil
+	return false, nil
 }

--- a/collector/logs/sources/tail/docker_test.go
+++ b/collector/logs/sources/tail/docker_test.go
@@ -1,0 +1,84 @@
+package tail
+
+import (
+	"testing"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerParse(t *testing.T) {
+	t.Run("Single full log", func(t *testing.T) {
+		parser := NewDockerParser()
+		log := types.NewLog()
+		isPartial, err := parser.Parse(`{"log":"log1\n","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.False(t, isPartial)
+		require.Equal(t, uint64(1625097600000000000), log.Timestamp)
+		require.Equal(t, "stdout", log.Body["stream"])
+		require.Equal(t, "log1", log.Body[types.BodyKeyMessage])
+	})
+
+	t.Run("Invalid formatted log", func(t *testing.T) {
+		parser := NewDockerParser()
+		log := types.NewLog()
+		_, err := parser.Parse(`{"log":"log1\n","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z`, log)
+		require.Error(t, err)
+	})
+
+	t.Run("Single partial log", func(t *testing.T) {
+		parser := NewDockerParser()
+		log := types.NewLog()
+		// No newline at the end of the "log" field
+		isPartial, err := parser.Parse(`{"log":"log1","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.True(t, isPartial)
+	})
+
+	t.Run("Partials combined", func(t *testing.T) {
+		parser := NewDockerParser()
+		log := types.NewLog()
+		isPartial, err := parser.Parse(`{"log":"log1 ","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.True(t, isPartial)
+
+		isPartial, err = parser.Parse(`{"log":"log2 ","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.True(t, isPartial)
+
+		isPartial, err = parser.Parse(`{"log":"log3\n","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.False(t, isPartial)
+		require.Equal(t, uint64(1625097600000000000), log.Timestamp)
+		require.Equal(t, "stdout", log.Body["stream"])
+		require.Equal(t, "log1 log2 log3", log.Body[types.BodyKeyMessage])
+	})
+
+	t.Run("Partials combined per stream", func(t *testing.T) {
+		parser := NewDockerParser()
+		log := types.NewLog()
+		isPartial, err := parser.Parse(`{"log":"stdoutlog1 ","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.True(t, isPartial)
+
+		isPartial, err = parser.Parse(`{"log":"stderrlog1 ","stream":"stderr","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.True(t, isPartial)
+
+		log = types.NewLog()
+		isPartial, err = parser.Parse(`{"log":"stdoutlog2\n","stream":"stdout","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.False(t, isPartial)
+		require.Equal(t, uint64(1625097600000000000), log.Timestamp)
+		require.Equal(t, "stdout", log.Body["stream"])
+		require.Equal(t, "stdoutlog1 stdoutlog2", log.Body[types.BodyKeyMessage])
+
+		log = types.NewLog()
+		isPartial, err = parser.Parse(`{"log":"stderrlog2\n","stream":"stderr","time":"2021-07-01T00:00:00.000000000Z"}`, log)
+		require.NoError(t, err)
+		require.False(t, isPartial)
+		require.Equal(t, uint64(1625097600000000000), log.Timestamp)
+		require.Equal(t, "stderr", log.Body["stream"])
+		require.Equal(t, "stderrlog1 stderrlog2", log.Body[types.BodyKeyMessage])
+	})
+}


### PR DESCRIPTION
Log sources like the docker-json format splits lines over 16k by omitting a "\n" character at the end of the log field. These splits are done on a per-stream basis and a split is marked as "finished" when a log is consumed where the log field is terminated with "\n".