### PR TITLE
Add transform configuration for tail

### DIFF
--- a/cmd/collector/config_test.go
+++ b/cmd/collector/config_test.go
@@ -729,6 +729,54 @@ func TestConfig_Validate_TailLog(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Success_valid_transform",
+			config: &TailLog{
+				StaticTailTarget: []*TailTarget{
+					{
+						FilePath: "/path",
+						Database: "db",
+						Table:    "table",
+					},
+				},
+				Transforms: []*TailTransform{
+					{
+						Name: "plugin",
+						Config: map[string]interface{}{
+							"GoPath":     "path",
+							"ImportName": "import",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Failure_invalid_transform",
+			config: &TailLog{
+				StaticTailTarget: []*TailTarget{
+					{
+						FilePath: "/path",
+						Database: "db",
+						Table:    "table",
+					},
+				},
+				Transforms: []*TailTransform{
+					{
+						Name: "plugin",
+						Config: map[string]interface{}{
+							"GoPath":     "path",
+							"ImportName": "import",
+						},
+					},
+					{
+						Name:   "shootlasers",
+						Config: map[string]interface{}{},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/collector/logs/transforms/plugin/yaegi.go
+++ b/collector/logs/transforms/plugin/yaegi.go
@@ -37,6 +37,25 @@ import (
                                             └── logs.go
 */
 
+func FromConfigMap(config map[string]interface{}) (types.Transformer, error) {
+	goPath, ok := config["GoPath"].(string)
+	if !ok {
+		return nil, fmt.Errorf("GoPath is required")
+	}
+
+	importName, ok := config["ImportName"].(string)
+	if !ok {
+		return nil, fmt.Errorf("ImportName is required")
+	}
+
+	transformConfig := TransformConfig{
+		GoPath:     goPath,
+		ImportName: importName,
+	}
+
+	return NewTransform(transformConfig)
+}
+
 type TransformConfig struct {
 	// Path on disk that contains the plugin.
 	// This expects a directory with a src directory at the base.

--- a/collector/logs/transforms/transform.go
+++ b/collector/logs/transforms/transform.go
@@ -1,0 +1,32 @@
+package transforms
+
+import (
+	"fmt"
+
+	"github.com/Azure/adx-mon/collector/logs/transforms/plugin"
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+type TransformCreator func(config map[string]any) (types.Transformer, error)
+
+const (
+	TransformTypePlugin = "plugin"
+)
+
+var transformCreators = map[string]TransformCreator{
+	TransformTypePlugin: plugin.FromConfigMap,
+}
+
+func IsValidTransformType(transformType string) bool {
+	_, ok := transformCreators[transformType]
+	return ok
+}
+
+func NewTransform(transformType string, config map[string]any) (types.Transformer, error) {
+	creator, ok := transformCreators[transformType]
+	if !ok {
+		return nil, fmt.Errorf("unknown transform type: %s", transformType)
+	}
+
+	return creator(config)
+}

--- a/collector/logs/transforms/transform_test.go
+++ b/collector/logs/transforms/transform_test.go
@@ -1,0 +1,54 @@
+package transforms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTransform(t *testing.T) {
+	type testcase struct {
+		name          string
+		transformType string
+		config        map[string]interface{}
+		expectErr     bool
+	}
+
+	testcases := []testcase{
+		{
+			name:          "plugin_valid_config",
+			transformType: "plugin",
+			config: map[string]interface{}{
+				"GoPath":     "plugin/test-plugin",
+				"ImportName": "github.com/Azure/testplugin/pkg/transforms",
+			},
+			expectErr: false,
+		},
+		{
+			name:          "plugin_bad_config",
+			transformType: "plugin",
+			config: map[string]interface{}{
+				"GoPath":     "plugin/foo/bar",
+				"ImportName": "github.com/Azure/testplugin/pkg/transforms",
+			},
+			expectErr: true,
+		},
+		{
+			name:          "unknown plugin",
+			transformType: "fakeplugin",
+			config:        map[string]interface{}{},
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewTransform(tc.transformType, tc.config)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add configuration for specifying a list of transforms. The current supported transform is "plugin", which accepts configuration for a yaegi-based plugin.