### PR TITLE
Serialize OTLP LogRecord to CSV by handling nested value types

### DIFF
--- a/ingestor/transform/csv_test.go
+++ b/ingestor/transform/csv_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
@@ -188,196 +189,211 @@ func TestMarshalCSV_OTLPLog(t *testing.T) {
 		{
 			Name: "unstructured",
 			Log: []byte(`{
-				"resourceLogs": [
-					{
-						"resource": {
-							"attributes": [
-								{
-									"key": "source",
-									"value": {
-										"stringValue": "hostname"
-									}
-								}
-							],
-							"droppedAttributesCount": 1
-						},
-						"scopeLogs": [
-							{
-								"scope": {
-									"name": "name",
-									"version": "version",
-									"droppedAttributesCount": 1
-								},
-								"logRecords": [
+								"resourceLogs": [
 									{
-										"timeUnixNano": "1669112524001",
-										"observedTimeUnixNano": "1669112524001",
-										"severityNumber": 17,
-										"severityText": "Error",
-										"body": {
-											"stringValue": "{\"msg\":\"something happened\"}"
+										"resource": {
+											"attributes": [
+												{
+													"key": "source",
+													"value": {
+														"stringValue": "hostname"
+													}
+												}
+											],
+											"droppedAttributesCount": 1
 										},
-										"attributes": [
+										"scopeLogs": [
 											{
-												"key": "kusto.table",
-												"value": {
-													"stringValue": "ATable"
-												}
-											},
-											{
-												"key": "kusto.database",
-												"value": {
-													"stringValue": "ADatabase"
-												}
+												"scope": {
+													"name": "name",
+													"version": "version",
+													"droppedAttributesCount": 1
+												},
+												"logRecords": [
+													{
+														"timeUnixNano": "1669112524001",
+														"observedTimeUnixNano": "1669112524001",
+														"severityNumber": 17,
+														"severityText": "Error",
+														"body": {
+															"stringValue": "something happened"
+														},
+														"attributes": [
+															{
+																"key": "kusto.table",
+																"value": {
+																	"stringValue": "ATable"
+																}
+															},
+															{
+																"key": "kusto.database",
+																"value": {
+																	"stringValue": "ADatabase"
+																}
+															}
+														],
+														"droppedAttributesCount": 1,
+														"flags": 1,
+														"traceId": "",
+														"spanId": ""
+													}
+												],
+												"schemaUrl": "scope_schema"
 											}
 										],
-										"droppedAttributesCount": 1,
-										"flags": 1,
-										"traceId": "",
-										"spanId": ""
+										"schemaUrl": "resource_schema"
 									}
-								],
-								"schemaUrl": "scope_schema"
-							}
-						],
-						"schemaUrl": "resource_schema"
-					}
-				]
-			}`),
-			Expect: `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,"{""msg"":""something happened""}","{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
+								]
+							}`),
+			Expect: `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,something happened,"{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
 `,
 		},
 		{
 			Name: "structured",
 			Log: []byte(`{
-				"resourceLogs": [
-					{
-						"resource": {
-							"attributes": [
-								{
-									"key": "source",
-									"value": {
-										"stringValue": "hostname"
-									}
-								}
-							],
-							"droppedAttributesCount": 1
-						},
-						"scopeLogs": [
-							{
-								"scope": {
-									"name": "name",
-									"version": "version",
-									"droppedAttributesCount": 1
-								},
-								"logRecords": [
-									{
-										"timeUnixNano": "1694564005797489936",
-										"observedTimeUnixNano": "1694564005797489936",
-										"severityNumber": 17,
-										"severityText": "Error",
-										"body": {
-											"kvlistValue": {
-												"values":[
-													{
-														"key":"namespace",
-														"value": {
-															"stringValue": "default"
+										"resourceLogs": [
+											{
+												"resource": {
+													"attributes": [
+														{
+															"key": "source",
+															"value": {
+																"stringValue": "hostname"
+															}
 														}
+													],
+													"droppedAttributesCount": 1
+												},
+												"scopeLogs": [
+													{
+														"scope": {
+															"name": "name",
+															"version": "version",
+															"droppedAttributesCount": 1
+														},
+														"logRecords": [
+															{
+																"timeUnixNano": "1694564005797489936",
+																"observedTimeUnixNano": "1694564005797489936",
+																"severityNumber": 17,
+																"severityText": "Error",
+																"body": {
+																	"kvlistValue": {
+																		"values":[
+																			{
+																				"key":"namespace",
+																				"value": {
+																					"stringValue": "default"
+																				}
+																			}
+																		]
+																	}
+																},
+																"attributes": [
+																	{
+																		"key": "kusto.table",
+																		"value": {
+																			"stringValue": "ATable"
+																		}
+																	},
+																	{
+																		"key": "kusto.database",
+																		"value": {
+																			"stringValue": "ADatabase"
+																		}
+																	}
+																],
+																"droppedAttributesCount": 1,
+																"flags": 1,
+																"traceId": "",
+																"spanId": ""
+															}
+														],
+														"schemaUrl": "scope_schema"
 													}
-												]
+												],
+												"schemaUrl": "resource_schema"
 											}
-										},
-										"attributes": [
-											{
-												"key": "kusto.table",
-												"value": {
-													"stringValue": "ATable"
-												}
-											},
-											{
-												"key": "kusto.database",
-												"value": {
-													"stringValue": "ADatabase"
-												}
-											}
-										],
-										"droppedAttributesCount": 1,
-										"flags": 1,
-										"traceId": "",
-										"spanId": ""
-									}
-								],
-								"schemaUrl": "scope_schema"
-							}
-						],
-						"schemaUrl": "resource_schema"
-					}
-				]
-			}`),
+										]
+									}`),
 			Expect: `2023-09-13T00:13:25.797489936Z,2023-09-13T00:13:25.797489936Z,,,Error,SEVERITY_NUMBER_ERROR,"{""namespace"":""default""}","{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
 `,
 		},
 		{
 			Name: "unescaped newline",
 			Log: []byte(`{
-				"resourceLogs": [
-					{
-						"resource": {
-							"attributes": [
-								{
-									"key": "source",
-									"value": {
-										"stringValue": "hostname"
-									}
-								}
-							],
-							"droppedAttributesCount": 1
-						},
-						"scopeLogs": [
-							{
-								"scope": {
-									"name": "name",
-									"version": "version",
-									"droppedAttributesCount": 1
-								},
-								"logRecords": [
-									{
-										"timeUnixNano": "1669112524001",
-										"observedTimeUnixNano": "1669112524001",
-										"severityNumber": 17,
-										"severityText": "Error",
-										"body": {
-											"stringValue": "{\"msg\":\"something happened\n\"}"
-										},
-										"attributes": [
+										"resourceLogs": [
 											{
-												"key": "kusto.table",
-												"value": {
-													"stringValue": "ATable"
-												}
-											},
-											{
-												"key": "kusto.database",
-												"value": {
-													"stringValue": "ADatabase"
-												}
+												"resource": {
+													"attributes": [
+														{
+															"key": "source",
+															"value": {
+																"stringValue": "hostname"
+															}
+														}
+													],
+													"droppedAttributesCount": 1
+												},
+												"scopeLogs": [
+													{
+														"scope": {
+															"name": "name",
+															"version": "version",
+															"droppedAttributesCount": 1
+														},
+														"logRecords": [
+															{
+																"timeUnixNano": "1669112524001",
+																"observedTimeUnixNano": "1669112524001",
+																"severityNumber": 17,
+																"severityText": "Error",
+																"body": {
+																	"kvlistValue": {
+																		"values":[
+																			{
+																				"key":"msg",
+																				"value": {
+																					"stringValue": "something happened\n"
+																				}
+																			}
+																		]
+																	}
+																},
+																"attributes": [
+																	{
+																		"key": "kusto.table",
+																		"value": {
+																			"stringValue": "ATable"
+																		}
+																	},
+																	{
+																		"key": "kusto.database",
+																		"value": {
+																			"stringValue": "ADatabase"
+																		}
+																	}
+																],
+																"droppedAttributesCount": 1,
+																"flags": 1,
+																"traceId": "",
+																"spanId": ""
+															}
+														],
+														"schemaUrl": "scope_schema"
+													}
+												],
+												"schemaUrl": "resource_schema"
 											}
-										],
-										"droppedAttributesCount": 1,
-										"flags": 1,
-										"traceId": "",
-										"spanId": ""
-									}
-								],
-								"schemaUrl": "scope_schema"
-							}
-						],
-						"schemaUrl": "resource_schema"
-					}
-				]
-			}`),
-			Expect: `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,"{""msg"":""something happened%0A""}","{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
+										]
+									}`),
+			Expect: `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,"{""msg"":""something happened\n""}","{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
+`,
+		},
+		{
+			Name: "nested",
+			Log:  nestedRawLog,
+			Expect: `2022-11-22T10:22:04.001Z,2022-11-22T10:22:04.001Z,,,Error,SEVERITY_NUMBER_ERROR,"{""kusto.database"":""FakeDatabase"",""kusto.table"":""FakeTable"",""date"":""1715247667.480479"",""output"":""09:41:07.480478650: Notice Known system binary sent/received network traffic (user=root user_loginuid=-1 connection=REDACTED container_id=host image=\u003cNA\u003e, proc=bash)"",""priority"":""Notice"",""rule"":""System procs network activity"",""source"":""syscall"",""tags"":[""mitre_exfiltration"",""network""],""output_fields"":{""container.id"":""host"",""container.image.repository"":"""",""evt.time"":""1715247667480478650"",""fd.name"":""REDACTED"",""proc.name"":""bash"",""user.loginuid"":""-1"",""user.name"":""root""}}","{""source"":""hostname""}","{""kusto.table"":""ATable"",""kusto.database"":""ADatabase""}"
 `,
 		},
 	}
@@ -397,77 +413,15 @@ func TestMarshalCSV_OTLPLog(t *testing.T) {
 
 			err := w.MarshalLog(logs)
 			require.NoError(t, err)
+			t.Log(prettyPrintOTLPCSV(b.String()))
 			require.Equal(t, tt.Expect, b.String())
 		})
 	}
 }
 
 func BenchmarkMarshalCSV_OTLPLog(b *testing.B) {
-	rawlog := []byte(`{
-    "resourceLogs": [
-        {
-            "resource": {
-                "attributes": [
-                    {
-                        "key": "RPTenant",
-                        "value": {
-                            "stringValue": "eastus"
-                        }
-                    },
-					{
-                        "key": "UnderlayName",
-                        "value": {
-                            "stringValue": "hcp-underlay-eastus-cx-test"
-                        }
-                    }
-                ],
-                "droppedAttributesCount": 1
-            },
-            "scopeLogs": [
-                {
-                    "scope": {
-                        "name": "name",
-                        "version": "version",
-                        "droppedAttributesCount": 1
-                    },
-                    "logRecords": [
-                        {
-                            "timeUnixNano": "1669112524001",
-                            "observedTimeUnixNano": "1669112524001",
-                            "severityNumber": 17,
-                            "severityText": "Error",
-                            "body": {
-                                "stringValue": "{\"msg\":\"something happened\"}"
-                            },
-                            "attributes": [
-                                {
-                                    "key": "kusto.table",
-                                    "value": {
-                                        "stringValue": "ATable"
-                                    }
-                                },
-								{
-                                    "key": "kusto.database",
-                                    "value": {
-                                        "stringValue": "ADatabase"
-                                    }
-                                }
-                            ],
-                            "droppedAttributesCount": 1,
-                            "flags": 1,
-                            "traceId": "",
-                            "spanId": ""
-                        }
-                    ],
-                    "schemaUrl": "scope_schema"
-                }
-            ],
-            "schemaUrl": "resource_schema"
-        }
-    ]
-}`)
 	var log v1.ExportLogsServiceRequest
-	protojson.Unmarshal(rawlog, &log)
+	protojson.Unmarshal(nestedRawLog, &log)
 	var buf bytes.Buffer
 	w := NewCSVWriter(&buf, nil)
 	logs := &otlp.Logs{
@@ -479,6 +433,22 @@ func BenchmarkMarshalCSV_OTLPLog(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		w.MarshalLog(logs)
 	}
+}
+
+func TestSerializeAnyValue(t *testing.T) {
+	var log v1.ExportLogsServiceRequest
+	require.NoError(t, protojson.Unmarshal(nestedRawLog, &log))
+
+	var (
+		buf       strings.Builder
+		logRecord = log.ResourceLogs[0].ScopeLogs[0].LogRecords[0]
+		body      = logRecord.GetBody()
+	)
+
+	serializeAnyValue(&buf, body, 0)
+	got := buf.String()
+	want := `{"kusto.database":"FakeDatabase","kusto.table":"FakeTable","date":"1715247667.480479","output":"09:41:07.480478650: Notice Known system binary sent/received network traffic (user=root user_loginuid=-1 connection=REDACTED container_id=host image=\u003cNA\u003e, proc=bash)","priority":"Notice","rule":"System procs network activity","source":"syscall","tags":["mitre_exfiltration","network"],"output_fields":{"container.id":"host","container.image.repository":"","evt.time":"1715247667480478650","fd.name":"REDACTED","proc.name":"bash","user.loginuid":"-1","user.name":"root"}}`
+	require.Equal(t, want, got, "Want=%s, Got=%s", prettyPrintOTLPCSV(want), prettyPrintOTLPCSV(got))
 }
 
 func TestMarshalCSV_NativeLog(t *testing.T) {
@@ -759,3 +729,271 @@ func getLogRecord(fields []string) (*logrecord, error) {
 		Attributes:        attributes,
 	}, nil
 }
+
+func BenchmarkProtojson(b *testing.B) {
+	var log v1.ExportLogsServiceRequest
+	protojson.Unmarshal(nestedRawLog, &log)
+
+	// We're setting up a buffer because serializeKvList uses a bytes.Buffer for writing
+	// the serialized format, so we want to make sure we're benchmarking apples to apples.
+	var buf bytes.Buffer
+	logRecord := log.ResourceLogs[0].ScopeLogs[0].LogRecords[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		body := logRecord.GetBody().GetKvlistValue()
+		serialized, _ := protojson.Marshal(body)
+		buf.Write(serialized)
+	}
+}
+
+// Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkProtojson$ github.com/Azure/adx-mon/ingestor/transform
+
+// goos: linux
+// goarch: amd64
+// pkg: github.com/Azure/adx-mon/ingestor/transform
+// cpu: AMD EPYC 7763 64-Core Processor
+// BenchmarkProtojson-16    	   40689	     29458 ns/op	   11512 B/op	     262 allocs/op
+// PASS
+// ok  	github.com/Azure/adx-mon/ingestor/transform	1.514s
+
+func BenchmarkSerializeKvList(b *testing.B) {
+	var log v1.ExportLogsServiceRequest
+	protojson.Unmarshal(nestedRawLog, &log)
+
+	var buf strings.Builder
+	logRecord := log.ResourceLogs[0].ScopeLogs[0].LogRecords[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		body := logRecord.GetBody()
+		serializeAnyValue(&buf, body, 0)
+	}
+}
+
+// Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkSerializeKvList$ github.com/Azure/adx-mon/ingestor/transform
+
+// goos: linux
+// goarch: amd64
+// pkg: github.com/Azure/adx-mon/ingestor/transform
+// cpu: AMD EPYC 7763 64-Core Processor
+// BenchmarkSerializeKvList-16    	  386356	      2707 ns/op	    2576 B/op	      43 allocs/op
+// PASS
+// ok  	github.com/Azure/adx-mon/ingestor/transform	1.092s
+
+func prettyPrintOTLPCSV(s string) string {
+	var sb strings.Builder
+	r := csv.NewReader(strings.NewReader(s))
+	records, _ := r.ReadAll()
+
+	if len(records) != 1 {
+		return "malformed record"
+	}
+	fields := records[0]
+	if len(fields) != 9 {
+		return "malformed fields"
+	}
+
+	sb.WriteString(fmt.Sprintf("CSV: %s\n", s))
+	sb.WriteString(fmt.Sprintf("Timestamp: %s\n", fields[0]))
+	sb.WriteString(fmt.Sprintf("ObservedTimestamp: %s\n", fields[1]))
+	sb.WriteString(fmt.Sprintf("TraceId: %s\n", fields[2]))
+	sb.WriteString(fmt.Sprintf("SpanId: %s\n", fields[3]))
+	sb.WriteString(fmt.Sprintf("SeverityText: %s\n", fields[4]))
+	sb.WriteString(fmt.Sprintf("SeverityNumber: %s\n", fields[5]))
+
+	body := prettyPrintJSON(fields[6])
+	if body == "" {
+		body = fields[6]
+	}
+	sb.WriteString(fmt.Sprintf("Body: %s\n", body))
+
+	resource := prettyPrintJSON(fields[7])
+	sb.WriteString(fmt.Sprintf("Resource: %s\n", resource))
+
+	attributes := prettyPrintJSON(fields[8])
+	sb.WriteString(fmt.Sprintf("Attributes: %s\n", attributes))
+
+	return sb.String()
+}
+
+func prettyPrintJSON(input string) string {
+	var objmap map[string]*json.RawMessage
+	err := json.Unmarshal([]byte(input), &objmap)
+	if err != nil {
+		return ""
+	}
+
+	pretty, err := json.MarshalIndent(objmap, "", "  ")
+	if err != nil {
+		return ""
+	}
+
+	return string(pretty)
+}
+
+var nestedRawLog = []byte(`{
+	"resourceLogs": [
+		{
+			"resource": {
+				"attributes": [
+					{
+						"key": "source",
+						"value": {
+							"stringValue": "hostname"
+						}
+					}
+				],
+				"droppedAttributesCount": 1
+			},
+			"scopeLogs": [
+				{
+					"scope": {
+						"name": "name",
+						"version": "version",
+						"droppedAttributesCount": 1
+					},
+					"logRecords": [
+						{
+							"timeUnixNano": "1669112524001",
+							"observedTimeUnixNano": "1669112524001",
+							"severityNumber": 17,
+							"severityText": "Error",
+							"body": {
+								"kvlistValue": {
+									"values": [
+										{
+											"key": "kusto.database",
+											"value": {
+												"stringValue": "FakeDatabase"
+											}
+										},
+										{
+											"key": "kusto.table",
+											"value": {
+												"stringValue": "FakeTable"
+											}
+										},
+										{
+											"key": "date",
+											"value": {
+												"doubleValue": 1715247667.480479
+											}
+										},
+										{
+											"key": "output",
+											"value": {
+												"stringValue": "09:41:07.480478650: Notice Known system binary sent/received network traffic (user=root user_loginuid=-1 connection=REDACTED container_id=host image=<NA>, proc=bash)"
+											}
+										},
+										{
+											"key": "priority",
+											"value": {
+												"stringValue": "Notice"
+											}
+										},
+										{
+											"key": "rule",
+											"value": {
+												"stringValue": "System procs network activity"
+											}
+										},
+										{
+											"key": "source",
+											"value": {
+												"stringValue": "syscall"
+											}
+										},
+										{
+											"key": "tags",
+											"value": {
+												"arrayValue": {
+													"values": [
+														{
+															"stringValue": "mitre_exfiltration"
+														},
+														{
+															"stringValue": "network"
+														}
+													]
+												}
+											}
+										},
+										{
+											"key": "output_fields",
+											"value": {
+												"kvlistValue": {
+													"values": [
+														{
+															"key": "container.id",
+															"value": {
+																"stringValue": "host"
+															}
+														},
+														{
+															"key": "container.image.repository",
+															"value": {}
+														},
+														{
+															"key": "evt.time",
+															"value": {
+																"intValue": "1715247667480478650"
+															}
+														},
+														{
+															"key": "fd.name",
+															"value": {
+																"stringValue": "REDACTED"
+															}
+														},
+														{
+															"key": "proc.name",
+															"value": {
+																"stringValue": "bash"
+															}
+														},
+														{
+															"key": "user.loginuid",
+															"value": {
+																"intValue": "-1"
+															}
+														},
+														{
+															"key": "user.name",
+															"value": {
+																"stringValue": "root"
+															}
+														}
+													]
+												}
+											}
+										}
+									]
+								}
+							},
+							"attributes": [
+								{
+									"key": "kusto.table",
+									"value": {
+										"stringValue": "ATable"
+									}
+								},
+								{
+									"key": "kusto.database",
+									"value": {
+										"stringValue": "ADatabase"
+									}
+								}
+							],
+							"droppedAttributesCount": 1,
+							"flags": 1,
+							"traceId": "",
+							"spanId": ""
+						}
+					],
+					"schemaUrl": "scope_schema"
+				}
+			],
+			"schemaUrl": "resource_schema"
+		}
+	]
+}`)

--- a/tools/otlp/logs/collector.toml
+++ b/tools/otlp/logs/collector.toml
@@ -1,0 +1,71 @@
+# Ingestor URL to send collected telemetry.
+endpoint = 'https://ingestor:9090'
+# Skip TLS verification.
+insecure-skip-verify = true
+# Address to listen on for endpoints.
+listen-addr = ':8080'
+# Maximum number of samples to send in a single batch.
+max-batch-size = 5000
+# Max segment agent in seconds.
+max-segment-age-seconds = 1
+# Maximum segment size in bytes.
+max-segment-size = 0
+# Maximum allowed size in bytes of all segments on disk.
+max-disk-usage = 0
+# Storage directory for the WAL and log cursors.
+storage-dir = '/tmp'
+# Enable pprof endpoints.
+enable-pprof = false
+# Global Regexes of metrics to drop.
+drop-metrics = []
+# Global Regexes of metrics to keep.
+keep-metrics = []
+# Global Regexes of metrics to keep if they have the given label and value in the format <metrics regex>=<label name>=<label value>.  These are kept from all metrics collected by this agent
+keep-metrics-with-label-value = []
+# Disable metrics forwarding to endpoints.
+disable-metrics-forwarding = true
+# Attributes lifted from the Body and added to Attributes.
+lift-attributes = ['kusto.database', 'kusto.table']
+
+# Defines a prometheus scrape endpoint.
+[prometheus-scrape]
+  # Path to kubernetes client config
+  kube-config = '/root/.kube/config'
+  # Database to store metrics in.
+  database = 'TestMetrics'
+  # Defines a static scrape target.
+  static-scrape-target = []
+  # Scrape interval in seconds.
+  scrape-interval = 30
+  # Disable metrics forwarding to endpoints.
+  disable-metrics-forwarding = true
+  # Regexes of metrics to drop.
+  drop-metrics = []
+  # Global Regexes of metrics to keep.
+  keep-metrics = []
+  # Global Regexes of metrics to keep if they have the given label and value in the format <metrics regex>=<label name>=<label value>.  These are kept from all metrics collected by this agent
+  keep-metrics-with-label-value = []
+
+# Defines a prometheus remote write endpoint.
+[[prometheus-remote-write]]
+  # Database to store metrics in.
+  database = 'TestMetrics'
+  # The path to listen on for prometheus remote write requests.  Defaults to /receive.
+  path = '/remote_write'
+  # Regexes of metrics to drop.
+  drop-metrics = []
+  # Global Regexes of metrics to keep.
+  keep-metrics = []
+  # Global Regexes of metrics to keep if they have the given label and value in the format <metrics regex>=<label name>=<label value>.  These are kept from all metrics collected by this agent
+  keep-metrics-with-label-value = []
+
+  # Key/value pairs of labels to add to all metrics.
+  [prometheus-remote-write.add-labels]
+
+# Defines an OpenTelemetry log endpoint.
+[otel-log]
+  # Attributes lifted from the Body and added to Attributes.
+  lift-attributes = ['kusto.database', 'kusto.table']
+
+  # Key/value pairs of attributes to add to all logs.
+  [otel-log.add-attributes]

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -26,12 +26,10 @@ services:
       context: ../../..
     volumes:
       - ~/.kube/config:/root/.kube/config
+      - ./collector.toml:/var/lib/adx-mon/collector.toml
     ports:
       - 8080:8080
-    # While the _endpoints_ URI doesn't match the expected OTLP syntax, keep in
-    # mind that _Collector_ is currently configured to connect to _Ingestor_, so we
-    # just modify the _endpoints_ in pkg/otlp/proxy to be OTLP compliant.
-    command: --kubeconfig /root/.kube/config --endpoints https://ingestor:9090 --insecure-skip-verify --target=.*=http://localhost:8080/metrics:adx-mon/collector/collector --add-attributes Environment=dev --lift-attributes kusto.database --lift-attributes kusto.table --storage-dir /tmp
+    command: --config /var/lib/adx-mon/collector.toml
     depends_on:
       - ingestor
     environment:


### PR DESCRIPTION
When we serialize an OTLP/log into CSV for transfer to Kusto, we weren't handling recursive nested json and array types. This PR updates our integration test harness so we can show how a log of this type flows through our components and also updates the CSV serializer to recursively handle nested types.