### PR TITLE
Fix flaky test with Go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Build
       run: go build -mod=vendor -v ./...


### PR DESCRIPTION
Changes to the slices.Delete method in 1.22 exposed some issues in how we were removing elements from slices inline. We were looping through all of the indices of a slice, even if we were deleting elements inline which didn't behave well with the zeroing behavior that was added in 1.22. Instead, use the slices.DeleteFunc() method to delete elements if needed and to add to the attributes if the label is lifted.