### PR TITLE
Re-generate logs-types for new additions

### DIFF
--- a/collector/logs/transforms/plugin/github_com-Azure-adx-mon-collector-logs-types.go
+++ b/collector/logs/transforms/plugin/github_com-Azure-adx-mon-collector-logs-types.go
@@ -5,15 +5,20 @@ package plugin
 import (
 	"context"
 	"github.com/Azure/adx-mon/collector/logs/types"
+	"go/constant"
+	"go/token"
 	"reflect"
 )
 
 func init() {
 	Symbols["github.com/Azure/adx-mon/collector/logs/types/types"] = map[string]reflect.Value{
 		// function, constant and variable definitions
-		"LogBatchPool": reflect.ValueOf(&types.LogBatchPool).Elem(),
-		"LogPool":      reflect.ValueOf(&types.LogPool).Elem(),
-		"NewLog":       reflect.ValueOf(types.NewLog),
+		"AttributeDatabaseName": reflect.ValueOf(constant.MakeFromLiteral("\"adxmon_destination_database\"", token.STRING, 0)),
+		"AttributeTableName":    reflect.ValueOf(constant.MakeFromLiteral("\"adxmon_destination_table\"", token.STRING, 0)),
+		"BodyKeyMessage":        reflect.ValueOf(constant.MakeFromLiteral("\"message\"", token.STRING, 0)),
+		"LogBatchPool":          reflect.ValueOf(&types.LogBatchPool).Elem(),
+		"LogPool":               reflect.ValueOf(&types.LogPool).Elem(),
+		"NewLog":                reflect.ValueOf(types.NewLog),
 
 		// type definitions
 		"Log":         reflect.ValueOf((*types.Log)(nil)),

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/go.mod
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/go.mod
@@ -1,7 +1,9 @@
 module github.com/Azure/testplugin
 
-go 1.21.0
+go 1.22.0
 
-require github.com/Azure/adx-mon v0.0.0-20231221224656-32bfbeeec10e
+toolchain go1.22.3
+
+require github.com/Azure/adx-mon v0.0.0-20240522171325-300776b36aa1
 
 require github.com/libp2p/go-buffer-pool v0.1.0 // indirect

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/go.sum
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/go.sum
@@ -1,12 +1,12 @@
-github.com/Azure/adx-mon v0.0.0-20231221224656-32bfbeeec10e h1:Po9gCKvXQbrSWrjSnMKEM1yOiBWZINFddHIVhLBRcdU=
-github.com/Azure/adx-mon v0.0.0-20231221224656-32bfbeeec10e/go.mod h1:lZJoa1lgAcsc+dnvKmnXb++pXDvuYEUSP+o/Ky6Wajo=
+github.com/Azure/adx-mon v0.0.0-20240522171325-300776b36aa1 h1:UfgHWBrgcDZqKO0Vl42h0ADaQ/QYMzu/b0JJ/7w2WZQ=
+github.com/Azure/adx-mon v0.0.0-20240522171325-300776b36aa1/go.mod h1:sUQgYrvfWcwm9CCkQtxe4G0ugVb4lNzjkZXCQsCi4SQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji.go
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji.go
@@ -28,7 +28,7 @@ func (t *AddEmoji) Transform(ctx context.Context, batch *types.LogBatch) (*types
 		if !ok {
 			continue
 		}
-		log.Body["message"] = mapping.Map(messageStr)
+		log.Body[types.BodyKeyMessage] = mapping.Map(messageStr)
 	}
 	return batch, nil
 }

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/github.com/Azure/adx-mon/collector/logs/types/fields.go
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/github.com/Azure/adx-mon/collector/logs/types/fields.go
@@ -1,0 +1,13 @@
+package types
+
+const (
+	// Body map keys
+	// BodyKeyMessage is the key for the unparsed message field of a log.
+	BodyKeyMessage = "message"
+
+	// Attributes map keys
+	// AttributeDatabaseName is the name of the ADX database that the log should be sent to.
+	AttributeDatabaseName = "adxmon_destination_database"
+	// AttributeTableName is the name of the ADX table that the log should be sent to.
+	AttributeTableName = "adxmon_destination_table"
+)

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/github.com/Azure/adx-mon/collector/logs/types/logs.go
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/github.com/Azure/adx-mon/collector/logs/types/logs.go
@@ -12,18 +12,23 @@ type Log struct {
 
 	// Attributes of the log entry, not included in the log body.
 	Attributes map[string]any
+
+	// Resource that has collected the log
+	Resource map[string]any
 }
 
 func NewLog() *Log {
 	return &Log{
 		Body:       map[string]any{},
 		Attributes: map[string]any{},
+		Resource:   map[string]any{},
 	}
 }
 
 func (l *Log) Reset() {
 	clear(l.Body)
 	clear(l.Attributes)
+	clear(l.Resource)
 }
 
 // Copy returns a distinct copy of the log. This is useful for splitting logs.
@@ -37,6 +42,9 @@ func (l *Log) Copy() *Log {
 	}
 	for k, v := range l.Body {
 		copy.Body[k] = v
+	}
+	for k, v := range l.Resource {
+		copy.Resource[k] = v
 	}
 	return copy
 }

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/modules.txt
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/vendor/modules.txt
@@ -1,5 +1,5 @@
-# github.com/Azure/adx-mon v0.0.0-20231221224656-32bfbeeec10e
-## explicit; go 1.21
+# github.com/Azure/adx-mon v0.0.0-20240522171325-300776b36aa1
+## explicit; go 1.22.0
 github.com/Azure/adx-mon/collector/logs/types
 github.com/Azure/adx-mon/pkg/pool
 # github.com/libp2p/go-buffer-pool v0.1.0


### PR DESCRIPTION
Plugins need access to the new fields and types added within adx-mon/collector/logs/types.