### PR TITLE
Set max query time, track number of total queries

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -115,6 +115,13 @@ var (
 		Help:      "Gauge indicating if a query is healthy or not",
 	}, []string{"namespace", "name"})
 
+	QueriesRunTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "alerter",
+		Name:      "queries_run_total",
+		Help:      "Counter of the number of queries run",
+	}, []string{})
+
 	NotificationUnhealthy = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "alerter",


### PR DESCRIPTION
We want to ensure we never get stuck running queries so we continue to make forward progress, even in the face of stuck network connections and the like.

We now emit a counter to track the number of queries being run over time to more easily monitor for the condition where queries are not successfully running.