### PR TITLE
Publish logs to kustainer for testing purposes

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/tls"
+	"github.com/Azure/adx-mon/tools/otlp/logs/kustainer"
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/ingest"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -491,17 +492,25 @@ func newUploaders(endpoints []string, storageDir string, concurrentUploads int,
 		if err != nil {
 			return nil, nil, err
 		}
-		client, err := newKustoClient(addr)
-		if err != nil {
-			return nil, nil, err
+		if strings.HasPrefix(addr, "http://") {
+
+			logger.Warnf("Using Kustainer for endpoint %s", endpoint)
+			uploaders = append(uploaders, kustainer.New(database, addr))
+		} else {
+
+			client, err := newKustoClient(addr)
+			if err != nil {
+				return nil, nil, err
+			}
+			uploaders = append(uploaders, adx.NewUploader(client, adx.UploaderOpts{
+				StorageDir:        storageDir,
+				Database:          database,
+				ConcurrentUploads: concurrentUploads,
+				DefaultMapping:    defaultMapping,
+				SampleType:        sampleType,
+			}))
 		}
-		uploaders = append(uploaders, adx.NewUploader(client, adx.UploaderOpts{
-			StorageDir:        storageDir,
-			Database:          database,
-			ConcurrentUploads: concurrentUploads,
-			DefaultMapping:    defaultMapping,
-			SampleType:        sampleType,
-		}))
+
 		uploadDatabaseNames = append(uploadDatabaseNames, database)
 	}
 	return uploaders, uploadDatabaseNames, nil

--- a/tools/otlp/logs/README.md
+++ b/tools/otlp/logs/README.md
@@ -12,3 +12,9 @@ opentelemetry-collector with Ingestor.
 docker compose -f tools/otlp/logs/compose.yaml build
 docker compose -f tools/otlp/logs/compose.yaml up
 ```
+
+## Kusto
+
+[Kustainer](https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-install) is a container that
+runs Kusto in volatile mode. Logs are uploaded to Kustainer and can be inspected by connecting to `http://localhost:8081`, be sure to set `Security` to `Client Security: None` in the connection dialog. From there you can
+inspect logs as uploaded by _Ingestor_ as consumed by _Collector_ and published by _Fluent_ as defined by _fluent.yaml_.

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -17,9 +17,12 @@ services:
       - ~/.kube/config:/root/.kube/config
     ports:
       - 9090:9090
-    command: --kubeconfig /root/.kube/config --namespace adx-mon --storage-dir /tmp
+    command: --kubeconfig /root/.kube/config --namespace adx-mon --storage-dir /tmp  --logs-kusto-endpoints OTLPLogs=http://kustainer:8080 --disable-peer-transfer --max-segment-size 1024
     environment:
       - LOG_LEVEL=DEBUG
+    depends_on:
+      - kustainer
+    restart: on-failure
 
   collector:
     build:
@@ -36,10 +39,9 @@ services:
     environment:
       - LOG_LEVEL=DEBUG
 
-  # otel:
-  #   image: otel/opentelemetry-collector
-  #   volumes:
-  #     - ./otlp.yaml:/root/otlp.yaml
-  #   command: --config /root/otlp.yaml
-  #   ports:
-  #     - 4317:4317
+  kustainer:
+    image: mcr.microsoft.com/azuredataexplorer/kustainer-linux
+    environment:
+      - ACCEPT_EULA=Y
+    ports:
+      - 8081:8080

--- a/tools/otlp/logs/fluent.yaml
+++ b/tools/otlp/logs/fluent.yaml
@@ -1,29 +1,28 @@
 service:
   flush: 1
-  log_level: debug
+  log_level: error
 
 pipeline:
 
   inputs:
     - name: dummy
-      tag: dummy
-      dummy: '{"message": {"log": "hello world", "nested": "{\"objectone\": {\"key\": \"value\"}}\"", "kusto.database": "FakeDatabase", "kusto.table": "FakeTable"}}'
+      tag: nested
+      dummy: '{ "log": { "message": "hello world", "nested": "{\"objectone\": {\"key\": \"value\"}}" }, "kusto.database": "OTLPLogs", "kusto.table": "Nested" }'
+
+    - name: dummy
+      tag: formatted
+      dummy: '{ "log": { "foo": "bar" }, "kusto.database": "OTLPLogs", "kusto.table": "Formatted" }'
+
+    - name: dummy
+      tag: unformatted
+      dummy: '{ "log": "beep boop", "kusto.database": "OTLPLogs", "kusto.table": "unformatted" }'
 
   outputs:
     - Name: opentelemetry
       Match: "*"
       Host: collector
       Port: 8080
-      # Logs_uri: /logs
       Logs_uri: /v1/logs
       Log_response_payload: true
       TLS: false
       TLS.verify: false
-    # - Name: opentelemetry
-    #   Match: "*"
-    #   Host: otel
-    #   Port: 4317
-    #   Logs_uri: /v1/logs
-    #   Log_response_payload: true
-    #   TLS: false
-    #   TLS.verify: false

--- a/tools/otlp/logs/kustainer/uploader.go
+++ b/tools/otlp/logs/kustainer/uploader.go
@@ -1,0 +1,143 @@
+package kustainer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Azure/adx-mon/ingestor/adx"
+	"github.com/Azure/adx-mon/ingestor/cluster"
+	"github.com/Azure/adx-mon/ingestor/storage"
+	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/adx-mon/pkg/wal"
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+)
+
+// Uploader implements an adx.Uploader for use with Kustainer,
+// which is a volatile storage Kusto that is only meant for
+// testing purposes.
+type Uploader struct {
+	DatabaseName string
+	endpoint     string
+	q            chan *cluster.Batch
+	client       *kusto.Client
+	syncer       *adx.Syncer
+}
+
+func New(databaseName, endpoint string) *Uploader {
+	return &Uploader{
+		DatabaseName: databaseName,
+		endpoint:     endpoint,
+		q:            make(chan *cluster.Batch, 1000),
+	}
+}
+
+func (u *Uploader) Open(ctx context.Context) error {
+	builder := kusto.NewConnectionStringBuilder(u.endpoint)
+	client, err := kusto.New(builder)
+	if err != nil {
+		return fmt.Errorf("failed to create kustainer client: %w", err)
+	}
+	u.client = client
+
+	// Wait for Kustainer to come online
+	for {
+		stmt := fmt.Sprintf(".create database %s volatile", u.DatabaseName)
+		cmd := kusto.NewStmt("", kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(stmt)
+		_, err = u.client.Mgmt(ctx, u.DatabaseName, cmd)
+		if err != nil {
+			logger.Warnf("Waiting for Kustainer to come online")
+			time.Sleep(5 * time.Second)
+		}
+		break
+	}
+
+	u.syncer = adx.NewSyncer(client, u.DatabaseName, storage.DefaultLogsMapping, adx.OTLPLogs)
+	if err := u.syncer.Open(ctx); err != nil {
+		return fmt.Errorf("failed to open syncer: %w", err)
+	}
+	go u.run(ctx)
+
+	return nil
+}
+
+func (u *Uploader) Close() error {
+	close(u.q)
+	return u.client.Close()
+}
+
+func (u *Uploader) Database() string {
+	return u.DatabaseName
+}
+
+func (u *Uploader) UploadQueue() chan *cluster.Batch {
+	return u.q
+}
+
+func (u *Uploader) Mgmt(context.Context, kusto.Statement, ...kusto.QueryOption) (*kusto.RowIterator, error) {
+	return nil, errors.New("kustainer mgmt not implemented yet")
+}
+
+func (u *Uploader) run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case batch := <-u.q:
+
+			if batch.Database != u.DatabaseName {
+				logger.Errorf("Batch database does not match uploader database: %s != %s", batch.Database, u.DatabaseName)
+				continue
+			}
+			segments := batch.Segments
+
+			for _, si := range segments {
+				if err := u.uploadSegment(ctx, si.Path); err != nil {
+					logger.Errorf("Failed to upload segment: %s", err.Error())
+					continue
+				}
+			}
+			batch.Release()
+		}
+	}
+}
+
+func (u *Uploader) uploadSegment(ctx context.Context, path string) error {
+	_, table, _, err := wal.ParseFilename(path)
+	if err != nil {
+		return fmt.Errorf("failed to parse file: %w", err)
+	}
+
+	f, err := wal.NewSegmentReader(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	d, err := io.ReadAll(f)
+	f.Close()
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	if err := u.syncer.EnsureTable(table); err != nil {
+		return fmt.Errorf("failed to ensure table %s: %w", table, err)
+	}
+	if _, err := u.syncer.EnsureMapping(table); err != nil {
+		return fmt.Errorf("failed to ensure mapping for table %s: %w", table, err)
+	}
+
+	stmt := fmt.Sprintf(".ingest inline into table %s <| %s", table, d)
+	cmd := kusto.NewStmt("", kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(stmt)
+	_, err = u.client.Mgmt(ctx, u.DatabaseName, cmd)
+	if err != nil {
+		return fmt.Errorf("failed to upload segment: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Introduce a volatile mode where kustainer is used for uploading logs. Using kustainer is especially helpful when verifying log content, particularly with datatype conversions between OTLP and Kusto.