### PR TITLE
Integration tests for log processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ build-collector:
 	CGO_ENABLED=0 go build -o bin/collector ./cmd/collector/...
 .PHONY: build
 
-
 build: build-alerter build-ingestor build-collector
 .PHONY: build
 
@@ -26,6 +25,10 @@ clean:
 test:
 	go test ./...
 .PHONY: test
+
+e2e:
+	KUSTO_INTEGRATION_TEST=true go test -timeout 5m -count=1 -v github.com/Azure/adx-mon/tools/test/logs
+.PHONY: e2e
 
 default:
 	@$(MAKE) test

--- a/tools/otlp/logs/compose.yaml
+++ b/tools/otlp/logs/compose.yaml
@@ -7,7 +7,6 @@ services:
       - ./fluent.yaml:/etc/fluent-bit/config.yaml
     depends_on:
       - collector
-      # - otel
 
   ingestor:
     build:
@@ -19,7 +18,7 @@ services:
       - 9090:9090
     command: --kubeconfig /root/.kube/config --namespace adx-mon --storage-dir /tmp  --logs-kusto-endpoints OTLPLogs=http://kustainer:8080 --disable-peer-transfer --max-segment-size 1024
     environment:
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=INFO
     depends_on:
       - kustainer
     restart: on-failure
@@ -37,7 +36,7 @@ services:
     depends_on:
       - ingestor
     environment:
-      - LOG_LEVEL=DEBUG
+      - LOG_LEVEL=INFO
 
   kustainer:
     image: mcr.microsoft.com/azuredataexplorer/kustainer-linux

--- a/tools/otlp/logs/fluent.yaml
+++ b/tools/otlp/logs/fluent.yaml
@@ -5,17 +5,14 @@ service:
 pipeline:
 
   inputs:
-    - name: dummy
-      tag: nested
-      dummy: '{ "log": { "message": "hello world", "nested": "{\"objectone\": {\"key\": \"value\"}}" }, "kusto.database": "OTLPLogs", "kusto.table": "Nested" }'
 
     - name: dummy
-      tag: formatted
-      dummy: '{ "log": { "foo": "bar" }, "kusto.database": "OTLPLogs", "kusto.table": "Formatted" }'
+      tag: TestNested
+      dummy: '{ "log": { "message": "hello world", "nested": {"objectone": {"key": "value"}} }, "kusto.database": "OTLPLogs", "kusto.table": "TestNested" }'
 
     - name: dummy
-      tag: unformatted
-      dummy: '{ "log": "beep boop", "kusto.database": "OTLPLogs", "kusto.table": "unformatted" }'
+      tag: TestTypes
+      dummy: '{ "Log": { "Str": "string", "Int": 4, "Bool": true, "Nested": {"A": "b"} }, "kusto.database": "OTLPLogs", "kusto.table": "TestTypes" }'
 
   outputs:
     - Name: opentelemetry

--- a/tools/test/logs/e2e_suite_test.go
+++ b/tools/test/logs/e2e_suite_test.go
@@ -1,0 +1,85 @@
+package e2e_logs
+
+import (
+	"testing"
+
+	"github.com/Azure/adx-mon/tools/test/testutils"
+	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	testutils.MainKustoIntegrationTest(m)
+}
+
+func TestNested(t *testing.T) {
+	testutils.KustoIntegrationTestEnabled(t)
+
+	q := kql.New("TestNested").
+		AddLiteral(" | extend _log = todynamic(Body['log'])").
+		AddLiteral(" | extend _message = tostring(_log['message'])").
+		AddLiteral(" | extend _nested = todynamic(_log['nested'])").
+		AddLiteral(" | extend _objectone = todynamic(_nested['objectone'])").
+		AddLiteral(" | extend _key = tostring(_objectone['key'])").
+		AddLiteral(" | project _key")
+
+	type res struct {
+		Key string `kusto:"_key"`
+	}
+	var results []res
+	testutils.QueryKusto(t, q, func(row *table.Row) error {
+		var r res
+		if err := row.ToStruct(&r); err != nil {
+			return err
+		}
+		results = append(results, r)
+		return nil
+	})
+
+	require.NotEmpty(t, results)
+	require.Equal(t, "value", results[0].Key)
+}
+
+func TestTypes(t *testing.T) {
+	testutils.KustoIntegrationTestEnabled(t)
+
+	q := kql.New("TestTypes").
+		AddLiteral(" | extend Log = todynamic(Body['Log'])").
+		AddLiteral(" | extend Str = tostring(Log['Str'])").
+		AddLiteral(" | extend Int = toint(Log['Int'])").
+		AddLiteral(" | extend Bool = tobool(Log['Bool'])").
+		AddLiteral(" | extend Nested = todynamic(Log['Nested'])").
+		AddLiteral(" | extend A = tostring(Nested['A'])").
+		AddLiteral(" | project Log, Str, Int, Bool, Nested, A").
+		AddLiteral(" | limit 1")
+
+	type res struct {
+		Log struct {
+			Str    string `kusto:"Str"`
+			Int    string `kusto:"Int"`
+			Bool   string `kusto:"Bool"`
+			Nested struct {
+				A string `kusto:"A"`
+			} `kusto:"Nested"`
+		} `kusto:"Log"`
+		Str    string `kusto:"Str"`
+		Int    int    `kusto:"Int"`
+		Bool   bool   `kusto:"Bool"`
+		Nested struct {
+			A string `kusto:"A"`
+		} `kusto:"Nested"`
+		A string `kusto:"A"`
+	}
+	var results []res
+	testutils.QueryKusto(t, q, func(row *table.Row) error {
+		var r res
+		if err := row.ToStruct(&r); err != nil {
+			return err
+		}
+		results = append(results, r)
+		return nil
+	})
+
+	require.NotEmpty(t, results)
+}

--- a/tools/test/testutils/int.go
+++ b/tools/test/testutils/int.go
@@ -1,0 +1,53 @@
+package testutils
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+)
+
+const (
+	KustoIntegrationTest             = "KUSTO_INTEGRATION_TEST"
+	KustoIntegrationTestSkipTearDown = "KUSTO_INTEGRATION_TEST_SKIP_TEARDOWN"
+)
+
+func MainKustoIntegrationTest(m *testing.M) {
+	if !truthy(KustoIntegrationTest) {
+		log.Println("Kusto integration tests are not enabled, skipping...")
+		os.Exit(0)
+	}
+
+	if err := StartKusto(); err != nil {
+		logger.Fatalf("Failed to start kustainer: %s\n", err)
+	}
+
+	code := m.Run()
+
+	if !truthy(KustoIntegrationTestSkipTearDown) {
+		if err := StopKusto(); err != nil {
+			logger.Errorf("Failed to stop kustainer: %s\n", err)
+		}
+	}
+
+	os.Exit(code)
+}
+
+func KustoIntegrationTestEnabled(t *testing.T) {
+	t.Helper()
+
+	if !truthy(KustoIntegrationTest) {
+		t.Skip("Kusto integration tests are not enabled, skipping...")
+	}
+}
+
+func truthy(envVar string) bool {
+	v := os.Getenv(envVar)
+	switch v {
+	case "true", "True", "1", "TRUE":
+		return true
+	default:
+		return false
+	}
+}

--- a/tools/test/testutils/kusto.go
+++ b/tools/test/testutils/kusto.go
@@ -1,0 +1,89 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	KustoLocalEndpoint = "http://localhost:8081"
+	DatabaseName       = "OTLPLogs"
+)
+
+func StartKusto() error {
+	if err := BuildEnv(); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("docker", "compose", "-f", "../../otlp/logs/compose.yaml", "up", "--detach")
+	_, err := Run(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to start docker compose: %s", err)
+	}
+
+	return nil
+}
+
+func BuildEnv() error {
+	cmd := exec.Command("docker", "compose", "-f", "../../otlp/logs/compose.yaml", "build")
+	_, err := Run(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to build docker compose: %s", err)
+	}
+
+	return nil
+}
+
+func StopKusto() error {
+	cmd := exec.Command("docker", "compose", "-f", "../../otlp/logs/compose.yaml", "down", "--remove-orphans", "--volumes")
+	_, err := Run(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to stop docker compose: %s", err)
+	}
+
+	return nil
+}
+
+func QueryKusto(t *testing.T, q *kql.Builder, iter func(row *table.Row) error) {
+	t.Helper()
+
+	var (
+		rows *kusto.RowIterator
+		err  error
+	)
+	sb := kusto.NewConnectionStringBuilder(KustoLocalEndpoint)
+	client, err := kusto.New(sb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	require.Eventually(t, func() bool {
+		rows, err = client.Query(context.Background(), DatabaseName, q)
+		return err == nil
+	}, time.Minute, 5*time.Second)
+	defer rows.Stop()
+
+	for {
+		row, errInline, errFinal := rows.NextRowOrError()
+		if errFinal == io.EOF {
+			break
+		}
+		if errInline != nil {
+			continue
+		}
+		if errFinal != nil {
+			t.Fatalf("failed to retrieve row: %v", errFinal)
+		}
+		if err := iter(row); err != nil {
+			t.Fatalf("failed to parse row: %v", err)
+		}
+	}
+}

--- a/tools/test/testutils/proc.go
+++ b/tools/test/testutils/proc.go
@@ -1,0 +1,19 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func Run(cmd *exec.Cmd) ([]byte, error) {
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	command := strings.Join(cmd.Args, " ")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+	}
+
+	return output, nil
+}


### PR DESCRIPTION
Introduce e2e tests for log processing by emitting from Fluent and flowing through adx-mon into Kustainer, then testing their queried output for correctness.