### PR TITLE
Switch remote write proxy to buffer incoming writes into batches

### DIFF
--- a/tools/cmd/write-load/main.go
+++ b/tools/cmd/write-load/main.go
@@ -161,7 +161,7 @@ func writer(ctx context.Context, endpoint string, stats *stats, ch chan *prompb.
 				if err == nil {
 					break
 				}
-				logger.Warnf("write failed: %s.  Retrying...", err)
+				logger.Warnf("write failed: %s %s.  Retrying...", endpoint, err)
 				time.Sleep(1 * time.Second)
 			}
 			// println(time.Since(ts).String(), len(batch.Timeseries))


### PR DESCRIPTION
This changes the remote write proxy for collector to buffer up many small writes into larger batches and then flush the batches instead of proxying each write request to ingestor directly.

This will reduce the throttling and other transient errors caused by many collector instances handling lots of concurrent writes.  It will also reduce the load on ingestor as there will be fewer writes that are larger.