### PR TITLE
Emit latency metrics

### DIFF
--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -213,6 +213,7 @@ func (n *uploader) upload(ctx context.Context) error {
 						logger.Errorf("Failed to parse file: %s", err.Error())
 						continue
 					}
+					metrics.SampleLatency.WithLabelValues(database, table).Set(time.Since(si.CreatedAt).Seconds())
 
 					f, err := wal.NewSegmentReader(si.Path)
 					if os.IsNotExist(err) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -100,6 +100,13 @@ var (
 		Help:      "Counter of the number of logs dropped due to ingestor errors",
 	}, []string{})
 
+	SampleLatency = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "ingestor",
+		Name:      "sample_latency",
+		Help:      "Latency of a sample in seconds as determined by epoch in the filename vs the time the sample was uploaded.",
+	}, []string{"database", "table"})
+
 	// Alerting metrics
 	AlerterHealthCheck = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
@@ -179,12 +186,12 @@ var (
 		Help:      "Size of logs in bytes",
 	}, []string{"database", "table"})
 
-	LogsCollectorLogsCollected = promauto.NewCounterVec(prometheus.CounterOpts{
+	LogLatency = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "collector",
-		Name:      "logs_collected",
-		Help:      "Counter of the number of logs collected by the collector",
-	}, []string{"source"})
+		Name:      "logs_latency",
+		Help:      "Latency of logs in seconds as determined by the timestamp in a log vs the time the log was recieved.",
+	}, []string{"database", "table"})
 
 	LogsCollectorLogsSent = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,

--- a/pkg/otlp/logs.go
+++ b/pkg/otlp/logs.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"log/slog"
 	"strconv"
+	"time"
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
@@ -84,10 +85,14 @@ func Group(req *v1.ExportLogsServiceRequest, add []*commonv1.KeyValue, log *slog
 					idx = len(grouped) - 1
 				}
 
+				// Set the log latency metric in seconds since the time when the log was generated to the time when it was received
+				metrics.LogLatency.WithLabelValues(database, table).Set(float64(l.GetTimeUnixNano()-uint64(time.Now().UnixNano())) / 1e9)
+
 				grouped[idx].Logs = append(grouped[idx].Logs, l)
 			}
 		}
 	}
+
 	return grouped
 }
 


### PR DESCRIPTION
When a log is received in Collector, we emit metric collector_logs_latency, which is the amount of time elapsed, in seconds, between when the log was generated and when it was received by Collector. These logs are turned into WAL segments in Collector, batched, then sent to Ingestor. In the process of creating WAL segments, the filename contains a flakeid with an epoch of the time the file was generated. In Ingestor, prior to uploading the file to Kusto, we inspect the filename's flakeid, convert it to the epoch time of when the file was created, then compare this with the current time, this is then emitted as the metric ingestor_sample_latency, also in seconds. We can then use these to metrics, in addition to the Kusto generated metric "ingestion_time", to determine the total end-to-end latency and the latencies at each touch-point in time.