### PR TITLE
Drop unused tables

### DIFF
--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -314,7 +314,7 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 	}
 
 	// CountCardinality needs at least 1 table to exists before it can be created due to the union * statement.
-	if err := s.EnsureTable("AdxmonIngestorMetricsCardinalityCount"); err != nil {
+	if err := s.EnsureTable("AdxmonIngestorTableCardinalityCount"); err != nil {
 		return err
 	}
 

--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -1,0 +1,99 @@
+package adx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+)
+
+type TableDetail struct {
+	TableName       string  `kusto:"TableName"`
+	HotExtentSize   float64 `kusto:"HotExtentSize"`
+	TotalExtentSize float64 `kusto:"TotalExtentSize"`
+	TotalExtents    int64   `kusto:"TotalExtents"`
+	HotRowCount     int64   `kusto:"HotRowCount"`
+	TotalRowCount   int64   `kusto:"TotalRowCount"`
+}
+
+type DropUnusedTablesTask struct {
+	mu           sync.Mutex
+	unusedTables map[string]int
+	kustoCli     StatementExecutor
+	database     string
+}
+
+type StatementExecutor interface {
+	Database() string
+	Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+}
+
+func NewDropUnusedTablesTask(kustoCli StatementExecutor) *DropUnusedTablesTask {
+	return &DropUnusedTablesTask{
+		unusedTables: make(map[string]int),
+		kustoCli:     kustoCli,
+	}
+}
+
+func (t *DropUnusedTablesTask) Run(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	details, err := t.loadTableDetails(ctx)
+	if err != nil {
+		return fmt.Errorf("error loading table details: %w", err)
+	}
+
+	for _, v := range details {
+		if v.TotalRowCount > 0 {
+			delete(t.unusedTables, v.TableName)
+		}
+
+		if v.TotalRowCount == 0 {
+			t.unusedTables[v.TableName]++
+			logger.Infof("Marking table %s.%s as unused", t.database, v.TableName)
+		}
+	}
+
+	for table, count := range t.unusedTables {
+		if count > 2 {
+			logger.Infof("Dropping unused table %s.%s", t.kustoCli.Database(), table)
+			stmt := kusto.NewStmt("", kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(fmt.Sprintf(".drop table %s", table))
+			if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
+				return fmt.Errorf("error dropping table %s: %w", table, err)
+			}
+			delete(t.unusedTables, table)
+		}
+	}
+	return nil
+}
+
+func (t *DropUnusedTablesTask) loadTableDetails(ctx context.Context) ([]TableDetail, error) {
+	stmt := kusto.NewStmt(".show tables details | project TableName, HotExtentSize, TotalExtentSize, TotalExtents, HotRowCount, TotalRowCount")
+	rows, err := t.kustoCli.Mgmt(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	var tables []TableDetail
+	for {
+		row, err1, err2 := rows.NextRowOrError()
+		if err2 == io.EOF {
+			return tables, nil
+		} else if err1 != nil {
+			return tables, err1
+		} else if err2 != nil {
+			return tables, err2
+		}
+
+		var v TableDetail
+		if err := row.ToStruct(&v); err != nil {
+			return tables, err
+		}
+		tables = append(tables, v)
+	}
+}

--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -100,8 +100,7 @@ func (n *uploader) Close() error {
 	}
 
 	n.ingestors = nil
-
-	return nil
+	return n.syncer.Close()
 }
 
 func (n *uploader) UploadQueue() chan *cluster.Batch {

--- a/metrics/service.go
+++ b/metrics/service.go
@@ -27,6 +27,7 @@ type TimeSeriesWriter interface {
 }
 
 type StatementExecutor interface {
+	Database() string
 	Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 

--- a/pkg/scheduler/Periodic.go
+++ b/pkg/scheduler/Periodic.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+)
+
+type Elector interface {
+	IsLeader() bool
+}
+
+type Periodic struct {
+	cancelFn context.CancelFunc
+	closing  chan struct{}
+	elector  Elector
+}
+
+func NewScheduler(elector Elector) *Periodic {
+	return &Periodic{
+		elector: elector,
+	}
+}
+
+func (s *Periodic) Open(ctx context.Context) error {
+	ctx, cancelFn := context.WithCancel(ctx)
+	s.cancelFn = cancelFn
+	s.closing = make(chan struct{})
+	return nil
+}
+
+func (s *Periodic) Close() error {
+	s.cancelFn()
+	close(s.closing)
+	return nil
+}
+
+func (s *Periodic) ScheduleEvery(interval time.Duration, name string, fn func(ctx context.Context) error) {
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-s.closing:
+				return
+			case <-t.C:
+				if s.elector != nil && !s.elector.IsLeader() {
+					continue
+				}
+
+				if err := fn(context.Background()); err != nil {
+					logger.Errorf("Failed to run scheduled task %s: %s", name, err)
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
If a table has no rows after two checks, the table is considered unused and then dropped.

This adds a simple task scheduler service so that we can add more control around periodic tasks instead of having them spun up across the code base.