### PR TITLE
Add quick start instructions

### DIFF
--- a/build/k8s/collector.yaml
+++ b/build/k8s/collector.yaml
@@ -59,7 +59,7 @@ data:
     endpoint = 'https://ingestor.adx-mon.svc.cluster.local'
 
     # Region is a location identifier
-    region = 'region'
+    region = '$REGION'
 
     # Skip TLS verification.
     insecure-skip-verify = true
@@ -85,12 +85,13 @@ data:
     # Key/value pairs of labels to add to all metrics.
     [add-labels]
       host = '$(HOSTNAME)'
+      cluster = '$CLUSTER'
 
     # Defines a prometheus scrape endpoint.
     [prometheus-scrape]
 
       # Database to store metrics in.
-      database = '<DB Name>'
+      database = '$DATABASE_NAME'
 
       default-drop-metrics = false
 
@@ -107,9 +108,6 @@ data:
 
         # Scrape cadvisor metrics
         { host-regex = '.*', url = 'https://$(HOSTNAME):10250/metrics/resource', namespace = 'kube-system', pod = 'kubelet', container = 'resource' },
-
-        # Scrape api-server metrics
-        { host-regex = '.+-master-.+', url = 'https://$(HOSTNAME):6443/metrics', namespace = 'kube-system', pod = 'kube-apiserver', container = 'kube-apiserver' },
       ]
 
       # Scrape interval in seconds.
@@ -128,7 +126,7 @@ data:
     [[prometheus-remote-write]]
 
       # Database to store metrics in.
-      database = '<DB Name>'
+      database = '$DATABASE_NAME'
 
       # The path to listen on for prometheus remote write requests.  Defaults to /receive.
       path = '/receive'
@@ -179,6 +177,8 @@ spec:
         adxmon: collector
     spec:
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule

--- a/build/k8s/ingestor.yaml
+++ b/build/k8s/ingestor.yaml
@@ -91,10 +91,10 @@ spec:
               value: INFO
             - name: "GODEBUG"
               value: "http2client=0"
-#            - name: "AZURE_RESOURCE"
-#              value: "https://<cluster>.<region>.kusto.windows.net"
-#            - name:  "AZURE_CLIENT_ID"
-#              value: "<MSI ID With ADX Access>"
+            - name: "AZURE_RESOURCE"
+              value: "$ADX_URL"
+            - name:  "AZURE_CLIENT_ID"
+              value: "$CLIENT_ID"
           command:
             - /ingestor
           args:
@@ -105,11 +105,12 @@ spec:
             - "--max-connections=1000"
             - "--insecure-skip-verify"
             - "--lift-label=host"
+            - "--lift-label=cluster"
             - "--lift-label=adxmon_namespace=Namespace"
             - "--lift-label=adxmon_pod=Pod"
             - "--lift-label=adxmon_container=Container"
-#            - "--metrics-kusto-endpoints=<DBName>=https://<cluster>.<region>.kusto.windows.net"
-#            - "--logs-kusto-endpoints=<DBName>=https://<cluster>.<region>.kusto.windows.net"
+            - "--metrics-kusto-endpoints=$DATABASE_NAME=$ADX_URL"
+            - "--logs-kusto-endpoints=$DATABASE_NAME=$ADX_URL"
           volumeMounts:
             - name: metrics
               mountPath: /mnt/data

--- a/build/k8s/install.sh
+++ b/build/k8s/install.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+
+if ! command -v az &> /dev/null
+then
+    echo "The 'az' command could not be found. Please install Azure CLI before continuing."
+    exit
+fi
+
+if ! az account show &> /dev/null; then
+    echo "You are not logged in to Azure CLI. Please log in."
+    az login
+fi
+
+TOKEN_EXPIRY=$(az account get-access-token --query expires_on -o tsv)
+CURRENT_DATE=$(date -u +%s)
+
+if [[ "$CURRENT_DATE" > "$TOKEN_EXPIRY" ]]; then
+    echo "Your Azure CLI token has expired. Please log in again."
+    az login
+fi
+
+if ! az extension show --name resource-graph &> /dev/null; then
+    read -p "The 'resource-graph' extension is not installed. Do you want to install it now? (y/n) " INSTALL_RG
+    if [[ "$INSTALL_RG" == "y" ]]; then
+        az extension add --name resource-graph
+    else
+        echo "The 'resource-graph' extension is required. Exiting."
+        exit 1
+    fi
+fi
+
+# Ask for the name of the aks cluster and read it as input.  With that name, run a graph query to find
+read -p "Please enter the name of the AKS cluster where ADX-Mon components should be deployed: " CLUSTER
+while [[ -z "${CLUSTER// }" ]]; do
+    echo "Cluster cannot be empty. Please enter the name of the AKS cluster:"
+    read CLUSTER
+done
+
+# Run a graph query to find the cluster's resource group and subscription id
+CLUSTER_INFO=$(az graph query -q "Resources | where type =~ 'Microsoft.ContainerService/managedClusters' and name =~ '$CLUSTER' | project resourceGroup, subscriptionId, location")
+if [[ $(echo $CLUSTER_INFO | jq '.data | length') -eq 0 ]]; then
+    echo "No AKS cluster could be found for the cluster name '$CLUSTER'. Exiting."
+    exit 1
+fi
+
+RESOURCE_GROUP=$(echo $CLUSTER_INFO | jq -r '.data[0].resourceGroup')
+SUBSCRIPTION_ID=$(echo $CLUSTER_INFO | jq -r '.data[0].subscriptionId')
+REGION=$(echo $CLUSTER_INFO | jq -r '.data[0].location')
+
+# Find the managed identity client ID attached to the AKS node pools
+NODE_POOL_IDENTITY=$(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER --query identityProfile.kubeletidentity.clientId -o tsv)
+
+echo
+echo -e "Found AKS cluster info:"
+echo -e "  AKS Cluster Name: \e[32m$CLUSTER\e[0m"
+echo -e "  Resource Group: \e[32m$RESOURCE_GROUP\e[0m"
+echo -e "  Subscription ID:\e[32m $SUBSCRIPTION_ID\e[0m"
+echo -e "  Region: \e[32m$REGION\e[0m"
+echo -e "  Managed Identity Client ID: \e[32m$NODE_POOL_IDENTITY\e[0m"
+echo
+read -p "Is this information correct? (y/n) " CONFIRM
+if [[ "$CONFIRM" != "y" ]]; then
+    echo "Exiting as the information is not correct."
+    exit 1
+fi
+
+az aks get-credentials --subscription $SUBSCRIPTION_ID --resource-group $RESOURCE_GROUP --name $CLUSTER
+
+echo
+read -p "Please enter the Azure Data Explorer cluster name where ADX-Mon will store telemetry: " CLUSTER_NAME
+while [[ -z "${CLUSTER_NAME// }" ]]; do
+    echo "ADX cluster name cannot be empty. Please enter the database name:"
+    read CLUSTER_NAME
+done
+
+CLUSTER_INFO=$(az graph query -q "Resources | where type =~ 'Microsoft.Kusto/clusters' and name =~ '$CLUSTER_NAME' | project name, resourceGroup, subscriptionId, location, properties.uri")
+CLUSTER_COUNT=$(echo $CLUSTER_INFO | jq '.data | length')
+
+if [[ $CLUSTER_COUNT -eq 0 ]]; then
+    echo "No Kusto cluster could be found for the database name '$CLUSTER_NAME'. Exiting."
+    exit 1
+else
+    CLUSTER_NAME=$(echo $CLUSTER_INFO | jq -r '.data[0].name')
+    SUBSCRIPTION_ID=$(echo $CLUSTER_INFO | jq -r '.data[0].subscriptionId')
+    RESOURCE_GROUP=$(echo $CLUSTER_INFO | jq -r '.data[0].resourceGroup')
+    ADX_FQDN=$(echo $CLUSTER_INFO | jq -r '.data[0].properties_uri')
+fi
+echo
+echo "Found ADX cluster info:"
+echo -e "  Cluster Name: \e[32m$CLUSTER_NAME\e[0m"
+echo -e "  Subscription ID: \e[32m$SUBSCRIPTION_ID\e[0m"
+echo -e "  Resource Group: \e[32m$RESOURCE_GROUP\e[0m"
+echo -e "  ADX FQDN: \e[32m$ADX_FQDN\e[0m"
+echo
+read -p "Is this the correct ADX cluster info? (y/n) " CONFIRM
+if [[ "$CONFIRM" != "y" ]]; then
+    echo "Exiting as the ADX cluster info is not correct."
+    exit 1
+fi
+
+DATABASE_NAME=ADXMon
+# Check if the ADXMon database exists
+DATABASE_EXISTS=$(az kusto database show --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --database-name $DATABASE_NAME --query "name" -o tsv)
+if [[ -z "$DATABASE_EXISTS" ]]; then
+    echo "The ADXMon database does not exist. Creating it now."
+    az kusto database create --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --database-name $DATABASE_NAME --read-write-database
+else
+    echo "The ADXMon database already exists."
+fi
+
+# Check if the NODE_POOL_IDENTITY is an admin on the DATABASE_NAME database
+ADMIN_CHECK=$(az kusto database list-principal --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --database-name $DATABASE_NAME --query "[?type=='App' && appId=='$NODE_POOL_IDENTITY' && role=='Admin']" -o tsv)
+if [[ -z "$ADMIN_CHECK" ]]; then
+    echo "The Managed Identity Client ID is not configured to use database $DATABASE_NAME. Adding it as an admin."
+    az kusto database add-principal --cluster-name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --database-name $DATABASE_NAME --value role=Admin name=ADXMon type=app app-id=$NODE_POOL_IDENTITY
+else
+    echo "The Managed Identity Client ID is already configured to use database $DATABASE_NAME."
+fi
+
+
+export CLUSTER=$CLUSTER
+export REGION=$REGION
+export DATABASE_NAME=$DATABASE_NAME
+export CLIENT_ID=$NODE_POOL_IDENTITY
+export ADX_URL=$ADX_FQDN
+envsubst < $SCRIPT_DIR/collector.yaml | kubectl apply -f -
+envsubst < $SCRIPT_DIR/ingestor.yaml | kubectl apply -f -
+
+echo
+echo -e "\e[97mSuccessfully deployed ADX-Mon components to AKS cluster $CLUSTER.\e[0m"
+echo
+echo "Collected telemetry can be found the $DATABASE_NAME database at $ADX_FQDN."

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,8 +1,8 @@
 # Quick Start
 
-This guide will walk you through the steps needed to deploy ADX-Mon on an Azure Kubernetes Service (AKS) cluster.  It
-will deploy all components within the cluster and demonstrate how to enable telemetry collection on a pod and 
-query it from Azure Data Explorer.
+This guide will deploy ADX-Mon on an Azure Kubernetes Service (AKS) cluster and send collected telemetry
+to an Azure Data Explorer cluster.  It will deploy all components within the cluster and demonstrate 
+how to enable telemetry collection on a pod and query it from Azure Data Explorer.
 
 ## Pre-Requisites
 
@@ -10,30 +10,20 @@ You will need the following to complete this guide.
 
 * An AKS cluster
 * An Azure Data Explorer cluster
-* An MSI with admin permissions to the ADX cluster
+* A Linux environment with Azure CLI installed
 
-## Setup Azure Data Explorer
+These clusters should be in the same region for this guid.  You should have full admin access to both clusters.
+
+## Deploy ADX-Mon
 
 ```sh
-# TODO: Add instructions for setting up ADX
+$ git clone https://github.com/Azure/adx-mon.git
+$ cd adx-mon
+$ ./build/k8s/install.sh
 ```
 
-## Setup AKS Cluster
-
-```sh
-````
-
-
-## Deploy Collector
-
-```sh
-
-```
-
-## Deploy Ingestor
-```sh
-# TODO: Add instructions for deploying the ingestor
-```
+This script will prompt you for the name or you AKS and ADX cluster and configure them to accept telemetry from ADX-Mon
+components. 
 
 ## Annotate Your Pods
 
@@ -66,11 +56,6 @@ adx-mon/path: "/metrics"
 # TODO: Add instructions for querying data
 ```
 
-### Deploy Alerter
-
-```sh
-# TODO: Add instructions for deploying the alerter
-```
 
 ### Setup Dashboards
 


### PR DESCRIPTION
This adds some kubernetes deployment specs and an installer script to quickly setup adx-mon on and AKS cluster.  The setup configures everything to be sent to one database and it uses the AKS kubelet identity for access to the cluster.  This setup isn't intended for production as is, but straightforward to start trying adx-mon provided you have the two pre-requisites.