### PR TITLE
Ensure metrics explicitly dropped take precedence over allowed

### DIFF
--- a/ingestor/transform/transformer.go
+++ b/ingestor/transform/transformer.go
@@ -155,6 +155,13 @@ func (f *RequestTransformer) TransformTimeSeries(v prompb.TimeSeries) prompb.Tim
 
 func (f *RequestTransformer) ShouldDropMetric(v prompb.TimeSeries, name []byte) bool {
 	if f.DefaultDropMetrics {
+		// Explicitly dropped metrics take precedence over explicitly kept metrics.
+		for _, r := range f.DropMetrics {
+			if r.Match(name) {
+				return true
+			}
+		}
+
 		for _, r := range f.KeepMetrics {
 			if r.Match(name) {
 				return false

--- a/ingestor/transform/transformer_test.go
+++ b/ingestor/transform/transformer_test.go
@@ -379,7 +379,7 @@ func TestRequestTransformer_TransformWriteRequest_KeepMetricsAndDrop(t *testing.
 	}
 
 	res := f.TransformWriteRequest(req)
-	require.Equal(t, 3, len(res.Timeseries))
+	require.Equal(t, 2, len(res.Timeseries))
 	require.Equal(t, []byte("__name__"), res.Timeseries[0].Labels[0].Name)
 	require.Equal(t, []byte("cpu"), res.Timeseries[0].Labels[0].Value)
 	require.Equal(t, []byte("__name__"), res.Timeseries[1].Labels[0].Name)
@@ -608,13 +608,25 @@ func TestRequestTransformer_ShouldDropMetric(t *testing.T) {
 			f: &transform.RequestTransformer{
 				DefaultDropMetrics: true,
 				KeepMetrics:        []*regexp.Regexp{regexp.MustCompile("metric")},
-				DropMetrics:        []*regexp.Regexp{regexp.MustCompile("metric")},
 			},
 			args: args{
 				name: []byte("metric"),
 				v:    prompb.TimeSeries{},
 			},
 			want: false,
+		},
+		{
+			name: "Drop Metric When DefaultDropMetrics and Match KeepMetrics",
+			f: &transform.RequestTransformer{
+				DefaultDropMetrics: true,
+				KeepMetrics:        []*regexp.Regexp{regexp.MustCompile("metric")},
+				DropMetrics:        []*regexp.Regexp{regexp.MustCompile("metric")},
+			},
+			args: args{
+				name: []byte("metric"),
+				v:    prompb.TimeSeries{},
+			},
+			want: true,
 		},
 		{
 			name: "Drop Metric with KeepMetricsWithLabelValue",


### PR DESCRIPTION
This fixes a regression to the default drop metrics scenario where metrics that matched an allow rule would always be allowed.  The prior behavior was that we would apply the drop rules first since those have higher precedence than allow rules.