### PR TITLE
Add options to change scraper http client defaults

### DIFF
--- a/cmd/collector/config.go
+++ b/cmd/collector/config.go
@@ -103,6 +103,7 @@ type PrometheusScrape struct {
 	Database                 string          `toml:"database" comment:"Database to store metrics in."`
 	StaticScrapeTarget       []*ScrapeTarget `toml:"static-scrape-target" comment:"Defines a static scrape target."`
 	ScrapeIntervalSeconds    int             `toml:"scrape-interval" comment:"Scrape interval in seconds."`
+	ScrapeTimeout            int             `toml:"scrape-timeout" comment:"Scrape timeout in seconds."`
 	DisableMetricsForwarding bool            `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
 
 	DefaultDropMetrics        *bool             `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -236,6 +236,7 @@ func realMain(ctx *cli.Context) error {
 			DefaultDropMetrics:        defaultDropMetrics,
 			DisableMetricsForwarding:  cfg.PrometheusScrape.DisableMetricsForwarding,
 			ScrapeInterval:            time.Duration(cfg.PrometheusScrape.ScrapeIntervalSeconds) * time.Second,
+			ScrapeTimeout:             time.Duration(cfg.PrometheusScrape.ScrapeTimeout) * time.Second,
 			Targets:                   staticTargets,
 			MaxBatchSize:              cfg.MaxBatchSize,
 		}

--- a/collector/client_test.go
+++ b/collector/client_test.go
@@ -35,7 +35,7 @@ go_gc_duration_seconds_count 8452
 	}))
 	defer svr.Close()
 
-	client, err := collector.NewMetricsClient()
+	client, err := collector.NewMetricsClient(collector.ClientOpts{})
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -75,7 +75,7 @@ go_gc_duration_seconds_count 8452
 	}))
 	defer svr.Close()
 
-	client, err := collector.NewMetricsClient()
+	client, err := collector.NewMetricsClient(collector.ClientOpts{})
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -47,6 +47,9 @@ type ScraperOpts struct {
 	// ScrapeInterval is the interval at which to scrape metrics from the targets.
 	ScrapeInterval time.Duration
 
+	// ScrapeTimeout is the timeout for scraping metrics from a target.
+	ScrapeTimeout time.Duration
+
 	// DisableMetricsForwarding disables the forwarding of metrics to the remote write endpoint.
 	DisableMetricsForwarding bool
 
@@ -131,7 +134,9 @@ func (s *Scraper) Open(ctx context.Context) error {
 	s.cancel = cancelFn
 
 	var err error
-	s.scrapeClient, err = NewMetricsClient()
+	s.scrapeClient, err = NewMetricsClient(ClientOpts{
+		ScrapeTimeOut: s.opts.ScrapeTimeout,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create metrics client: %w", err)
 	}


### PR DESCRIPTION
Some endpoints can take a while to scrape and the 10s timeout causes them to fail. This makes the setting configurable.