### PR TITLE
Add option to disable target discovery for metrics scraping

### DIFF
--- a/build/k8s/collector.yaml
+++ b/build/k8s/collector.yaml
@@ -266,3 +266,168 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-singleton-config
+  namespace: adx-mon
+data:
+  config.toml: |
+    # Ingestor URL to send collected telemetry.
+    endpoint = 'https://ingestor.adx-mon.svc.cluster.local'
+
+    # Region is a location identifier
+    region = '$REGION'
+
+    # Skip TLS verification.
+    insecure-skip-verify = true
+
+    # Address to listen on for endpoints.
+    listen-addr = ':8080'
+
+    # Maximum number of connections to accept.
+    max-connections = 100
+
+    # Maximum number of samples to send in a single batch.
+    max-batch-size = 10000
+
+    # Storage directory for the WAL.
+    storage-dir = '/mnt/data'
+
+    # Regexes of metrics to drop from all sources.
+    drop-metrics = []
+
+    # Disable metrics forwarding to endpoints.
+    disable-metrics-forwarding = false
+
+    # Key/value pairs of labels to add to all metrics.
+    [add-labels]
+      host = '$(HOSTNAME)'
+      cluster = '$CLUSTER'
+
+    # Defines a prometheus scrape endpoint.
+    [prometheus-scrape]
+
+      # Database to store metrics in.
+      database = 'Metrics'
+
+      default-drop-metrics = false
+
+      # Defines a static scrape target.
+      static-scrape-target = [
+        # Scrape api server endpoint
+        { host-regex = '.*', url = 'https://kubernetes.default.svc/metrics', namespace = 'kube-system', pod = 'kube-apiserver', container = 'kube-apiserver' },
+      ]
+
+      # Scrape interval in seconds.
+      scrape-interval = 30
+
+      # Scrape timeout in seconds.
+      scrape-timeout = 25
+
+      # Disable dynamic discovery of scrape targets.
+      disable-discovery = true
+
+      # Disable metrics forwarding to endpoints.
+      disable-metrics-forwarding = false
+
+      # Regexes of metrics to keep from scraping source.
+      keep-metrics = []
+
+      # Regexes of metrics to drop from scraping source.
+      drop-metrics = []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector-singleton
+  namespace: adx-mon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      adxmon: collector
+  template:
+    metadata:
+      labels:
+        adxmon: collector
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/port: "9091"
+        adx-mon/path: "/metrics"
+        adx-mon/log-destination: "Logs:Collector"
+        adx-mon/log-parsers: json
+    spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      serviceAccountName: collector
+      containers:
+        - name: collector
+          image: "ghcr.io/azure/adx-mon/collector:latest"
+          command:
+            - /collector
+          args:
+            - "--config=/etc/config/config.toml"
+            - "--hostname=$(HOSTNAME)"
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "GODEBUG"
+              value: "http2client=0"
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs
+              readOnly: true
+            - mountPath: /etc/pki/ca-trust/extracted
+              name: etc-pki-ca-certs
+              readOnly: true
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage
+              mountPath: /mnt/data
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 2000Mi
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: Directory
+        - name: etc-pki-ca-certs
+          hostPath:
+            path: /etc/pki/ca-trust/extracted
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: collector-singleton-config
+        - name: storage
+          hostPath:
+            path: /mnt/collector
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/cmd/collector/config.go
+++ b/cmd/collector/config.go
@@ -105,6 +105,7 @@ type PrometheusScrape struct {
 	ScrapeIntervalSeconds    int             `toml:"scrape-interval" comment:"Scrape interval in seconds."`
 	ScrapeTimeout            int             `toml:"scrape-timeout" comment:"Scrape timeout in seconds."`
 	DisableMetricsForwarding bool            `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
+	DisableDiscovery         bool            `toml:"disable-discovery" comment:"Disable discovery of kubernetes pod targets."`
 
 	DefaultDropMetrics        *bool             `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`
 	AddLabels                 map[string]string `toml:"add-labels" comment:"Key/value pairs of labels to add to all metrics."`

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -235,6 +235,7 @@ func realMain(ctx *cli.Context) error {
 			KeepMetricsWithLabelValue: keepMetricLabelValues,
 			DefaultDropMetrics:        defaultDropMetrics,
 			DisableMetricsForwarding:  cfg.PrometheusScrape.DisableMetricsForwarding,
+			DisableDiscovery:          cfg.PrometheusScrape.DisableDiscovery,
 			ScrapeInterval:            time.Duration(cfg.PrometheusScrape.ScrapeIntervalSeconds) * time.Second,
 			ScrapeTimeout:             time.Duration(cfg.PrometheusScrape.ScrapeTimeout) * time.Second,
 			Targets:                   staticTargets,


### PR DESCRIPTION
This allows collector to be used for just static scraping of specific
targets.  Since collector is intended to be deployed as a DaemonSet,
it's not idel to scrape things like the api server, service endpoints,
etc.. from all the nodes since that can create lots of duplicae data.

This option allows target discovery to be disabled so that you can
deploy a separate collector with fewer replicas that scrapes static
targets only.