### PR TITLE
Rework collector pod discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ image: image-ingestor image-alerter image-collector
 .PHONY: image
 
 image-ingestor:
-	docker build -t ghcr.io/azure/adx-mon/ingestor:latest -f build/images/Dockerfile.ingestor .
+	docker build --no-cache -t ghcr.io/azure/adx-mon/ingestor:latest -f build/images/Dockerfile.ingestor .
 
 image-alerter:
-	docker build -t ghcr.io/azure/adx-mon/alerter:latest -f build/images/Dockerfile.alerter .
+	docker build --no-cache -t ghcr.io/azure/adx-mon/alerter:latest -f build/images/Dockerfile.alerter .
 
 image-collector:
-	docker build -t ghcr.io/azure/adx-mon/collector:latest -f build/images/Dockerfile.collector .
+	docker build --no-cache -t ghcr.io/azure/adx-mon/collector:latest -f build/images/Dockerfile.collector .
 
 push:
 	docker push ghcr.io/azure/adx-mon/alerter:latest

--- a/build/k8s/collector.yaml
+++ b/build/k8s/collector.yaml
@@ -19,6 +19,7 @@ rules:
       - ""
     resources:
       - nodes/metrics
+      - nodes/proxy
     verbs:
       - get
   - apiGroups:

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -158,6 +158,7 @@ func realMain(ctx *cli.Context) error {
 			}
 
 			staticTargets = append(staticTargets, collector.ScrapeTarget{
+				Static:    true,
 				Addr:      target.URL,
 				Namespace: target.Namespace,
 				Pod:       target.Pod,

--- a/collector/logs/transforms/parser/json.go
+++ b/collector/logs/transforms/parser/json.go
@@ -33,7 +33,7 @@ func (p *JsonParser) Parse(log *types.Log) error {
 		return ErrNotString
 	}
 
-	if msg[0] != '{' {
+	if len(msg) == 0 || msg[0] != '{' {
 		return nil
 	}
 

--- a/collector/scraper_test.go
+++ b/collector/scraper_test.go
@@ -110,8 +110,7 @@ func TestScraper_isScrapeable_PodIpReused(t *testing.T) {
 		},
 	}
 
-	targets, existing := s.isScrapeable(p)
-	require.False(t, existing)
+	targets := s.isScrapeable(p)
 
 	s.targets = make(map[string]ScrapeTarget)
 	for _, target := range targets {
@@ -136,9 +135,7 @@ func TestScraper_isScrapeable_PodIpReused(t *testing.T) {
 		},
 	}
 
-	targets, existing = s.isScrapeable(p)
-	require.False(t, existing)
-
+	targets = s.isScrapeable(p)
 }
 
 type fakeClient struct {


### PR DESCRIPTION
The pod discovery with the informer wasn't working reliably.  Sometimes pod delete events would get missed so a collector instance would continue scraping the endpoing and get "no route to host" errors.  The informer should be resyncing every minute, but it's not working.

To address this, we have each collector list pods every minute to resync and reconcile targets.  Since collector is a daemonset and list pods from every node could be expensive, we take advantage of the fact that we only need the list of pods on the current nodes.  Conveniently, kubelet exposes a pods API that returns the pods on the current nodes.

This change scrapes the local pods API to reconcile pods on the node which avoids taxing the API server/Etcd and serializing the pods over the network.