### PR TITLE
Use label selector for ingestor pods

### DIFF
--- a/ingestor/cluster/coordinator_test.go
+++ b/ingestor/cluster/coordinator_test.go
@@ -118,6 +118,9 @@ func TestCoordinator_LostPeer(t *testing.T) {
 					Name: "ingestor",
 				},
 			},
+			Labels: map[string]string{
+				"app": "ingestor",
+			},
 		},
 		Status: v1.PodStatus{
 			PodIP: "10.200.0.1",
@@ -147,6 +150,9 @@ func TestCoordinator_LostPeer(t *testing.T) {
 					Kind: "StatefulSet",
 					Name: "ingestor",
 				},
+			},
+			Labels: map[string]string{
+				"app": "ingestor",
 			},
 		},
 		Status: v1.PodStatus{


### PR DESCRIPTION
Ingestor was watching all pods instead of just ingestor pods which causes a lot of allocation from the pod unmarshalling in the informer.