### PR TITLE
Log reason for ingestor instance reporting unhealthy

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -506,6 +506,7 @@ func (f fakeHealthChecker) UploadQueueSize() int           { return 0 }
 func (f fakeHealthChecker) SegmentsTotal() int64           { return 0 }
 func (f fakeHealthChecker) SegmentsSize() int64            { return 0 }
 func (f fakeHealthChecker) IsHealthy() bool                { return true }
+func (f fakeHealthChecker) UnhealthyReason() string        { return "" }
 
 // remotePartitioner is a Partitioner that always returns the same owner that forces a remove transfer.
 type remotePartitioner struct {

--- a/metrics/service.go
+++ b/metrics/service.go
@@ -20,6 +20,7 @@ type HealthReporter interface {
 	UploadQueueSize() int
 	SegmentsTotal() int64
 	SegmentsSize() int64
+	UnhealthyReason() string
 }
 
 type TimeSeriesWriter interface {
@@ -140,7 +141,7 @@ func (s *service) collect(ctx context.Context) {
 			}
 
 			logger.Infof("Ingestion rate %0.2f samples/sec, samples ingested=%d, health=%v, "+
-				"upload queue size=%d, transfer queue size=%d, segments total=%d, segments size=%d "+
+				"upload queue size=%d, transfer queue size=%d, segments total=%d, segments size=%d reason=%s "+
 				"active connections=%d dropped connections=%d",
 				(currentTotal-lastCount)/60, uint64(currentTotal),
 				s.health.IsHealthy(),
@@ -148,6 +149,7 @@ func (s *service) collect(ctx context.Context) {
 				s.health.TransferQueueSize(),
 				s.health.SegmentsTotal(),
 				s.health.SegmentsSize(),
+				s.health.UnhealthyReason(),
 				int(activeConns),
 				int(droppedConns))
 


### PR DESCRIPTION
There are a few limits where ingestor will start to throttle client requests.  For example, if the number of segments exceeds the max segment limit or the size of segments on disk excees the max disk usage limit, ingestor will reject new writes to trigger back pressure to clients.

When these occur, it's hard to known the reason why an instance is reporting unhealthy unless you are familiar with the various health checks ingestor uses internally.

This adds the reason to the health logging so we can make it easier to determine what remediation might be necessary to get instance healthy again.  For example, if max segments is exceeded, a DRI might need to increase the max segments limit if the reported value is expected.