### PR TITLE
Add metrics for active/dropped connections

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Azure/azure-kusto-go/kusto/ingest"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/net/netutil"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -347,7 +346,7 @@ func realMain(ctx *cli.Context) error {
 	}
 	if maxConns > 0 {
 		logger.Infof("Limiting connections to %d", maxConns)
-		l = netutil.LimitListener(l, maxConns)
+		l = ingestor.LimitListener(l, maxConns)
 	}
 	defer l.Close()
 

--- a/ingestor/listener.go
+++ b/ingestor/listener.go
@@ -1,0 +1,56 @@
+package ingestor
+
+import (
+	"net"
+	"sync"
+
+	"github.com/Azure/adx-mon/metrics"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener and will drop extra connections.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{Listener: l, sem: make(chan struct{}, n)}
+}
+
+// limitListener is a listener that limits the number of active connections
+// at any given time.
+type limitListener struct {
+	net.Listener
+	sem chan struct{}
+}
+
+func (l *limitListener) release() {
+	<-l.sem
+}
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	for {
+		c, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		select {
+		case l.sem <- struct{}{}:
+			metrics.IngestorActiveConnections.Inc()
+			return &limitListenerConn{Conn: c, release: l.release}, nil
+		default:
+			metrics.IngestorDroppedConnectionsTotal.Inc()
+			c.Close()
+		}
+	}
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	metrics.IngestorActiveConnections.Dec()
+	return err
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,6 +30,20 @@ var (
 		Help:      "Counter of samples stored for an ingestor instance",
 	}, []string{"metric"})
 
+	IngestorActiveConnections = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Subsystem: "ingestor",
+		Name:      "active_connections",
+		Help:      "Gauge indicating the number of active connections for an ingestor instance",
+	})
+
+	IngestorDroppedConnectionsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "ingestor",
+		Name:      "dropped_connections_total",
+		Help:      "Counter of dropped connections for an ingestor instance",
+	})
+
 	IngestorQueueSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: Namespace,
 		Subsystem: "ingestor",


### PR DESCRIPTION
This adds metrics to the listener that limits active connections.