### PR TITLE
Remove upload on shutdown

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -405,11 +405,6 @@ func realMain(ctx *cli.Context) error {
 
 		logger.Infof("Received signal %s, uploading pending segments...", sig.String())
 
-		// Upload pending segments
-		if err := svc.UploadSegments(); err != nil {
-			logger.Errorf("Failed to upload segments: %s", err)
-		}
-
 		// Trigger shutdown of any pending background processes
 		cancel()
 


### PR DESCRIPTION
When ingestor is shutdown, it would attempt to upload any pending segments it had on disk.  It did this to support scaledowns so that data would not be lost.

Unfortunately, there isn't enough time to clean the node for a pod shutdown to it rarely fully completes and just slows down updates.

Since this approach is not reliable, removing it since it just makes
updates slower.   We'll need a differnet way to cordon/drain an ingestor
node before removed permanently.