### PR TITLE
Handle bad request replication errors by dropping the segment

### DIFF
--- a/ingestor/cluster/batcher_test.go
+++ b/ingestor/cluster/batcher_test.go
@@ -407,10 +407,11 @@ func requireValidBatch(t *testing.T, batch []*Batch) {
 
 type fakePartitioner struct {
 	owner string
+	addr  string
 }
 
 func (f *fakePartitioner) Owner(b []byte) (string, string) {
-	return f.owner, ""
+	return f.owner, f.addr
 }
 
 type fakeSegmenter struct {

--- a/ingestor/cluster/client.go
+++ b/ingestor/cluster/client.go
@@ -15,6 +15,17 @@ var (
 	ErrSegmentExists  = fmt.Errorf("segment already exists")
 )
 
+type ErrBadRequest struct {
+	Msg string
+}
+
+func (e ErrBadRequest) Error() string {
+	return fmt.Sprintf("bad request: %s", e.Msg)
+}
+func (e ErrBadRequest) Is(target error) bool {
+	return target == ErrBadRequest{}
+}
+
 type Client struct {
 	httpClient *http.Client
 }
@@ -80,6 +91,10 @@ func (c *Client) Write(ctx context.Context, endpoint string, filename string, bo
 
 		if resp.StatusCode == http.StatusConflict {
 			return ErrSegmentExists
+		}
+
+		if resp.StatusCode == http.StatusBadRequest {
+			return &ErrBadRequest{Msg: fmt.Sprintf("write failed: %s", string(body))}
 		}
 
 		return fmt.Errorf("write failed: %s", string(body))

--- a/ingestor/cluster/client_test.go
+++ b/ingestor/cluster/client_test.go
@@ -1,0 +1,93 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_Write_Success(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "/transfer", r.URL.Path)
+		require.Equal(t, "filename=testfile", r.URL.RawQuery)
+		require.Equal(t, "text/csv", r.Header.Get("Content-Type"))
+		require.Equal(t, "adx-mon", r.Header.Get("User-Agent"))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(time.Second, true)
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.NoError(t, err)
+}
+
+func TestClient_Write_BadRequest(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("bad request error"))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(time.Second, true)
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.Error(t, err)
+	require.IsType(t, &ErrBadRequest{}, err)
+	require.Contains(t, err.Error(), "bad request error")
+	require.True(t, errors.Is(err, ErrBadRequest{}))
+}
+
+func TestClient_Write_TooManyRequests(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(time.Second, true)
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.Error(t, err)
+	require.Equal(t, ErrPeerOverloaded, err)
+	require.True(t, errors.Is(err, ErrPeerOverloaded))
+}
+
+func TestClient_Write_SegmentExists(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(time.Second, true)
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.Error(t, err)
+	require.Equal(t, ErrSegmentExists, err)
+	require.True(t, errors.Is(err, ErrSegmentExists))
+}
+
+func TestClient_Write_HTTPError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(time.Second, true)
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal server error")
+}

--- a/ingestor/cluster/fake.go
+++ b/ingestor/cluster/fake.go
@@ -53,3 +53,22 @@ func (f *FakeReplicator) replicate(ctx context.Context) {
 func (f *FakeReplicator) TransferQueue() chan *Batch {
 	return f.queue
 }
+
+type fakeSegmentRemover struct {
+}
+
+func (f fakeSegmentRemover) Remove(path string) error {
+	return nil
+}
+
+type fakeBatcher struct{}
+
+func (f fakeBatcher) Open(ctx context.Context) error { return nil }
+func (f fakeBatcher) Close() error                   { return nil }
+func (f fakeBatcher) BatchSegments() error           { return nil }
+func (f fakeBatcher) UploadQueueSize() int           { return 0 }
+func (f fakeBatcher) TransferQueueSize() int         { return 0 }
+func (f fakeBatcher) SegmentsTotal() int64           { return 0 }
+func (f fakeBatcher) SegmentsSize() int64            { return 0 }
+func (f fakeBatcher) Release(batch *Batch)           {}
+func (f fakeBatcher) Remove(batch *Batch) error      { return nil }

--- a/ingestor/cluster/replicator_test.go
+++ b/ingestor/cluster/replicator_test.go
@@ -1,0 +1,228 @@
+package cluster
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Azure/adx-mon/pkg/wal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicator_SuccessfulTransfer(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	opts := ReplicatorOpts{
+		Partitioner:        &fakePartitioner{owner: "node2", addr: server.URL},
+		Health:             &fakeHealthChecker{healthy: true},
+		SegmentRemover:     &fakeSegmentRemover{},
+		InsecureSkipVerify: true,
+		Hostname:           "node1",
+	}
+
+	rep, err := NewReplicator(opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rep.Open(ctx)
+	require.NoError(t, err)
+	defer rep.Close()
+
+	segmentPath := filepath.Join(os.TempDir(), "DB_Table_1.wal")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("test"), 0644))
+	batch := &Batch{
+		Segments: []wal.SegmentInfo{
+			{Path: segmentPath},
+		},
+		batcher: &fakeBatcher{},
+	}
+
+	rep.TransferQueue() <- batch
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, rep.Close())
+
+	require.True(t, batch.IsReleased())
+	require.True(t, batch.IsRemoved())
+}
+
+func TestReplicator_BadRequestError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("invalid file name"))
+	}))
+	defer server.Close()
+
+	opts := ReplicatorOpts{
+		Partitioner:        &fakePartitioner{owner: "node2", addr: server.URL},
+		Health:             &fakeHealthChecker{healthy: true},
+		SegmentRemover:     &fakeSegmentRemover{},
+		InsecureSkipVerify: true,
+		Hostname:           "node1",
+	}
+
+	rep, err := NewReplicator(opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rep.Open(ctx)
+	require.NoError(t, err)
+	defer rep.Close()
+
+	segmentPath := filepath.Join(os.TempDir(), "DB_Table_1.wal")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("test"), 0644))
+	batch := &Batch{
+		Segments: []wal.SegmentInfo{
+			{Path: segmentPath},
+		},
+		batcher: &fakeBatcher{},
+	}
+
+	rep.TransferQueue() <- batch
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, rep.Close())
+
+	require.True(t, batch.IsReleased())
+	require.True(t, batch.IsRemoved())
+}
+
+func TestReplicator_SegmentExistsError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+
+	opts := ReplicatorOpts{
+		Partitioner:        &fakePartitioner{owner: "node2", addr: server.URL},
+		Health:             &fakeHealthChecker{healthy: true},
+		SegmentRemover:     &fakeSegmentRemover{},
+		InsecureSkipVerify: true,
+		Hostname:           "node1",
+	}
+
+	rep, err := NewReplicator(opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rep.Open(ctx)
+	require.NoError(t, err)
+	defer rep.Close()
+
+	segmentPath := filepath.Join(os.TempDir(), "DB_Table_1.wal")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("test"), 0644))
+	batch := &Batch{
+		Segments: []wal.SegmentInfo{
+			{Path: segmentPath},
+		},
+		batcher: &fakeBatcher{},
+	}
+
+	rep.TransferQueue() <- batch
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, rep.Close())
+
+	require.True(t, batch.IsReleased())
+	require.True(t, batch.IsRemoved())
+}
+
+func TestReplicator_PeerOverloadedError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	opts := ReplicatorOpts{
+		Partitioner:        &fakePartitioner{owner: "node2", addr: server.URL},
+		Health:             &fakeHealthChecker{healthy: true},
+		SegmentRemover:     &fakeSegmentRemover{},
+		InsecureSkipVerify: true,
+		Hostname:           "node1",
+	}
+
+	rep, err := NewReplicator(opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rep.Open(ctx)
+	require.NoError(t, err)
+	defer rep.Close()
+
+	segmentPath := filepath.Join(os.TempDir(), "DB_Table_1.wal")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("test"), 0644))
+	batch := &Batch{
+		Segments: []wal.SegmentInfo{
+			{Path: segmentPath},
+		},
+		batcher: &fakeBatcher{},
+	}
+
+	rep.TransferQueue() <- batch
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, rep.Close())
+
+	require.True(t, batch.IsReleased())
+	require.False(t, batch.IsRemoved())
+
+}
+
+func TestReplicator_UnknownError(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	opts := ReplicatorOpts{
+		Partitioner:        &fakePartitioner{owner: "node2", addr: server.URL},
+		Health:             &fakeHealthChecker{healthy: true},
+		SegmentRemover:     &fakeSegmentRemover{},
+		InsecureSkipVerify: true,
+		Hostname:           "node1",
+	}
+
+	rep, err := NewReplicator(opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = rep.Open(ctx)
+	require.NoError(t, err)
+	defer rep.Close()
+
+	segmentPath := filepath.Join(os.TempDir(), "DB_Table_1.wal")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("test"), 0644))
+	batch := &Batch{
+		Segments: []wal.SegmentInfo{
+			{Path: segmentPath},
+		},
+		batcher: &fakeBatcher{},
+	}
+
+	rep.TransferQueue() <- batch
+	time.Sleep(100 * time.Millisecond)
+
+	require.NoError(t, rep.Close())
+
+	require.True(t, batch.IsReleased())
+	require.False(t, batch.IsRemoved())
+
+}


### PR DESCRIPTION
If collector or ingestor gets a bad request response from ingestor, this is a fatal error for the client as it will continue to resend the same request over and over.

To prevent this from repeating indefinitely, we log and drop the segment as it's not able to be transferred.