### PR TITLE
Reduce lock contention in WAL

### DIFF
--- a/pkg/wal/repository.go
+++ b/pkg/wal/repository.go
@@ -120,6 +120,16 @@ func (s *Repository) Open(ctx context.Context) error {
 				continue
 			}
 
+			// If the segment is only 8 bytes, that means only the segment magic header has been written and there
+			// is no data in the file.  We don't want to upload these to kusto so they can be removed.
+			if fi.Size() == 8 {
+				logger.Warnf("Removing empty segment: %s", path)
+				if err := os.Remove(path); err != nil {
+					logger.Warnf("Failed to remove empty segment: %s %s", path, err.Error())
+				}
+				continue
+			}
+
 			info := SegmentInfo{
 				Prefix:    prefix,
 				Ulid:      epoch,

--- a/pkg/wal/repository_test.go
+++ b/pkg/wal/repository_test.go
@@ -83,6 +83,7 @@ func TestRepository_Remove(t *testing.T) {
 
 			// Add a closed segment for this WAL.
 			seg, err := wal.NewSegment(dir, "db_foo")
+			require.NoError(t, seg.Write(context.Background(), []byte("bar")))
 			require.NoError(t, err)
 			require.NoError(t, seg.Close())
 


### PR DESCRIPTION
In the write path, a Write lock is needed in the slow path to ensure a segment exists.  This was getting hit more frquently than expected because we roll segments more quickly and the max segment size triggers a rollover more frequently.

To address, this we create a new segment when we rotate proactive so that the slow patch for writes isn't hit as oftent.  The side effect of this is that if writes not frequent, we roll over emtpy segments frequently.  If we try to upload them, they show up as ingestion failures in kusto because the file has no rows.  To address this issue, we just remove the segment if it only contains the segment magic header bytes.