### PR TITLE
Various memory/allocation changes

### DIFF
--- a/collector/service.go
+++ b/collector/service.go
@@ -390,6 +390,7 @@ func (s *Service) Open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	opts := &http.ServerOpts{
 		MaxConns:     s.opts.MaxConnections,
 		WriteTimeout: 30 * time.Second,
@@ -400,6 +401,7 @@ func (s *Service) Open(ctx context.Context) error {
 
 	primaryHttp.RegisterHandler("/metrics", promhttp.Handler())
 	if s.opts.EnablePprof {
+		opts.WriteTimeout = 60 * time.Second
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/", pprof.Index)
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/cmdline", pprof.Cmdline)
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/profile", pprof.Profile)

--- a/ingestor/cluster/replicator_test.go
+++ b/ingestor/cluster/replicator_test.go
@@ -47,7 +47,7 @@ func TestReplicator_SuccessfulTransfer(t *testing.T) {
 	}
 
 	rep.TransferQueue() <- batch
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 
 	require.NoError(t, rep.Close())
 

--- a/ingestor/metrics/handler.go
+++ b/ingestor/metrics/handler.go
@@ -134,7 +134,8 @@ func (s *Handler) HandleReceive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Note: this cause allocations, but holding onto them in a pool causes a lot of memory to be used over time.
-	req := &prompb.WriteRequest{}
+	req := prompb.WriteRequestPool.Get()
+	defer prompb.WriteRequestPool.Put(req)
 	if err := req.Unmarshal(reqBuf); err != nil {
 		m.WithLabelValues(strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/ingestor/transform/transformer.go
+++ b/ingestor/transform/transformer.go
@@ -154,7 +154,7 @@ func (f *RequestTransformer) TransformTimeSeries(v *prompb.TimeSeries) *prompb.T
 	}
 	v.Labels = v.Labels[:i]
 	for _, ll := range f.addLabels {
-		l := &prompb.Label{}
+		l := prompb.LabelPool.Get()
 		l.Name = append(l.Name[:0], ll.Name...)
 		l.Value = append(l.Value[:0], ll.Value...)
 		v.Labels = append(v.Labels, l)

--- a/pkg/prompb/iterator_test.go
+++ b/pkg/prompb/iterator_test.go
@@ -126,8 +126,9 @@ func TestIterator_TimeSeries_Malformed(t *testing.T) {
 			iter := NewIterator(io.NopCloser(strings.NewReader(c)))
 			defer iter.Close()
 
+			ts := &TimeSeries{}
 			require.True(t, iter.Next())
-			_, err := iter.TimeSeries()
+			_, err := iter.TimeSeriesInto(ts)
 			require.Error(t, err)
 		})
 	}
@@ -417,8 +418,9 @@ func TestIterator_TimeSeries(t *testing.T) {
 			iter := NewIterator(io.NopCloser(strings.NewReader(c.input)))
 			defer iter.Close()
 
+			ts := &TimeSeries{}
 			require.True(t, iter.Next())
-			ts, err := iter.TimeSeries()
+			ts, err := iter.TimeSeriesInto(ts)
 			require.NoError(t, err)
 			require.Equal(t, c.want, ts)
 		})

--- a/pkg/prompb/pool.go
+++ b/pkg/prompb/pool.go
@@ -1,0 +1,28 @@
+package prompb
+
+import "sync"
+
+type Resetter interface {
+	Reset()
+}
+
+type Pool[T Resetter] struct {
+	p   *sync.Pool
+	New func() T
+}
+
+func NewPool[T Resetter](new func() T) *Pool[T] {
+	return &Pool[T]{
+		p:   &sync.Pool{New: func() interface{} { return new() }},
+		New: new,
+	}
+}
+
+func (p *Pool[T]) Put(r T) {
+	r.Reset()
+	p.p.Put(r)
+}
+
+func (p *Pool[T]) Get() T {
+	return p.p.Get().(T)
+}

--- a/pkg/prompb/protobuf.go
+++ b/pkg/prompb/protobuf.go
@@ -328,8 +328,8 @@ func (m *Label) Size() (n int) {
 }
 
 func (m *Label) marshalProtobuf(mm *easyproto.MessageMarshaler) {
-	mm.AppendString(1, string(m.Name))
-	mm.AppendString(2, string(m.Value))
+	mm.AppendBytes(1, m.Name)
+	mm.AppendBytes(2, m.Value)
 }
 
 func (m *Label) unmarshalProtobuf(src []byte) (err error) {

--- a/pkg/prompb/protobuf_test.go
+++ b/pkg/prompb/protobuf_test.go
@@ -71,6 +71,35 @@ func TestUnmarshal(t *testing.T) {
 	require.Equal(t, 1.0, wr.Timeseries[0].Samples[0].Value)
 }
 
+func BenchmarkWriteRequestMarshalTo(b *testing.B) {
+	wr := WriteRequest{
+		Timeseries: []*TimeSeries{
+			{
+				Labels: []*Label{
+					{Name: []byte("__name__"), Value: []byte("cpu")},
+					{Name: []byte("instance"), Value: []byte("localhost:9090")},
+					{Name: []byte("job"), Value: []byte("prometheus")},
+					{Name: []byte("region"), Value: []byte("us-west")},
+					{Name: []byte("zone"), Value: []byte("us-west-1a")},
+					{Name: []byte("environment"), Value: []byte("production")},
+				},
+				Samples: []*Sample{
+					{Timestamp: int64(1), Value: 1.0},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf := make([]byte, wr.Size())
+		_, err := wr.MarshalTo(buf[:0])
+		if err != nil {
+			b.Fatalf("MarshalTo failed: %v", err)
+		}
+	}
+}
+
 func formatBytes(b []byte) string {
 	s := ""
 	for i, v := range b {

--- a/pkg/prompb/protobuf_test.go
+++ b/pkg/prompb/protobuf_test.go
@@ -100,6 +100,37 @@ func BenchmarkWriteRequestMarshalTo(b *testing.B) {
 	}
 }
 
+func BenchmarkWriteRequestUnmarshal(b *testing.B) {
+	wr := &WriteRequest{
+		Timeseries: []*TimeSeries{
+			{
+				Labels: []*Label{
+					{Name: []byte("__name__"), Value: []byte("cpu")},
+					{Name: []byte("instance"), Value: []byte("localhost:9090")},
+					{Name: []byte("job"), Value: []byte("prometheus")},
+					{Name: []byte("region"), Value: []byte("us-west")},
+					{Name: []byte("zone"), Value: []byte("us-west-1a")},
+					{Name: []byte("environment"), Value: []byte("production")},
+				},
+				Samples: []*Sample{
+					{Timestamp: int64(1), Value: 1.0},
+				},
+			},
+		},
+	}
+
+	buf, err := wr.Marshal()
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	wr = &WriteRequest{}
+	for i := 0; i < b.N; i++ {
+		wr.Timeseries = nil
+		require.NoError(b, wr.Unmarshal(buf))
+	}
+}
+
 func formatBytes(b []byte) string {
 	s := ""
 	for i, v := range b {

--- a/pkg/prompb/sort_test.go
+++ b/pkg/prompb/sort_test.go
@@ -1,7 +1,9 @@
 package prompb
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +84,41 @@ func BenchmarkIsSorted(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		IsSorted(l)
 	}
+}
+
+func BenchmarkSort(b *testing.B) {
+	// Seed the random number generator
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Generate a slice of random labels
+	labels := make([]*Label, 1000)
+	for i := range labels {
+		labels[i] = &Label{
+			Name:  randomLabelName(rng),
+			Value: randomLabelValue(rng),
+		}
+	}
+	b.ResetTimer()
+
+	// Run the benchmark
+	for n := 0; n < b.N; n++ {
+		// Make a copy of the labels to sort
+		labelsCopy := make([]*Label, len(labels))
+		copy(labelsCopy, labels)
+
+		// Sort the labels
+		Sort(labelsCopy)
+	}
+}
+
+// randomLabelName generates a random Prometheus label name
+func randomLabelName(rng *rand.Rand) []byte {
+	labelNames := []string{"job", "instance", "method", "path", "status", "__name__"}
+	return []byte(labelNames[rng.Intn(len(labelNames))])
+}
+
+// randomLabelValue generates a random Prometheus label value
+func randomLabelValue(rng *rand.Rand) []byte {
+	labelValues := []string{"api-server", "localhost:9090", "GET", "/api/v1/query", "200", "up"}
+	return []byte(labelValues[rng.Intn(len(labelValues))])
 }

--- a/pkg/promremote/client.go
+++ b/pkg/promremote/client.go
@@ -130,7 +130,10 @@ func (c *Client) Write(ctx context.Context, endpoint string, wr *prompb.WriteReq
 		return fmt.Errorf("marshal proto: %w", err)
 	}
 
-	encoded := snappy.Encode(nil, b)
+	b1 := pool.Get(snappy.MaxEncodedLen(len(b)))
+	defer pool.Put(b1)
+
+	encoded := snappy.Encode(b1[:0], b)
 	body := bytes.NewReader(encoded)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/receive", endpoint), body)


### PR DESCRIPTION
See commits for specifics but the main change is using pools for the metrics type we marshal/unmarshal all the time.  