### PR TITLE
Fix log scraping

### DIFF
--- a/build/k8s/collector.yaml
+++ b/build/k8s/collector.yaml
@@ -231,8 +231,8 @@ spec:
               mountPath: /etc/config
             - name: storage
               mountPath: /mnt/data
-            - name: varlogpods
-              mountPath: /var/log/pods
+            - name: varlog
+              mountPath: /var/log
               readOnly: true
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
@@ -261,9 +261,9 @@ spec:
         - name: storage
           hostPath:
             path: /mnt/collector
-        - name: varlogpods
+        - name: varlog
           hostPath:
-            path: /var/log/pods
+            path: /var/log
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
@@ -398,8 +398,8 @@ spec:
               mountPath: /etc/config
             - name: storage
               mountPath: /mnt/data
-            - name: varlogpods
-              mountPath: /var/log/pods
+            - name: varlog
+              mountPath: /var/log
               readOnly: true
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
@@ -426,9 +426,9 @@ spec:
         - name: storage
           hostPath:
             path: /mnt/collector
-        - name: varlogpods
+        - name: varlog
           hostPath:
-            path: /var/log/pods
+            path: /var/log
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers

--- a/collector/logs/sources/tail/pod_target_test.go
+++ b/collector/logs/sources/tail/pod_target_test.go
@@ -68,7 +68,7 @@ func TestGetFileTargets(t *testing.T) {
 			}),
 			expected: []FileTailTarget{
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_container1-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -77,7 +77,7 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":         "pod1",
 						"namespace":   "namespace1",
 						"container":   "container1",
-						"containerID": "docker://container1",
+						"containerID": "docker://container1id",
 					},
 				},
 			},
@@ -91,7 +91,7 @@ func TestGetFileTargets(t *testing.T) {
 			}),
 			expected: []FileTailTarget{
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_container1-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -100,7 +100,7 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":         "pod1",
 						"namespace":   "namespace1",
 						"container":   "container1",
-						"containerID": "docker://container1",
+						"containerID": "docker://container1id",
 					},
 				},
 			},
@@ -126,7 +126,7 @@ func TestGetFileTargets(t *testing.T) {
 			}),
 			expected: []FileTailTarget{
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_container1-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -135,13 +135,13 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":                                    "pod1",
 						"namespace":                              "namespace1",
 						"container":                              "container1",
-						"containerID":                            "docker://container1",
+						"containerID":                            "docker://container1id",
 						"annotation.cni.projectcalico.org/podIP": "10.10.10.10",
 						"label.app":                              "myapp",
 					},
 				},
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/container2/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_container2-container2id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -150,7 +150,7 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":                                    "pod1",
 						"namespace":                              "namespace1",
 						"container":                              "container2",
-						"containerID":                            "docker://container2",
+						"containerID":                            "docker://container2id",
 						"annotation.cni.projectcalico.org/podIP": "10.10.10.10",
 						"label.app":                              "myapp",
 					},
@@ -182,23 +182,27 @@ func TestGetFileTargets(t *testing.T) {
 						{
 							Name: "container1",
 							// Not a real id format
-							ContainerID: "docker://container1",
+							ContainerID: "docker://container1id",
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},
 						},
+					},
+					InitContainerStatuses: []v1.ContainerStatus{
 						{
 							Name: "init-container1",
 							// Not a real id format
-							ContainerID: "docker://init-container1",
+							ContainerID: "docker://init-container1id",
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},
 						},
+					},
+					EphemeralContainerStatuses: []v1.ContainerStatus{
 						{
 							Name: "ephemeral-container1",
 							// Not a real id format
-							ContainerID: "docker://ephemeral-container1",
+							ContainerID: "docker://ephemeral-container1id",
 							State: v1.ContainerState{
 								Running: &v1.ContainerStateRunning{},
 							},
@@ -208,7 +212,7 @@ func TestGetFileTargets(t *testing.T) {
 			},
 			expected: []FileTailTarget{
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_container1-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -217,12 +221,12 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":                                    "pod1",
 						"namespace":                              "namespace1",
 						"container":                              "container1",
-						"containerID":                            "docker://container1",
+						"containerID":                            "docker://container1id",
 						"annotation.cni.projectcalico.org/podIP": "10.10.10.10",
 					},
 				},
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/init-container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_init-container1-init-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -231,12 +235,12 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":                                    "pod1",
 						"namespace":                              "namespace1",
 						"container":                              "init-container1",
-						"containerID":                            "docker://init-container1",
+						"containerID":                            "docker://init-container1id",
 						"annotation.cni.projectcalico.org/podIP": "10.10.10.10",
 					},
 				},
 				{
-					FilePath: fmt.Sprint("/var/log/pods/namespace1_pod1_", uid, "/ephemeral-container1/0.log"),
+					FilePath: "/var/log/containers/pod1_namespace1_ephemeral-container1-ephemeral-container1id.log",
 					Database: "db1",
 					Table:    "table1",
 					LogType:  sourceparse.LogTypeKubernetes,
@@ -245,7 +249,7 @@ func TestGetFileTargets(t *testing.T) {
 						"pod":                                    "pod1",
 						"namespace":                              "namespace1",
 						"container":                              "ephemeral-container1",
-						"containerID":                            "docker://ephemeral-container1",
+						"containerID":                            "docker://ephemeral-container1id",
 						"annotation.cni.projectcalico.org/podIP": "10.10.10.10",
 					},
 				},
@@ -512,7 +516,7 @@ func genPod(name, namespace, nodeName string, containerNames []string, annotatio
 		statuses = append(statuses, v1.ContainerStatus{
 			Name: containerName,
 			// Not a real id format
-			ContainerID: fmt.Sprintf("docker://%s", containerName),
+			ContainerID: fmt.Sprintf("docker://%sid", containerName),
 			State: v1.ContainerState{
 				Running: &v1.ContainerStateRunning{},
 			},
@@ -548,7 +552,7 @@ func genPodWithLabels(name, namespace, nodeName string, containerNames []string,
 		statuses = append(statuses, v1.ContainerStatus{
 			Name: containerName,
 			// Not a real id format
-			ContainerID: fmt.Sprintf("docker://%s", containerName),
+			ContainerID: fmt.Sprintf("docker://%sid", containerName),
 			State: v1.ContainerState{
 				Running: &v1.ContainerStateRunning{},
 			},


### PR DESCRIPTION
This allows us to handle several situations more cleanly. In situations
where containers within a pod crash but do not replace the pod itself,
new containers are created with new container ids. This keeps the same
top-level directory for the pod within /var/log/pods, but it may create
entirely new paths within the directory that do not necessarily follow a
0.log file name convention. Instead, sometimes new files are created as
1.log, etc.

In these cases, the source of truth for the correct file is the file
associated with the correct container id within /var/log/containers
ending in .log. This appears to be stable even in cases where containers
are recreated inline.

This also fixes issues where we were not looking at the correct
ContainerStatuses field for init and ephemeral containers for the
container id.