### PR TITLE
Fix panic/corrupted labels

### DIFF
--- a/ingestor/metrics/handler.go
+++ b/ingestor/metrics/handler.go
@@ -135,7 +135,6 @@ func (s *Handler) HandleReceive(w http.ResponseWriter, r *http.Request) {
 
 	// Note: this cause allocations, but holding onto them in a pool causes a lot of memory to be used over time.
 	req := prompb.WriteRequestPool.Get()
-	defer prompb.WriteRequestPool.Put(req)
 	if err := req.Unmarshal(reqBuf); err != nil {
 		m.WithLabelValues(strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/promremote/client.go
+++ b/pkg/promremote/client.go
@@ -14,6 +14,11 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 )
 
+type RemoteWriteClient interface {
+	Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error
+	CloseIdleConnections()
+}
+
 // Client is a client for the prometheus remote write API.  It is safe to be shared between goroutines.
 type Client struct {
 	httpClient *http.Client

--- a/pkg/promremote/promremote_test.go
+++ b/pkg/promremote/promremote_test.go
@@ -1,0 +1,81 @@
+package promremote
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendBatchWithValidData(t *testing.T) {
+	client := &MockClient{}
+	proxy := NewRemoteWriteProxy(client, []string{"http://example.com"}, 10, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := proxy.Open(ctx)
+	require.NoError(t, err)
+	defer proxy.Close()
+
+	wr := &prompb.WriteRequest{
+		Timeseries: []*prompb.TimeSeries{
+			{
+				Labels: []*prompb.Label{
+					{
+						Name: []byte("test"), Value: []byte("value"),
+					},
+				},
+				Samples: []*prompb.Sample{
+					{
+						Timestamp: time.Now().Unix(), Value: 1.0},
+				},
+			},
+		},
+	}
+
+	err = proxy.Write(ctx, wr)
+	require.NoError(t, err)
+}
+
+func TestSendBatchWithEmptyBatch(t *testing.T) {
+	client := &MockClient{}
+	proxy := NewRemoteWriteProxy(client, []string{"http://example.com"}, 1, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := proxy.Open(ctx)
+	require.NoError(t, err)
+	defer proxy.Close()
+
+	wr := &prompb.WriteRequest{
+		Timeseries: []*prompb.TimeSeries{
+			{
+				Labels: []*prompb.Label{
+					{Name: []byte("test"), Value: []byte("value")},
+				},
+				Samples: []*prompb.Sample{
+					{Timestamp: time.Now().Unix(), Value: 1.0},
+				},
+			},
+			{
+				Samples: []*prompb.Sample{
+					{Timestamp: time.Now().Unix(), Value: 1.0},
+				},
+			},
+		},
+	}
+
+	err = proxy.Write(ctx, wr)
+	require.NoError(t, err)
+
+}
+
+type MockClient struct{}
+
+func (m *MockClient) CloseIdleConnections() {}
+
+func (m *MockClient) Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error {
+	return nil
+}


### PR DESCRIPTION
The metrics proxy was incorrectly adding the WriteRequest back to
the pool since it was done wit it.  This is usually the right path
but in the proxy path, the writes are buffered and flushed in batches
so the request is not actually void of uses.  This causes a panic
and label corruption if the request and timeseries are reused again
while they are cached.