### PR TITLE
Don't double release TimeSeries to pool

### DIFF
--- a/pkg/prompb/protobuf.go
+++ b/pkg/prompb/protobuf.go
@@ -333,8 +333,8 @@ func (m *Label) marshalProtobuf(mm *easyproto.MessageMarshaler) {
 
 func (m *Label) unmarshalProtobuf(src []byte) (err error) {
 	// Set default Sample values
-	m.Name = nil
-	m.Value = nil
+	m.Name = m.Name[:0]
+	m.Value = m.Value[:0]
 
 	// Parse Sample message at src
 	var fc easyproto.FieldContext
@@ -349,13 +349,13 @@ func (m *Label) unmarshalProtobuf(src []byte) (err error) {
 			if !ok {
 				return fmt.Errorf("cannot read sample value")
 			}
-			m.Name = name
+			m.Name = append(m.Name[:0], name...)
 		case 2:
 			value, ok := fc.Bytes()
 			if !ok {
 				return fmt.Errorf("cannot read sample value")
 			}
-			m.Value = value
+			m.Value = append(m.Value[:0], value...)
 		}
 	}
 	return nil

--- a/pkg/promremote/proxy.go
+++ b/pkg/promremote/proxy.go
@@ -118,9 +118,8 @@ func (c *RemoteWriteProxy) flush(ctx context.Context) {
 			}
 			nextBatch := prompb.WriteRequestPool.Get()
 			nextBatch.Timeseries = append(nextBatch.Timeseries, pendingBatch.Timeseries...)
-
+			pendingBatch.Timeseries = append(pendingBatch.Timeseries[:0])
 			c.ready <- nextBatch
-			pendingBatch.Reset()
 		}
 	}
 }


### PR DESCRIPTION
The time based flushing called reset on the WriteRequest which release all TimeSeries back to the pool.  The same TimeSeries are also released by sendBatch which causes them to be added to the pool twice which cause all kinds of bad stuff.