### PR TITLE
Update replicator client to restrict connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/VictoriaMetrics/easyproto v0.1.4
 	github.com/bufbuild/connect-go v1.10.0
 	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/davidnarayan/go-flake v0.0.0-20180604195229-c680a61bf75c
 	github.com/golang-jwt/jwt/v5 v5.2.1
@@ -59,7 +60,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/ingestor/cluster/client.go
+++ b/ingestor/cluster/client.go
@@ -28,27 +28,107 @@ func (e ErrBadRequest) Is(target error) bool {
 
 type Client struct {
 	httpClient *http.Client
+	opts       ClientOpts
 }
 
-func NewClient(timeout time.Duration, insecureSkipVerify bool) (*Client, error) {
+type ClientOpts struct {
+	// Close controls whether the client closes the connection after each request.
+	Close bool
+
+	// Timeout is the timeout for the http client and the http request.
+	Timeout time.Duration
+
+	// InsecureSkipVerify controls whether the client verifies the server's certificate chain and host name.
+	InsecureSkipVerify bool
+
+	// IdleConnTimeout is the maximum amount of time an idle (keep-alive) connection
+	// will remain idle before closing itself.
+	IdleConnTimeout time.Duration
+
+	// ResponseHeaderTimeout is the amount of time to wait for a server's response headers
+	// after fully writing the request (including its body, if any).
+	ResponseHeaderTimeout time.Duration
+
+	// MaxIdleConns controls the maximum number of idle (keep-alive) connections across all hosts.
+	MaxIdleConns int
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle (keep-alive) per host.
+	MaxIdleConnsPerHost int
+
+	// MaxConnsPerHost, if non-zero, controls the maximum connections per host.
+	MaxConnsPerHost int
+
+	// TLSHandshakeTimeout specifies the maximum amount of time to
+	// wait for a TLS handshake. Zero means no timeout.
+	TLSHandshakeTimeout time.Duration
+
+	// DisableHTTP2 controls whether the client disables HTTP/2 support.
+	DisableHTTP2 bool
+
+	// DisableKeepAlives controls whether the client disables HTTP keep-alives.
+	DisableKeepAlives bool
+}
+
+func (c ClientOpts) WithDefaults() ClientOpts {
+	if c.Timeout == 0 {
+		c.Timeout = 10 * time.Second
+	}
+	if c.IdleConnTimeout == 0 {
+		c.IdleConnTimeout = 1 * time.Minute
+	}
+	if c.ResponseHeaderTimeout == 0 {
+		c.ResponseHeaderTimeout = 10 * time.Second
+	}
+
+	if c.MaxIdleConns == 0 {
+		c.MaxIdleConns = 100
+	}
+
+	if c.MaxIdleConnsPerHost == 0 {
+		c.MaxIdleConnsPerHost = 5
+	}
+
+	if c.MaxConnsPerHost == 0 {
+		c.MaxConnsPerHost = 5
+	}
+
+	if c.TLSHandshakeTimeout == 0 {
+		c.TLSHandshakeTimeout = 10 * time.Second
+	}
+
+	return c
+}
+
+func NewClient(opts ClientOpts) (*Client, error) {
+	opts = opts.WithDefaults()
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.MaxIdleConns = 100
-	t.MaxConnsPerHost = 100
-	t.MaxIdleConnsPerHost = 100
-	t.ResponseHeaderTimeout = timeout
-	t.IdleConnTimeout = time.Minute
+	t.MaxIdleConns = opts.MaxIdleConns
+	t.MaxConnsPerHost = opts.MaxConnsPerHost
+	t.MaxIdleConnsPerHost = opts.MaxIdleConnsPerHost
+	t.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
+	t.IdleConnTimeout = opts.IdleConnTimeout
 	if t.TLSClientConfig == nil {
 		t.TLSClientConfig = &tls.Config{}
 	}
-	t.TLSClientConfig.InsecureSkipVerify = insecureSkipVerify
+	t.TLSClientConfig.InsecureSkipVerify = opts.InsecureSkipVerify
+	t.TLSHandshakeTimeout = opts.TLSHandshakeTimeout
+	t.DisableKeepAlives = opts.DisableKeepAlives
+
+	if opts.DisableHTTP2 {
+		t.ForceAttemptHTTP2 = false
+		t.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify}
+		t.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	}
 
 	httpClient := &http.Client{
-		Timeout:   timeout,
+		Timeout:   opts.Timeout,
 		Transport: t,
 	}
 
 	return &Client{
 		httpClient: httpClient,
+		opts:       opts,
 	}, nil
 }
 

--- a/ingestor/cluster/client_test.go
+++ b/ingestor/cluster/client_test.go
@@ -23,7 +23,10 @@ func TestClient_Write_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(time.Second, true)
+	client, err := NewClient(ClientOpts{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
@@ -37,7 +40,10 @@ func TestClient_Write_BadRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(time.Second, true)
+	client, err := NewClient(ClientOpts{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
@@ -53,7 +59,10 @@ func TestClient_Write_TooManyRequests(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(time.Second, true)
+	client, err := NewClient(ClientOpts{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
@@ -68,7 +77,10 @@ func TestClient_Write_SegmentExists(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(time.Second, true)
+	client, err := NewClient(ClientOpts{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
@@ -84,7 +96,10 @@ func TestClient_Write_HTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient(time.Second, true)
+	client, err := NewClient(ClientOpts{
+		Timeout:            time.Second,
+		InsecureSkipVerify: true,
+	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))

--- a/ingestor/cluster/replicator.go
+++ b/ingestor/cluster/replicator.go
@@ -57,7 +57,16 @@ type replicator struct {
 }
 
 func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
-	cli, err := NewClient(30*time.Second, opts.InsecureSkipVerify)
+	cli, err := NewClient(ClientOpts{
+		Timeout:               30 * time.Second,
+		InsecureSkipVerify:    opts.InsecureSkipVerify,
+		Close:                 false,
+		MaxIdleConnsPerHost:   1,
+		MaxIdleConns:          5,
+		ResponseHeaderTimeout: 20 * time.Second,
+		DisableHTTP2:          true,
+		DisableKeepAlives:     true,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since we're transferring more segments from collector, the default settings use a lot more connections and trigger TLS handshake errors more often.