### PR TITLE
Include endpoint in failed query correlation id

### DIFF
--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -137,15 +137,16 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 			return
 		}
 
+		endpointBaseName, _ := strings.CutPrefix(e.kustoClient.Endpoint(e.rule.Database), "https://")
 		if err := e.AlertCli.Create(ctx, e.AlertAddr, alert.Alert{
 			Destination:   e.rule.Destination,
 			Title:         fmt.Sprintf("Alert %s/%s has query errors on %s", e.rule.Namespace, e.rule.Name, e.kustoClient.Endpoint(e.rule.Database)),
 			Summary:       summary,
 			Severity:      3,
 			Source:        fmt.Sprintf("%s/%s", e.rule.Namespace, e.rule.Name),
-			CorrelationID: fmt.Sprintf("alert-failure/%s/%s", e.rule.Namespace, e.rule.Name),
+			CorrelationID: fmt.Sprintf("alert-failure/%s/%s/%s", endpointBaseName, e.rule.Namespace, e.rule.Name),
 		}); err != nil {
-			logger.Errorf("Failed to send failure alert for %s/%s: %s", e.rule.Namespace, e.rule.Name, err)
+			logger.Errorf("Failed to send failure alert for %s/%s/%s: %s", endpointBaseName, e.rule.Namespace, e.rule.Name, err)
 			// Only set the notification as failed if we are not able to send a failure alert directly.
 			metrics.NotificationUnhealthy.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(1)
 			return


### PR DESCRIPTION
In scaled situations where multiple alerters are running against different ADX clusters, it is useful to include the ADX endpoint in the correlation id like we do the title to distinguish between different deployments.