### PR TITLE
Move CRD storage to a shared location

### DIFF
--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -2,16 +2,17 @@ package engine
 
 import (
 	"fmt"
-	"github.com/Azure/adx-mon/alerter/rules"
+	"strings"
+	"time"
+
+	"github.com/Azure/adx-mon/pkg/crds"
 	"github.com/Azure/azure-kusto-go/kusto"
 	kustotypes "github.com/Azure/azure-kusto-go/kusto/data/types"
 	"github.com/Azure/azure-kusto-go/kusto/unsafe"
-	"strings"
-	"time"
 )
 
 type QueryContext struct {
-	Rule      *rules.Rule
+	Rule      *crds.Rule
 	Query     string
 	Stmt      kusto.Stmt
 	Params    kusto.Parameters
@@ -20,7 +21,7 @@ type QueryContext struct {
 	EndTime   time.Time
 }
 
-func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*QueryContext, error) {
+func NewQueryContext(rule *crds.Rule, endTime time.Time, region string) (*QueryContext, error) {
 	qc := &QueryContext{
 		Rule:      rule,
 		Region:    region,

--- a/alerter/engine/context_test.go
+++ b/alerter/engine/context_test.go
@@ -1,14 +1,15 @@
 package engine
 
 import (
-	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/Azure/adx-mon/pkg/crds"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewQueryContext_MgmtQuery(t *testing.T) {
-	r := &rules.Rule{IsMgmtQuery: true, Query: "fake query unchanged"}
+	r := &crds.Rule{IsMgmtQuery: true, Query: "fake query unchanged"}
 	qc, err := NewQueryContext(r, time.Now(), "region")
 	require.NoError(t, err)
 	require.Equal(t, "fake query unchanged", qc.Query)
@@ -29,7 +30,7 @@ func TestNewQueryContext_QueryWrapped(t *testing.T) {
 			exp:   "\nlet _startTime = datetime(2023-04-09T23:00:00Z);\nlet _endTime = datetime(2023-04-10T00:00:00Z);\nlet _region = \"region\";\nFoo | limit 1\n",
 		},
 	} {
-		r := &rules.Rule{Query: tt.query, Interval: time.Hour}
+		r := &crds.Rule{Query: tt.query, Interval: time.Hour}
 		qc, err := NewQueryContext(r, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "region")
 		require.NoError(t, err)
 		require.Equal(t, tt.exp, qc.Query)

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -11,15 +11,15 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/alerter/alert"
-	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/metrics"
+	"github.com/Azure/adx-mon/pkg/crds"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
 	kustovalues "github.com/Azure/azure-kusto-go/kusto/data/value"
 )
 
 type ruleStore interface {
-	Rules() []*rules.Rule
+	Rules() []*crds.Rule
 }
 
 type AlertCli interface {
@@ -75,11 +75,11 @@ func (e *Executor) Open(ctx context.Context) error {
 	return nil
 }
 
-func (e *Executor) workerKey(rule *rules.Rule) string {
+func (e *Executor) workerKey(rule *crds.Rule) string {
 	return fmt.Sprintf("%s/%s", rule.Namespace, rule.Name)
 }
 
-func (e *Executor) newWorker(rule *rules.Rule) *worker {
+func (e *Executor) newWorker(rule *crds.Rule) *worker {
 	lowerTags := make(map[string]string, len(e.tags))
 	for k, v := range e.tags {
 		lowerTags[strings.ToLower(k)] = strings.ToLower(v)

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/alerter/alert"
-	"github.com/Azure/adx-mon/alerter/rules"
+	"github.com/Azure/adx-mon/pkg/crds"
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
 	"github.com/Azure/azure-kusto-go/kusto/data/types"
@@ -19,7 +19,7 @@ func TestExecutor_Handler_MissingTitle(t *testing.T) {
 		alertCli: &fakeAlertClient{},
 	}
 
-	rule := &rules.Rule{}
+	rule := &crds.Rule{}
 	qc := &QueryContext{
 		Rule: rule,
 	}
@@ -139,7 +139,7 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 				alertCli: client,
 			}
 
-			rule := &rules.Rule{}
+			rule := &crds.Rule{}
 			qc := &QueryContext{
 				Rule: rule,
 			}
@@ -191,7 +191,7 @@ func TestExecutor_syncWorkers_Add(t *testing.T) {
 	e := Executor{
 		closeFn: cancel,
 		ruleStore: &fakeRuleStore{
-			rules: []*rules.Rule{
+			rules: []*crds.Rule{
 				{
 					Name:     "alert",
 					Interval: 10 * time.Second,
@@ -212,7 +212,7 @@ func TestExecutor_syncWorkers_NoChange(t *testing.T) {
 	e := Executor{
 		closeFn: cancel,
 		ruleStore: &fakeRuleStore{
-			rules: []*rules.Rule{
+			rules: []*crds.Rule{
 				{
 					Name:     "alert",
 					Interval: 10 * time.Second,
@@ -233,7 +233,7 @@ func TestExecutor_syncWorkers_NoChange(t *testing.T) {
 func TestExecutor_syncWorkers_Changed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	store := &fakeRuleStore{
-		rules: []*rules.Rule{
+		rules: []*crds.Rule{
 			{
 				Name:      "alert",
 				Namespace: "foo",
@@ -251,7 +251,7 @@ func TestExecutor_syncWorkers_Changed(t *testing.T) {
 	require.Equal(t, 0, len(e.workers))
 	e.syncWorkers(ctx)
 	require.Equal(t, 1, len(e.workers))
-	store.rules[0] = &rules.Rule{
+	store.rules[0] = &crds.Rule{
 		Version:   "changed",
 		Name:      "alert",
 		Namespace: "foo",
@@ -271,9 +271,9 @@ func (f *fakeAlertClient) Create(ctx context.Context, endpoint string, alert ale
 }
 
 type fakeRuleStore struct {
-	rules []*rules.Rule
+	rules []*crds.Rule
 }
 
-func (f *fakeRuleStore) Rules() []*rules.Rule {
+func (f *fakeRuleStore) Rules() []*crds.Rule {
 	return f.rules
 }

--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/queue"
-	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/metrics"
+	"github.com/Azure/adx-mon/pkg/crds"
 	"github.com/Azure/adx-mon/pkg/logger"
 	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
@@ -26,7 +26,7 @@ type worker struct {
 	cancel context.CancelFunc
 
 	wg          sync.WaitGroup
-	rule        *rules.Rule
+	rule        *crds.Rule
 	Region      string
 	tags        map[string]string
 	kustoClient Client

--- a/alerter/engine/worker_test.go
+++ b/alerter/engine/worker_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/alerter/alert"
-	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/metrics"
+	"github.com/Azure/adx-mon/pkg/crds"
 	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,7 +43,7 @@ func TestWorker_TagsMismatch(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 		Criteria: map[string][]string{
@@ -87,7 +87,7 @@ func TestWorker_TagsAtLeastOne(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 		Criteria: map[string][]string{
@@ -133,7 +133,7 @@ func TestWorker_TagsNoneMatch(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 		Criteria: map[string][]string{
@@ -179,7 +179,7 @@ func TestWorker_TagsMultiple(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 		Criteria: map[string][]string{
@@ -244,7 +244,7 @@ func TestWorker_ServerError(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -278,7 +278,7 @@ func TestWorker_ConnectionReset(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -313,7 +313,7 @@ func TestWorker_ContextTimeout(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -350,7 +350,7 @@ func TestWorker_RequestInvalid(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -386,7 +386,7 @@ func TestWorker_UnknownDB(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -422,7 +422,7 @@ func TestWorker_MissingColumnsFromResults(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace: "namespace",
 		Name:      "name",
 	}
@@ -458,7 +458,7 @@ func TestWorker_AlertsThrottled(t *testing.T) {
 		},
 	}
 
-	rule := &rules.Rule{
+	rule := &crds.Rule{
 		Namespace:   "namespace",
 		Name:        "name",
 		Destination: "destination/queue",

--- a/pkg/crds/localStore.go
+++ b/pkg/crds/localStore.go
@@ -1,4 +1,4 @@
-package rules
+package crds
 
 import (
 	"bytes"

--- a/pkg/crds/localStore_test.go
+++ b/pkg/crds/localStore_test.go
@@ -1,4 +1,4 @@
-package rules
+package crds
 
 import (
 	"os"


### PR DESCRIPTION
We're about to introduce a new CRD that will enable users to specify KQL Views to support custom schema definitions. This change moves our Rule CRD handling into a shared location ahead of the introduction of a new TableView CRD. There should be no functional difference in this change, it's just broken up to make reviewing easier.