### PR TITLE
Remove some redundant code

### DIFF
--- a/ingestor/transform/transformer.go
+++ b/ingestor/transform/transformer.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"sync"
 
@@ -57,7 +56,6 @@ func (f *RequestTransformer) init() {
 				Name:  []byte(k),
 				Value: []byte(v),
 			})
-			f.DropLabels[regexp.MustCompile(fmt.Sprintf("^%s\\b", k))] = regexp.MustCompile(".*")
 		}
 		prompb.Sort(addLabelsSlice)
 		f.addLabels = addLabelsSlice
@@ -146,10 +144,7 @@ func (f *RequestTransformer) TransformTimeSeries(v *prompb.TimeSeries) *prompb.T
 	}
 	v.Labels = v.Labels[:i]
 	for _, ll := range f.addLabels {
-		l := prompb.LabelPool.Get()
-		l.Name = append(l.Name[:0], ll.Name...)
-		l.Value = append(l.Value[:0], ll.Value...)
-		v.Labels = append(v.Labels, l)
+		v.AppendLabel(ll.Name, ll.Value)
 	}
 
 	prompb.Sort(v.Labels)


### PR DESCRIPTION
We don't need to add drop labels for corresponding match labels because we already handle that case.  This just add unnecessary regex matches on every label that are not needed.