### PR TITLE
Better handle missing containerids

### DIFF
--- a/collector/logs/sources/tail/pod_discovery.go
+++ b/collector/logs/sources/tail/pod_discovery.go
@@ -206,8 +206,10 @@ func (i *PodDiscovery) tombstoneTarget(existingCurrentTarget *currenttarget) {
 
 	// We don't want to just tell tailsource to stop tailing when the file reaches EOF because the file
 	// may be written to again in the "future" and perhaps even rotated.
-	logger.Infof("Tombstoning target %s", existingCurrentTarget.CurrentTarget.FilePath)
-	existingCurrentTarget.ExpireTime = i.nowFunc().Add(1 * time.Minute)
+	if existingCurrentTarget.ExpireTime.IsZero() {
+		logger.Infof("Tombstoning target %s", existingCurrentTarget.CurrentTarget.FilePath)
+		existingCurrentTarget.ExpireTime = i.nowFunc().Add(1 * time.Minute)
+	}
 }
 
 func (i *PodDiscovery) cleanTombstonedTargets() {

--- a/collector/logs/sources/tail/pod_target.go
+++ b/collector/logs/sources/tail/pod_target.go
@@ -172,7 +172,8 @@ func isTargetChanged(old, new FileTailTarget) bool {
 func getContainerID(containerStatuses []v1.ContainerStatus, containerName string) (string, bool) {
 	for _, container := range containerStatuses {
 		if container.Name == containerName {
-			return container.ContainerID, true
+			containerIdPopulated := container.ContainerID != ""
+			return container.ContainerID, containerIdPopulated
 		}
 	}
 	return "", false


### PR DESCRIPTION
There are cases when we are notified of a new container and there is a ContainerStatus object that matches the container, but the container is not running yet so it does not have a containerID property within it yet. This messes up our state machine where we attempt to tail the wrong file without a containerID as part of the file path.