### PR TITLE
CPU Usage Reduction

### DIFF
--- a/cmd/collector/config_test.go
+++ b/cmd/collector/config_test.go
@@ -896,3 +896,42 @@ func TestConfig_ValidateLiftLabels(t *testing.T) {
 		}}
 	require.NoError(t, c.Validate())
 }
+
+func TestConfig_WALFlushInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval int
+		wantErr  bool
+	}{
+		{
+			name:     "WALFlushIntervalGreaterThanZero",
+			interval: 100,
+			wantErr:  false,
+		},
+		{
+			name:     "WALFlushIntervalZero",
+			interval: 100,
+			wantErr:  false,
+		},
+		{
+			name:     "WALFlushIntervalNegative",
+			interval: -100,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{
+				WALFlushIntervalMilliSeconds: tt.interval,
+			}
+			err := c.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, "wal-flush-interval must be greater than 0", err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -308,6 +308,7 @@ func realMain(ctx *cli.Context) error {
 		MaxSegmentAge:      time.Duration(cfg.MaxSegmentAgeSeconds) * time.Second,
 		MaxSegmentSize:     cfg.MaxSegmentSize,
 		MaxDiskUsage:       cfg.MaxDiskUsage,
+		WALFlushInterval:   time.Duration(cfg.WALFlushIntervalMilliSeconds) * time.Millisecond,
 		Region:             cfg.Region,
 		StorageDir:         cfg.StorageDir,
 	}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -529,7 +529,7 @@ var (
 func (a *writerAdapter) Write(data []byte) (int, error) {
 	// Ignore TLS handshake errors that results in just a closed connection.  Load balancer
 	// health checks will cause this error to be logged.
-	if bytes.Contains(data, tlsHandshakeError) && bytes.Contains(data, ioEOFError) {
+	if bytes.Contains(data, tlsHandshakeError) && bytes.Contains(data, ioEOFError) || bytes.Contains(data, []byte("connection reset by peer")) {
 		return len(data), nil
 	}
 	return a.Writer.Write(data)

--- a/collector/service.go
+++ b/collector/service.go
@@ -119,6 +119,12 @@ type ServiceOpts struct {
 	Region string
 
 	MaxConnections int
+
+	// WALFlushInterval is the interval at which the WAL segment is flushed to disk.  A higher value results in
+	// better disk IO and less CPU usage but has a greater risk of data loss in the event of a crash.  A lower
+	// value results in more frequent disk IO and higher CPU usage but less data loss in the event of a crash.
+	// The default is 100ms and the value must be greater than 0.
+	WALFlushInterval time.Duration
 }
 
 type OtlpMetricsHandlerOpts struct {
@@ -184,6 +190,7 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 		LiftedLabels:     opts.LiftLabels,
 		LiftedAttributes: opts.LiftAttributes,
 		LiftedResources:  opts.LiftResources,
+		WALFlushInterval: opts.WALFlushInterval,
 	})
 
 	logsSvc := otlp.NewLogsService(otlp.LogsServiceOpts{

--- a/ingestor/cluster/replicator.go
+++ b/ingestor/cluster/replicator.go
@@ -63,9 +63,10 @@ func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
 		Close:                 false,
 		MaxIdleConnsPerHost:   1,
 		MaxIdleConns:          5,
+		IdleConnTimeout:       90 * time.Second,
 		ResponseHeaderTimeout: 20 * time.Second,
 		DisableHTTP2:          true,
-		DisableKeepAlives:     true,
+		DisableKeepAlives:     false,
 	})
 	if err != nil {
 		return nil, err

--- a/ingestor/metrics/handler.go
+++ b/ingestor/metrics/handler.go
@@ -101,8 +101,6 @@ func (s *Handler) HandleReceive(w http.ResponseWriter, r *http.Request) {
 			logger.Errorf("close http body: %s, path=%s duration=%s", err.Error(), s.Path, time.Since(start).String())
 		}
 	}()
-	r.Close = true
-	w.Header().Set("Connection", "close")
 
 	if !s.health.IsHealthy() {
 		m.WithLabelValues(strconv.Itoa(http.StatusTooManyRequests)).Inc()

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -16,6 +16,7 @@ import (
 	metricsHandler "github.com/Azure/adx-mon/ingestor/metrics"
 	"github.com/Azure/adx-mon/ingestor/otlp"
 	"github.com/Azure/adx-mon/metrics"
+	adxhttp "github.com/Azure/adx-mon/pkg/http"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/scheduler"
 	"github.com/Azure/adx-mon/pkg/wal"
@@ -300,16 +301,22 @@ func (s *Service) Close() error {
 
 // HandleReceive handles the prometheus remote write requests and writes them to the store.
 func (s *Service) HandleReceive(w http.ResponseWriter, r *http.Request) {
+	adxhttp.MaybeCloseConnection(w, r)
+
 	s.handler.HandleReceive(w, r)
 }
 
 // HandleLogs handles OTLP logs requests and writes them to the store.
 func (s *Service) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	adxhttp.MaybeCloseConnection(w, r)
+
 	s.logsHandler.ServeHTTP(w, r)
 }
 
 // HandleTransfer handles the transfer WAL segments from other nodes in the cluster.
 func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
+	adxhttp.MaybeCloseConnection(w, r)
+
 	start := time.Now()
 	m := metrics.RequestsReceived.MustCurryWith(prometheus.Labels{"path": "/transfer"})
 	filename := r.URL.Query().Get("filename")

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+type ClientOpts struct {
+	// Close controls whether the client closes the connection after each request.
+	Close bool
+
+	// Timeout is the timeout for the http client and the http request.
+	Timeout time.Duration
+
+	// InsecureSkipVerify controls whether the client verifies the server's certificate chain and host name.
+	InsecureSkipVerify bool
+
+	// IdleConnTimeout is the maximum amount of time an idle (keep-alive) connection
+	// will remain idle before closing itself.
+	IdleConnTimeout time.Duration
+
+	// ResponseHeaderTimeout is the amount of time to wait for a server's response headers
+	// after fully writing the request (including its body, if any).
+	ResponseHeaderTimeout time.Duration
+
+	// MaxIdleConns controls the maximum number of idle (keep-alive) connections across all hosts.
+	MaxIdleConns int
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle (keep-alive) per host.
+	MaxIdleConnsPerHost int
+
+	// MaxConnsPerHost, if non-zero, controls the maximum connections per host.
+	MaxConnsPerHost int
+
+	// TLSHandshakeTimeout specifies the maximum amount of time to
+	// wait for a TLS handshake. Zero means no timeout.
+	TLSHandshakeTimeout time.Duration
+
+	// DisableHTTP2 controls whether the client disables HTTP/2 support.
+	DisableHTTP2 bool
+
+	// DisableKeepAlives controls whether the client disables HTTP keep-alives.
+	DisableKeepAlives bool
+}
+
+func (c ClientOpts) WithDefaults() ClientOpts {
+	if c.Timeout == 0 {
+		c.Timeout = 10 * time.Second
+	}
+	if c.IdleConnTimeout == 0 {
+		c.IdleConnTimeout = 1 * time.Minute
+	}
+	if c.ResponseHeaderTimeout == 0 {
+		c.ResponseHeaderTimeout = 10 * time.Second
+	}
+
+	if c.MaxIdleConns == 0 {
+		c.MaxIdleConns = 100
+	}
+
+	if c.MaxIdleConnsPerHost == 0 {
+		c.MaxIdleConnsPerHost = 5
+	}
+
+	if c.MaxConnsPerHost == 0 {
+		c.MaxConnsPerHost = 5
+	}
+
+	if c.TLSHandshakeTimeout == 0 {
+		c.TLSHandshakeTimeout = 10 * time.Second
+	}
+
+	return c
+}
+
+func NewClient(opts ClientOpts) *http.Client {
+	opts = opts.WithDefaults()
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = opts.MaxIdleConns
+	t.MaxConnsPerHost = opts.MaxConnsPerHost
+	t.MaxIdleConnsPerHost = opts.MaxIdleConnsPerHost
+	t.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
+	t.IdleConnTimeout = opts.IdleConnTimeout
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	t.TLSClientConfig.InsecureSkipVerify = opts.InsecureSkipVerify
+	t.TLSHandshakeTimeout = opts.TLSHandshakeTimeout
+	t.DisableKeepAlives = opts.DisableKeepAlives
+
+	if http2Transport, err := http2.ConfigureTransports(t); err == nil {
+		// if the connection has been idle for 10 seconds, send a ping frame for a health check
+		http2Transport.ReadIdleTimeout = 10 * time.Second
+		// if there's no response to the ping within 2 seconds, close the connection
+		http2Transport.PingTimeout = 2 * time.Second
+		http2Transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: opts.InsecureSkipVerify,
+		}
+	}
+
+	if opts.DisableHTTP2 {
+		t.ForceAttemptHTTP2 = false
+		t.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify}
+		t.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	}
+
+	return &http.Client{
+		Timeout:   opts.Timeout,
+		Transport: t,
+	}
+}

--- a/pkg/http/randomizer.go
+++ b/pkg/http/randomizer.go
@@ -6,7 +6,7 @@ import (
 )
 
 // closeEvery is the chance that a request will be closed.
-const closeEvery = 10000 // every 1000 requests will be closed
+const closeEvery = 10000 // every 10000 requests will be closed
 
 var counter uint64
 

--- a/pkg/http/randomizer.go
+++ b/pkg/http/randomizer.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// closeEvery is the chance that a request will be closed.
+const closeEvery = 10000 // every 1000 requests will be closed
+
+var counter uint64
+
+func MaybeCloseConnection(w http.ResponseWriter, r *http.Request) {
+	if atomic.AddUint64(&counter, 1)%closeEvery == 0 {
+		r.Close = true
+		w.Header().Set("Connection", "close")
+	}
+}

--- a/pkg/promremote/client.go
+++ b/pkg/promremote/client.go
@@ -3,13 +3,13 @@ package promremote
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	adxhttp "github.com/Azure/adx-mon/pkg/http"
 	"github.com/Azure/adx-mon/pkg/prompb"
 	"github.com/golang/snappy"
 )
@@ -102,31 +102,18 @@ func (c ClientOpts) WithDefaults() ClientOpts {
 }
 
 func NewClient(opts ClientOpts) (*Client, error) {
-	opts = opts.WithDefaults()
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.MaxIdleConns = opts.MaxIdleConns
-	t.MaxConnsPerHost = opts.MaxConnsPerHost
-	t.MaxIdleConnsPerHost = opts.MaxIdleConnsPerHost
-	t.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
-	t.IdleConnTimeout = opts.IdleConnTimeout
-	if t.TLSClientConfig == nil {
-		t.TLSClientConfig = &tls.Config{}
-	}
-	t.TLSClientConfig.InsecureSkipVerify = opts.InsecureSkipVerify
-	t.TLSHandshakeTimeout = opts.TLSHandshakeTimeout
-	t.DisableKeepAlives = opts.DisableKeepAlives
-
-	if opts.DisableHTTP2 {
-		t.ForceAttemptHTTP2 = false
-		t.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
-		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: opts.InsecureSkipVerify}
-		t.TLSClientConfig.NextProtos = []string{"http/1.1"}
-	}
-
-	httpClient := &http.Client{
-		Timeout:   opts.Timeout,
-		Transport: t,
-	}
+	httpClient := adxhttp.NewClient(
+		adxhttp.ClientOpts{
+			Timeout:               opts.Timeout,
+			InsecureSkipVerify:    opts.InsecureSkipVerify,
+			Close:                 opts.Close,
+			MaxIdleConnsPerHost:   opts.MaxIdleConnsPerHost,
+			MaxIdleConns:          opts.MaxIdleConns,
+			IdleConnTimeout:       opts.IdleConnTimeout,
+			ResponseHeaderTimeout: opts.ResponseHeaderTimeout,
+			DisableHTTP2:          opts.DisableHTTP2,
+			DisableKeepAlives:     opts.DisableKeepAlives,
+		})
 
 	return &Client{
 		httpClient: httpClient,

--- a/pkg/wal/repository.go
+++ b/pkg/wal/repository.go
@@ -29,8 +29,9 @@ type RepositoryOpts struct {
 	SegmentMaxSize int64
 	SegmentMaxAge  time.Duration
 
-	MaxDiskUsage    int64
-	MaxSegmentCount int
+	MaxDiskUsage     int64
+	MaxSegmentCount  int
+	WALFlushInterval time.Duration
 }
 
 func NewRepository(opts RepositoryOpts) *Repository {
@@ -169,12 +170,13 @@ func (s *Repository) Close() error {
 
 func (s *Repository) newWAL(ctx context.Context, prefix string) (*WAL, error) {
 	walOpts := WALOpts{
-		Prefix:         prefix,
-		StorageDir:     s.opts.StorageDir,
-		SegmentMaxSize: s.opts.SegmentMaxSize,
-		SegmentMaxAge:  s.opts.SegmentMaxAge,
-		MaxDiskUsage:   s.opts.MaxDiskUsage,
-		Index:          s.index,
+		Prefix:           prefix,
+		StorageDir:       s.opts.StorageDir,
+		SegmentMaxSize:   s.opts.SegmentMaxSize,
+		SegmentMaxAge:    s.opts.SegmentMaxAge,
+		MaxDiskUsage:     s.opts.MaxDiskUsage,
+		Index:            s.index,
+		WALFlushInterval: s.opts.WALFlushInterval,
 	}
 
 	wal, err := NewWAL(walOpts)

--- a/pkg/wal/segment.go
+++ b/pkg/wal/segment.go
@@ -429,7 +429,8 @@ func (s *segment) Repair() error {
 		n, err = s.w.Read(buf[:blockLen])
 		idx += n
 		if err != nil {
-			return err
+			logger.Warnf("Repairing segment %s, unexected error %s, truncating at %d", s.path, err, lastGoodIdx)
+			return s.truncate(int64(lastGoodIdx))
 		}
 
 		if uint32(n) != blockLen {

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -83,6 +83,9 @@ type WALOpts struct {
 
 	// Index is the index of the WAL segments.
 	Index *Index
+
+	// WALFlushInterval is the interval at which the WAL should be flushed.
+	WALFlushInterval time.Duration
 }
 
 type SampleType uint16
@@ -250,7 +253,7 @@ func (w *WAL) rotate(ctx context.Context) {
 
 				toClose = seg
 				var err error
-				w.segment, err = NewSegment(w.opts.StorageDir, w.opts.Prefix)
+				w.segment, err = NewSegment(w.opts.StorageDir, w.opts.Prefix, WithFlushIntervale(w.opts.WALFlushInterval))
 				if err != nil {
 					logger.Errorf("Failed to create new segment: %s", err.Error())
 					w.segment = nil
@@ -332,7 +335,7 @@ func (w *WAL) tryAppend(ctx context.Context, buf []byte) error {
 	w.mu.Lock()
 	if w.segment == nil {
 		var err error
-		seg, err := NewSegment(w.opts.StorageDir, w.opts.Prefix)
+		seg, err := NewSegment(w.opts.StorageDir, w.opts.Prefix, WithFlushIntervale(w.opts.WALFlushInterval))
 		if err != nil {
 			w.mu.Unlock()
 			return err

--- a/storage/store.go
+++ b/storage/store.go
@@ -78,16 +78,18 @@ type StoreOpts struct {
 	LiftedLabels     []string
 	LiftedAttributes []string
 	LiftedResources  []string
+	WALFlushInterval time.Duration
 }
 
 func NewLocalStore(opts StoreOpts) *LocalStore {
 	return &LocalStore{
 		opts: opts,
 		repository: wal.NewRepository(wal.RepositoryOpts{
-			StorageDir:     opts.StorageDir,
-			SegmentMaxSize: opts.SegmentMaxSize,
-			SegmentMaxAge:  opts.SegmentMaxAge,
-			MaxDiskUsage:   opts.MaxDiskUsage,
+			StorageDir:       opts.StorageDir,
+			SegmentMaxSize:   opts.SegmentMaxSize,
+			SegmentMaxAge:    opts.SegmentMaxAge,
+			MaxDiskUsage:     opts.MaxDiskUsage,
+			WALFlushInterval: opts.WALFlushInterval,
 		}),
 		metrics: make(map[string]prometheus.Counter),
 	}


### PR DESCRIPTION
This has a few changes to reduce CPU.  The first is to use persistent connections with http 1.1 and a gradual drain on the server side.  The second is to make the segment flush interval configurable to reduce CPU usage.

This is before and after of CPU usage for ingeston and collector on a 100 node cluster.  Roughly a 3x decrease in CPU for ingestor and 3-10x for collector.

![image](https://github.com/user-attachments/assets/87def623-3fec-47b7-b633-3b44dbbc7d9b)
