### PR TITLE
Further path sanitization for wal filenames

### DIFF
--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -220,10 +220,10 @@ func (s *Syncer) EnsureMapping(table string, mapping schema.SchemaMapping) (stri
 	}
 
 	var b bytes.Buffer
-	kind := schema.Normalize([]byte(table))
+	kind := schema.NormalizeMetricName([]byte(table))
 	b.Write(kind)
 	for _, v := range mapping {
-		b.Write(schema.Normalize([]byte(v.Column)))
+		b.Write(schema.NormalizeMetricName([]byte(v.Column)))
 	}
 
 	name := fmt.Sprintf("%s_%d", string(kind), xxhash.Sum64(b.Bytes()))

--- a/pkg/wal/segment.go
+++ b/pkg/wal/segment.go
@@ -114,6 +114,12 @@ func NewSegment(dir, prefix string, opts ...SegmentOption) (Segment, error) {
 	if !fs.ValidPath(fileName) {
 		return nil, fmt.Errorf("invalid segment filename: %s", fileName)
 	}
+	// Ensure the filename is just the base name, with no path separators within it
+	baseName := filepath.Base(fileName)
+	if baseName != fileName {
+		return nil, fmt.Errorf("invalid segment filename: %s", fileName)
+	}
+
 	path := filepath.Join(dir, fileName)
 	fw, err := os.Create(path)
 	if err != nil {

--- a/pkg/wal/segment_test.go
+++ b/pkg/wal/segment_test.go
@@ -47,6 +47,30 @@ func TestNewSegment(t *testing.T) {
 	}
 }
 
+func TestNewSegment_InvalidPath(t *testing.T) {
+	tests := []struct {
+		Prefix string
+	}{
+		{Prefix: "Logs_BadPath/badfile"},
+		{Prefix: "Logs/file_BadPath"},
+		{Prefix: "Logs\\/file_BadPath"},
+		{Prefix: "../Logsfile_BadPath"},
+		{Prefix: "Logsfile/../../_BadPath"},
+		{Prefix: "Logsfile_BadPath/../../../../"},
+		{Prefix: "/"},
+		{Prefix: "_/"},
+		{Prefix: "/_"},
+		{Prefix: "/_/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Prefix, func(t *testing.T) {
+			_, err := wal.NewSegment("", tt.Prefix)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid segment filename")
+		})
+	}
+}
+
 func TestSegment_CreatedAt(t *testing.T) {
 	tests := []struct {
 		Name string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -15,6 +15,10 @@ var (
 	DefaultLogsMapping    SchemaMapping = NewLogsSchema()
 )
 
+const (
+	max_adx_identifier_length = 1024
+)
+
 type SchemaMapping []CSVMapping
 
 type CSVMapping struct {
@@ -201,23 +205,85 @@ func (m SchemaMapping) AddConstMapping(col, value string) SchemaMapping {
 }
 
 func (m SchemaMapping) AddStringMapping(col string) SchemaMapping {
-	return m.AddConstMapping(string(Normalize([]byte(col))), "")
+	return m.AddConstMapping(string(NormalizeMetricName([]byte(col))), "")
 }
 
-// Normalize converts a metrics name to a ProperCase table name
-func Normalize(s []byte) []byte {
-	return AppendNormalize(make([]byte, 0, len(s)), s)
-}
-
-// AppendNormalize converts a metrics name to a ProperCase table name and appends it to dst.
-func AppendNormalize(dst, s []byte) []byte {
+// NormalizeAdxIdentifier sanitizes a table or database name for use in ADX
+// This does not do ProperCase transformations for metrics, only removes invalid characters
+// See https://learn.microsoft.com/en-us/kusto/query/schema-entities/entity-names?view=microsoft-fabric#identifier-naming-rules
+func NormalizeAdxIdentifier(s string) string {
+	// Most common to not need normalization in this path. Only allocate if needed.
+	bytesToRemove := 0
 	for i := 0; i < len(s); i++ {
+		// ADX appears to only accept ASCII letters/numbers
+		if !(s[i] >= 'a' && s[i] <= 'z' || s[i] >= '0' && s[i] <= '9' || s[i] >= 'A' && s[i] <= 'Z') {
+			bytesToRemove += 1
+		}
+	}
+
+	if bytesToRemove == 0 && len(s) <= max_adx_identifier_length {
+		return s
+	}
+	destSize := len(s) - bytesToRemove
+
+	var b strings.Builder
+	if destSize < max_adx_identifier_length {
+		b.Grow(destSize)
+	} else {
+		b.Grow(max_adx_identifier_length)
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'a' && s[i] <= 'z' || s[i] >= '0' && s[i] <= '9' || s[i] >= 'A' && s[i] <= 'Z' {
+			b.WriteByte(s[i])
+			if b.Len() >= max_adx_identifier_length {
+				break
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// NormalizeAdxIdentifier sanitizes a table or database name for use in ADX and appends it to dst.
+// This does not do ProperCase transformations for metrics, only removes invalid characters
+// See https://learn.microsoft.com/en-us/kusto/query/schema-entities/entity-names?view=microsoft-fabric#identifier-naming-rules
+func AppendNormalizeAdxIdentifier(dst, s []byte) []byte {
+	appendedChars := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 'a' && s[i] <= 'z' || s[i] >= '0' && s[i] <= '9' || s[i] >= 'A' && s[i] <= 'Z' {
+			dst = append(dst, s[i])
+			appendedChars += 1
+			if appendedChars >= max_adx_identifier_length {
+				break
+			}
+		}
+	}
+
+	return dst
+}
+
+// NormalizeMetricName converts a metrics name to a ProperCase table name
+func NormalizeMetricName(s []byte) []byte {
+	return AppendNormalizeMetricName(make([]byte, 0, len(s)), s)
+}
+
+// AppendNormalizeMetricName converts a metrics name to a ProperCase table name and appends it to dst.
+func AppendNormalizeMetricName(dst, s []byte) []byte {
+	// Most common to require normalization in the metric path to transform prom-style metrics to ProperCase table names
+	appendedChars := 0
+	for i := 0; i < len(s); i++ {
+		if appendedChars >= max_adx_identifier_length {
+			break
+		}
+
 		// Skip any non-alphanumeric characters, but capitalize the first letter after it
+		// ADX appears to only accept ASCII letters/numbers
 		allowedChar := s[i] >= 'a' && s[i] <= 'z' || s[i] >= '0' && s[i] <= '9' || s[i] >= 'A' && s[i] <= 'Z'
 		if !allowedChar {
 			if i+1 < len(s) {
 				if s[i+1] >= 'a' && s[i+1] <= 'z' {
 					dst = append(dst, byte(unicode.ToUpper(rune(s[i+1]))))
+					appendedChars += 1
 					i += 1
 					continue
 				}
@@ -228,9 +294,11 @@ func AppendNormalize(dst, s []byte) []byte {
 		// Capitalize the first letter
 		if i == 0 {
 			dst = append(dst, byte(unicode.ToUpper(rune(s[i]))))
+			appendedChars += 1
 			continue
 		}
 		dst = append(dst, s[i])
+		appendedChars += 1
 	}
 	return dst
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -353,7 +353,7 @@ func SegmentKey(dst []byte, labels []*prompb.Label, hash uint64) ([]byte, error)
 
 	dst = append(dst, database...)
 	dst = append(dst, delim...)
-	dst = schema.AppendNormalize(dst, name)
+	dst = schema.AppendNormalizeMetricName(dst, name)
 	dst = append(dst, delim...)
 	return strconv.AppendUint(dst, hash, 36), nil
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -145,6 +145,14 @@ func (s *LocalStore) WriteTimeSeries(ctx context.Context, ts []*prompb.TimeSerie
 }
 
 func (s *LocalStore) WriteOTLPLogs(ctx context.Context, database, table string, logs *otlp.Logs) error {
+	sanitizedDB := schema.NormalizeAdxIdentifier(database)
+	sanitizedTable := schema.NormalizeAdxIdentifier(table)
+
+	if sanitizedDB == "" || sanitizedTable == "" {
+		logger.Warnf("Invalid database or table name: %s.%s", database, table)
+		return nil // Do not retry - move on
+	}
+
 	enc := csvWriterPool.Get(8 * 1024).(*transform2.CSVWriter)
 	defer csvWriterPool.Put(enc)
 
@@ -152,7 +160,7 @@ func (s *LocalStore) WriteOTLPLogs(ctx context.Context, database, table string, 
 	defer gbp.Put(key)
 
 	if logger.IsDebug() {
-		logger.Debugf("Store received %d logs for %s.%s", len(logs.Logs), database, table)
+		logger.Debugf("Store received %d logs for %s.%s", len(logs.Logs), sanitizedDB, sanitizedTable)
 		for _, log := range logs.Logs {
 			if l, err := protojson.Marshal(log); err == nil {
 				logger.Debugf("Log: %s", l)
@@ -160,14 +168,14 @@ func (s *LocalStore) WriteOTLPLogs(ctx context.Context, database, table string, 
 		}
 	}
 
-	key = fmt.Appendf(key[:0], "%s_%s", database, table)
+	key = fmt.Appendf(key[:0], "%s_%s", sanitizedDB, sanitizedTable)
 
 	w, err := s.GetWAL(ctx, key)
 	if err != nil {
 		return err
 	}
 
-	metrics.SamplesStored.WithLabelValues(table).Add(float64(len(logs.Logs)))
+	metrics.SamplesStored.WithLabelValues(sanitizedTable).Add(float64(len(logs.Logs)))
 
 	enc.Reset()
 	if err := enc.MarshalLog(logs); err != nil {
@@ -211,14 +219,24 @@ func (s *LocalStore) WriteNativeLogs(ctx context.Context, logs *types.LogBatch) 
 			noDestinationCount++
 			continue
 		}
+		sanitizedDB := schema.NormalizeAdxIdentifier(database)
+		if sanitizedDB == "" {
+			noDestinationCount++
+			continue
+		}
 
 		table, ok := log.Attributes[types.AttributeTableName].(string)
 		if !ok || table == "" {
 			noDestinationCount++
 			continue
 		}
+		sanitizedTable := schema.NormalizeAdxIdentifier(table)
+		if sanitizedTable == "" {
+			noDestinationCount++
+			continue
+		}
 
-		key = fmt.Appendf(key[:0], "%s_%s_", database, table)
+		key = fmt.Appendf(key[:0], "%s_%s_", sanitizedDB, sanitizedTable)
 		key = strconv.AppendUint(key, enc.SchemaHash(), 36)
 
 		wal, err := s.GetWAL(ctx, key)
@@ -351,7 +369,7 @@ func SegmentKey(dst []byte, labels []*prompb.Label, hash uint64) ([]byte, error)
 		return nil, fmt.Errorf("name label not found")
 	}
 
-	dst = append(dst, database...)
+	dst = schema.AppendNormalizeAdxIdentifier(dst, database)
 	dst = append(dst, delim...)
 	dst = schema.AppendNormalizeMetricName(dst, name)
 	dst = append(dst, delim...)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -368,7 +368,7 @@ func BenchmarkWriteTimeSeries(b *testing.B) {
 
 	batch := make([]*prompb.TimeSeries, 2500)
 	for i := 0; i < 2500; i++ {
-		batch[i] = newTimeSeries(fmt.Sprintf("metric%d", i%100), nil, 0, 0)
+		batch[i] = newTimeSeries(fmt.Sprintf("metric%d", i%100), map[string]string{"adxmon_database": "adxmetrics"}, 0, 0)
 	}
 	for i := 0; i < b.N; i++ {
 		require.NoError(b, s.WriteTimeSeries(context.Background(), batch))


### PR DESCRIPTION
We were not previously ensuring that subpaths were not being created from the prefix names.