### PR TITLE
Make tail source more resilient to individual tailers having errors

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -582,10 +582,7 @@ func realMain(ctx *cli.Context) error {
 
 				targets := make([]journal.JournalTargetConfig, 0, len(v.JournalTargets))
 				for _, target := range v.JournalTargets {
-					parsers, err := parser.NewParsers(target.Parsers)
-					if err != nil {
-						return nil, fmt.Errorf("create parsers: %w", err)
-					}
+					parsers := parser.NewParsers(target.Parsers, "journal")
 
 					targets = append(targets, journal.JournalTargetConfig{
 						Matches:        target.Matches,

--- a/collector/logs/engine/batch.go
+++ b/collector/logs/engine/batch.go
@@ -15,7 +15,7 @@ type BatchConfig struct {
 	AckGenerator func(log *types.Log) func()
 }
 
-func BatchLogs(ctx context.Context, config BatchConfig) error {
+func BatchLogs(ctx context.Context, config BatchConfig) {
 	ticker := time.NewTicker(config.MaxBatchWait)
 	defer ticker.Stop()
 
@@ -28,7 +28,7 @@ func BatchLogs(ctx context.Context, config BatchConfig) error {
 				flush(config, currentBatch)
 			}
 			close(config.OutputQueue)
-			return nil
+			return
 		case <-ticker.C:
 			if len(currentBatch.Logs) != 0 {
 				flush(config, currentBatch)

--- a/collector/logs/engine/worker.go
+++ b/collector/logs/engine/worker.go
@@ -27,11 +27,10 @@ func WorkerCreator(transforms []types.Transformer, sink types.Sink) func(string,
 	}
 }
 
-func (w *worker) Run() error {
+func (w *worker) Run() {
 	for msg := range w.Input {
 		w.processBatch(context.Background(), msg)
 	}
-	return nil
 }
 
 func (w *worker) processBatch(ctx context.Context, batch *types.LogBatch) {

--- a/collector/logs/sources/journal/tailer_linux.go
+++ b/collector/logs/sources/journal/tailer_linux.go
@@ -35,14 +35,14 @@ type tailer struct {
 }
 
 // readFromJournal follows the flow described in the examples within `man 3 sd_journal_wait`.
-func (t *tailer) readFromJournal(ctx context.Context) error {
+func (t *tailer) readFromJournal(ctx context.Context) {
 	t.seekCursorAtStart()
 
 	for {
 		select {
 		case <-ctx.Done():
 			t.reader.Close()
-			return nil
+			return
 		default:
 		}
 

--- a/collector/logs/sources/tail/tail.go
+++ b/collector/logs/sources/tail/tail.go
@@ -299,7 +299,8 @@ func readLines(ctx context.Context, tailer *Tailer, updateChannel <-chan FileTai
 			}
 		case line, ok := <-tailer.tail.Lines:
 			if !ok {
-				return fmt.Errorf("readLines: tailer closed the channel for filename %q", tailer.tail.Filename)
+				logger.Infof("readLines: tailer closed the channel for filename %q", tailer.tail.Filename)
+				return nil // No longer getting lines due to the tailer being closed. Exit.
 			}
 			if line.Err != nil {
 				logger.Errorf("readLines: tailer error for filename %q: %v", tailer.tail.Filename, line.Err)

--- a/collector/logs/sources/tail/tail.go
+++ b/collector/logs/sources/tail/tail.go
@@ -4,20 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Azure/adx-mon/collector/logs/engine"
 	"github.com/Azure/adx-mon/collector/logs/sources/tail/sourceparse"
-	"github.com/Azure/adx-mon/collector/logs/transforms/parser"
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/tenebris-tech/tail"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -31,7 +26,7 @@ var (
 )
 
 // FileTailTarget describes a file to tail, how to parse it, and the destination for the parsed logs.
-// It is used int he list of StaticTargets in TailSourceConfig, or used in AddTarget.
+// It is used in the list of StaticTargets in TailSourceConfig, or used in AddTarget.
 // NOTE: If new fields are added that change during runtime (e.g. from pod metadata changing) that are sent
 // via UpdateChan, update isTargetChanged to take this new field into account.
 type FileTailTarget struct {
@@ -69,23 +64,6 @@ type TailSourceConfig struct {
 	PodDiscoveryOpts *PodDiscoveryOpts
 }
 
-// Tailer is a specific instance of a file being tailed.
-type Tailer struct {
-	tail           *tail.Tail
-	shutdown       context.CancelFunc
-	database       string
-	table          string
-	logTypeParser  sourceparse.LogTypeParser
-	logLineParsers []parser.Parser
-	resources      map[string]interface{}
-}
-
-func (t *Tailer) Stop() {
-	t.tail.Cleanup()
-	t.tail.Stop()
-	t.shutdown()
-}
-
 // TailSource implements the types.Source interface for tailing files.
 type TailSource struct {
 	staticTargets   []FileTailTarget
@@ -94,8 +72,6 @@ type TailSource struct {
 
 	mu           sync.RWMutex
 	closeFn      context.CancelFunc
-	groupCtx     context.Context
-	group        *errgroup.Group
 	ackGenerator func(*types.Log) func()
 	tailers      map[string]*Tailer
 
@@ -120,10 +96,6 @@ func (s *TailSource) Open(ctx context.Context) error {
 	ctx, closeFn := context.WithCancel(ctx)
 	s.closeFn = closeFn
 
-	group, ctx := errgroup.WithContext(ctx)
-	s.group = group
-	s.groupCtx = ctx
-
 	s.ackGenerator = noopAckGenerator
 	if s.cursorDirectory != "" {
 		s.ackGenerator = func(log *types.Log) func() {
@@ -145,6 +117,7 @@ func (s *TailSource) Open(ctx context.Context) error {
 			// On startup, if we fail to add a target, we should close all the tailers we've opened so far and return.
 			for _, t := range s.tailers {
 				t.Stop()
+				t.Wait()
 			}
 			return fmt.Errorf("TailSource open: %w", err)
 		}
@@ -156,6 +129,7 @@ func (s *TailSource) Open(ctx context.Context) error {
 			// On startup, if we fail to open the pod discovery, we should close all the tailers we've opened so far and return.
 			for _, t := range s.tailers {
 				t.Stop()
+				t.Wait()
 			}
 			return fmt.Errorf("TailSource open: %w", err)
 		}
@@ -173,11 +147,13 @@ func (s *TailSource) Close() error {
 	for _, t := range s.tailers {
 		t.Stop()
 	}
+	for _, t := range s.tailers {
+		t.Wait()
+	}
 	clear(s.tailers)
 	s.mu.Unlock()
 
 	s.closeFn()
-	s.group.Wait()
 	return nil
 }
 
@@ -196,66 +172,19 @@ func (s *TailSource) AddTarget(target FileTailTarget, updateChan <-chan FileTail
 		return nil // already exists
 	}
 
-	tailerCtx, shutdown := context.WithCancel(s.groupCtx)
-	batchQueue := make(chan *types.Log, 512)
-	outputQueue := make(chan *types.LogBatch, 1)
-	tailConfig := tail.Config{Follow: true, ReOpen: true, Poll: true}
-	existingCursorPath := cursorPath(s.cursorDirectory, target.FilePath)
-	fileId, position, err := readCursor(existingCursorPath)
-	if err == nil {
-		if logger.IsDebug() {
-			logger.Debugf("TailSource: found existing cursor for file %q: %s %d", target.FilePath, fileId, position)
-		}
-		tailConfig.Location = &tail.SeekInfo{
-			Offset:         position,
-			Whence:         io.SeekStart,
-			FileIdentifier: fileId,
-		}
+	tailerConfig := TailerConfig{
+		Target:          target,
+		UpdateChan:      updateChan,
+		AckGenerator:    s.ackGenerator,
+		WorkerCreator:   s.workerCreator,
+		CursorDirectory: s.cursorDirectory,
+		WorkerName:      s.Name(),
 	}
 
-	tailFile, err := tail.TailFile(target.FilePath, tailConfig)
+	tailer, err := StartTailing(tailerConfig)
 	if err != nil {
-		shutdown()
-		return fmt.Errorf("addTarget create tailfile: %w", err)
+		return fmt.Errorf("AddTarget: %w", err)
 	}
-
-	parsers, err := parser.NewParsers(target.Parsers)
-	if err != nil {
-		shutdown()
-		return fmt.Errorf("addTarget create parsers: %w", err)
-	}
-
-	attributes := make(map[string]interface{})
-	for k, v := range target.Resources {
-		attributes[k] = v
-	}
-
-	tailer := &Tailer{
-		tail:           tailFile,
-		shutdown:       shutdown,
-		database:       target.Database,
-		table:          target.Table,
-		logTypeParser:  sourceparse.GetLogTypeParser(target.LogType),
-		logLineParsers: parsers,
-		resources:      attributes,
-	}
-	s.group.Go(func() error {
-		return readLines(tailerCtx, tailer, updateChan, batchQueue)
-	})
-
-	batchConfig := engine.BatchConfig{
-		MaxBatchSize: 1000,
-		MaxBatchWait: 1 * time.Second,
-		InputQueue:   batchQueue,
-		OutputQueue:  outputQueue,
-		AckGenerator: s.ackGenerator,
-	}
-	s.group.Go(func() error {
-		return engine.BatchLogs(tailerCtx, batchConfig)
-	})
-
-	worker := s.workerCreator(s.Name(), outputQueue)
-	s.group.Go(worker.Run)
 
 	s.tailers[target.FilePath] = tailer
 
@@ -271,90 +200,9 @@ func (s *TailSource) RemoveTarget(filePath string) {
 	tailer, ok := s.tailers[filePath]
 	if ok {
 		tailer.Stop()
+		tailer.Wait()
 		delete(s.tailers, filePath)
 		cleanCursor(cursorPath(s.cursorDirectory, filePath))
-	}
-}
-
-func readLines(ctx context.Context, tailer *Tailer, updateChannel <-chan FileTailTarget, outputQueue chan<- *types.Log) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		// Receive updates from the optional updateChannel.
-		case newTarget, ok := <-updateChannel:
-			if ok {
-				newParsers, err := parser.NewParsers(newTarget.Parsers)
-				if err != nil {
-					logger.Errorf("readLines: parser error for filename %q: %v", tailer.tail.Filename, err)
-					continue
-				}
-				tailer.logLineParsers = newParsers
-				tailer.database = newTarget.Database
-				tailer.table = newTarget.Table
-				tailer.resources = make(map[string]interface{})
-				for k, v := range newTarget.Resources {
-					tailer.resources[k] = v
-				}
-			}
-		case line, ok := <-tailer.tail.Lines:
-			if !ok {
-				logger.Infof("readLines: tailer closed the channel for filename %q", tailer.tail.Filename)
-				return nil // No longer getting lines due to the tailer being closed. Exit.
-			}
-			if line.Err != nil {
-				logger.Errorf("readLines: tailer error for filename %q: %v", tailer.tail.Filename, line.Err)
-				//skip
-				continue
-			}
-
-			log := types.LogPool.Get(1).(*types.Log)
-			log.Reset()
-
-			isPartial, err := tailer.logTypeParser.Parse(line.Text, log)
-			if err != nil {
-				logger.Errorf("readLines: parselog error for filename %q: %v", tailer.tail.Filename, err)
-				//skip
-				types.LogPool.Put(log)
-				continue
-			}
-			if isPartial {
-				types.LogPool.Put(log)
-				continue
-			}
-
-			position := line.Offset
-			currentFileId := line.FileIdentifier
-			log.Attributes[types.AttributeDatabaseName] = tailer.database
-			log.Attributes[types.AttributeTableName] = tailer.table
-
-			for k, v := range tailer.resources {
-				log.Resource[k] = v
-			}
-
-			successfulParse := false
-			for _, parser := range tailer.logLineParsers {
-				err := parser.Parse(log)
-				if err == nil {
-					successfulParse = true
-					break // successful parse
-				} else if logger.IsDebug() {
-					logger.Debugf("readLines: parser error for filename %q: %v", tailer.tail.Filename, err)
-				}
-			}
-
-			if successfulParse {
-				// Successful parse, remove the raw message
-				delete(log.Body, types.BodyKeyMessage)
-			}
-
-			// Write after parsing to ensure these values are always set to values we need for acking.
-			log.Attributes[cursor_position] = position
-			log.Attributes[cursor_file_id] = currentFileId
-			log.Attributes[cursor_file_name] = tailer.tail.Filename
-
-			outputQueue <- log
-		}
 	}
 }
 

--- a/collector/logs/sources/tail/tail_test.go
+++ b/collector/logs/sources/tail/tail_test.go
@@ -19,6 +19,7 @@ func TestTailSourceStaticTargets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 	numLogs := 1000
 
 	testDir := t.TempDir()
@@ -79,6 +80,7 @@ func TestTailSourcePartialLogs(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 	testDir := t.TempDir()
 	// consistent date so we know how many bytes are generated in the file.
 	// generatedLogStartTime := time.Unix(0, 0)
@@ -132,6 +134,7 @@ func TestTailSourceDynamicTargets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 	numLogs := 1000
 
 	testDir := t.TempDir()
@@ -215,6 +218,7 @@ func TestTailSourceDynamicUtilizesCursors(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
+	t.Parallel()
 	numLogs := 1000
 
 	testDir := t.TempDir()

--- a/collector/logs/sources/tail/tailer.go
+++ b/collector/logs/sources/tail/tailer.go
@@ -1,0 +1,201 @@
+package tail
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Azure/adx-mon/collector/logs/engine"
+	"github.com/Azure/adx-mon/collector/logs/sources/tail/sourceparse"
+	"github.com/Azure/adx-mon/collector/logs/transforms/parser"
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/tenebris-tech/tail"
+	"golang.org/x/sync/errgroup"
+)
+
+type TailerConfig struct {
+	Target          FileTailTarget
+	UpdateChan      <-chan FileTailTarget
+	AckGenerator    func(*types.Log) func()
+	WorkerCreator   engine.WorkerCreatorFunc
+	CursorDirectory string
+	WorkerName      string
+}
+
+// Tailer is a specific instance of a file being tailed.
+type Tailer struct {
+	tail           *tail.Tail
+	shutdown       context.CancelFunc
+	errgroup       *errgroup.Group
+	database       string
+	table          string
+	logTypeParser  sourceparse.LogTypeParser
+	logLineParsers []parser.Parser
+	resources      map[string]interface{}
+}
+
+func StartTailing(config TailerConfig) (*Tailer, error) {
+	group, ctx := errgroup.WithContext(context.Background())
+	ctx, shutdown := context.WithCancel(ctx)
+
+	batchQueue := make(chan *types.Log, 512)
+	outputQueue := make(chan *types.LogBatch, 1)
+	tailConfig := tail.Config{Follow: true, ReOpen: true, Poll: true}
+	existingCursorPath := cursorPath(config.CursorDirectory, config.Target.FilePath)
+	fileId, position, err := readCursor(existingCursorPath)
+	if err == nil {
+		if logger.IsDebug() {
+			logger.Debugf("TailSource: found existing cursor for file %q: %s %d", config.Target.FilePath, fileId, position)
+		}
+		tailConfig.Location = &tail.SeekInfo{
+			Offset:         position,
+			Whence:         io.SeekStart,
+			FileIdentifier: fileId,
+		}
+	}
+
+	tailFile, err := tail.TailFile(config.Target.FilePath, tailConfig)
+	if err != nil {
+		shutdown()
+		return nil, fmt.Errorf("addTarget create tailfile: %w", err)
+	}
+
+	parsers, err := parser.NewParsers(config.Target.Parsers)
+	if err != nil {
+		shutdown()
+		return nil, fmt.Errorf("addTarget create parsers: %w", err)
+	}
+
+	attributes := make(map[string]interface{})
+	for k, v := range config.Target.Resources {
+		attributes[k] = v
+	}
+
+	tailer := &Tailer{
+		tail:           tailFile,
+		shutdown:       shutdown,
+		errgroup:       group,
+		database:       config.Target.Database,
+		table:          config.Target.Table,
+		logTypeParser:  sourceparse.GetLogTypeParser(config.Target.LogType),
+		logLineParsers: parsers,
+		resources:      attributes,
+	}
+	group.Go(func() error {
+		return readLines(ctx, tailer, config.UpdateChan, batchQueue)
+	})
+
+	batchConfig := engine.BatchConfig{
+		MaxBatchSize: 1000,
+		MaxBatchWait: 1 * time.Second,
+		InputQueue:   batchQueue,
+		OutputQueue:  outputQueue,
+		AckGenerator: config.AckGenerator,
+	}
+	group.Go(func() error {
+		return engine.BatchLogs(ctx, batchConfig)
+	})
+
+	worker := config.WorkerCreator(config.WorkerName, outputQueue)
+	group.Go(worker.Run)
+
+	return tailer, nil
+}
+
+// Stop stops the tailer and cleans up resources.
+// Does not wait for the tailer to finish processing, to allow closing many tailers concurrently.
+// Call Wait() after calling Stop() to wait for the tailer to finish processing.
+func (t *Tailer) Stop() {
+	t.tail.Cleanup()
+	t.tail.Stop()
+	t.shutdown()
+}
+
+// Wait waits for the tailer to finish processing.
+func (t *Tailer) Wait() {
+	t.errgroup.Wait()
+}
+
+func readLines(ctx context.Context, tailer *Tailer, updateChannel <-chan FileTailTarget, outputQueue chan<- *types.Log) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		// Receive updates from the optional updateChannel.
+		case newTarget, ok := <-updateChannel:
+			if ok {
+				newParsers, err := parser.NewParsers(newTarget.Parsers)
+				if err != nil {
+					logger.Errorf("readLines: parser error for filename %q: %v", tailer.tail.Filename, err)
+					continue
+				}
+				tailer.logLineParsers = newParsers
+				tailer.database = newTarget.Database
+				tailer.table = newTarget.Table
+				tailer.resources = make(map[string]interface{})
+				for k, v := range newTarget.Resources {
+					tailer.resources[k] = v
+				}
+			}
+		case line, ok := <-tailer.tail.Lines:
+			if !ok {
+				logger.Infof("readLines: tailer closed the channel for filename %q", tailer.tail.Filename)
+				return nil // No longer getting lines due to the tailer being closed. Exit.
+			}
+			if line.Err != nil {
+				logger.Errorf("readLines: tailer error for filename %q: %v", tailer.tail.Filename, line.Err)
+				//skip
+				continue
+			}
+
+			log := types.LogPool.Get(1).(*types.Log)
+			log.Reset()
+
+			isPartial, err := tailer.logTypeParser.Parse(line.Text, log)
+			if err != nil {
+				logger.Errorf("readLines: parselog error for filename %q: %v", tailer.tail.Filename, err)
+				//skip
+				types.LogPool.Put(log)
+				continue
+			}
+			if isPartial {
+				types.LogPool.Put(log)
+				continue
+			}
+
+			position := line.Offset
+			currentFileId := line.FileIdentifier
+			log.Attributes[types.AttributeDatabaseName] = tailer.database
+			log.Attributes[types.AttributeTableName] = tailer.table
+
+			for k, v := range tailer.resources {
+				log.Resource[k] = v
+			}
+
+			successfulParse := false
+			for _, parser := range tailer.logLineParsers {
+				err := parser.Parse(log)
+				if err == nil {
+					successfulParse = true
+					break // successful parse
+				} else if logger.IsDebug() {
+					logger.Debugf("readLines: parser error for filename %q: %v", tailer.tail.Filename, err)
+				}
+			}
+
+			if successfulParse {
+				// Successful parse, remove the raw message
+				delete(log.Body, types.BodyKeyMessage)
+			}
+
+			// Write after parsing to ensure these values are always set to values we need for acking.
+			log.Attributes[cursor_position] = position
+			log.Attributes[cursor_file_id] = currentFileId
+			log.Attributes[cursor_file_name] = tailer.tail.Filename
+
+			outputQueue <- log
+		}
+	}
+}

--- a/collector/logs/transforms/parser/parser_test.go
+++ b/collector/logs/transforms/parser/parser_test.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewParsers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []Parser
+	}{
+		{
+			name:     "valid parser",
+			input:    []string{"json"},
+			expected: []Parser{&JsonParser{}},
+		},
+		{
+			name:     "empty",
+			input:    []string{},
+			expected: []Parser{},
+		},
+		{
+			name:     "skips invalid",
+			input:    []string{"invalid", "json", "invalid2"},
+			expected: []Parser{&JsonParser{}},
+		},
+		{
+			name:     "all invalid",
+			input:    []string{"invalid", "invalid2"},
+			expected: []Parser{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsers := NewParsers(tt.input, "test")
+			require.Len(t, parsers, len(tt.expected))
+			for i, parser := range parsers {
+				require.IsType(t, tt.expected[i], parser)
+			}
+		})
+	}
+}
+
+func TestIsValidParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid",
+			input:    "json",
+			expected: true,
+		},
+		{
+			name:     "invalid",
+			input:    "invalid",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsValidParser(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
We were previously sharing an errgroup amongst all tailers, which meant that any that returned an error would cause all tailers to stop. Instead, we now have per-tailer errgroups to prevent this from happening.

We also had a mixture of contexts and cancel functions within the source itself and within the tailer/discovery workers along with Open() and Close() functions on those workers. Instead, just use Open() and Close() on the workers.  