### PR TITLE
Minimize packages in collector container

### DIFF
--- a/build/images/Dockerfile.collector
+++ b/build/images/Dockerfile.collector
@@ -3,18 +3,23 @@ FROM golang:1.22 as builder
 ADD .. /code
 WORKDIR /code
 
-# Required for journal input
+# Headers required for journal input build
 RUN apt update && apt install -y libsystemd-dev
 
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o ./bin/collector ./cmd/collector
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+# Install systemd lib to get libsystemd.so
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0 as libsystemdsource
 
-# Required for journal input
 RUN tdnf install -y systemd
+
+FROM mcr.microsoft.com/cbl-mariner/distroless/base:2.0
 
 LABEL org.opencontainers.image.source https://github.com/Azure/adx-mon
 
-COPY --from=builder /code/bin /
+# Binary looks under /usr/lib64 for libsystemd.so and other required so files
+# Found with `export LD_DEBUG=libs` and running the binary
+COPY --from=libsystemdsource /usr/lib/libsystemd.so /usr/lib/liblzma.so.5 /usr/lib/libzstd.so.1 /usr/lib/liblz4.so.1 /usr/lib/libcap.so.2 /usr/lib/libgcrypt.so.20 /usr/lib/libgpg-error.so.0 /usr/lib/libgcc_s.so.1 /usr/lib64/
+COPY --from=builder /code/bin/collector /collector
 
 ENTRYPOINT ["/collector"]


### PR DESCRIPTION
Instead of requiring everything in the the cbl-mariner/base/core container with many unnecessary packages, we now use distroless/base to get the requirements for a dynamically linked Go binary (glibc) and copy the relevant libraries from a base/core container.