### PR TITLE
Don't block appends when segments are highly contended

### DIFF
--- a/build/k8s/ingestor.yaml
+++ b/build/k8s/ingestor.yaml
@@ -178,3 +178,85 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 300
+---
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: functions.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: Function
+    listKind: FunctionList
+    plural: functions
+    singular: function
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Function defines a KQL function to be maintained in the Kusto
+            cluster
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FunctionSpec defines the desired state of Function
+              properties:
+                body:
+                  description: Body is the KQL body of the function
+                  type: string
+                database:
+                  description: Database is the name of the database in which the function
+                    will be created
+                  type: string
+              required:
+                - body
+                - database
+              type: object
+            status:
+              description: FunctionStatus defines the observed state of Function
+              properties:
+                error:
+                  description: Error is a string that communicates any error message
+                    if one exists
+                  type: string
+                lastTimeReconciled:
+                  description: LastTimeReconciled is the last time the Function was
+                    reconciled
+                  format: date-time
+                  type: string
+                message:
+                  description: Message is a human-readable message indicating details
+                    about the Function
+                  type: string
+                status:
+                  description: Status is an enum that represents the status of the Function
+                  type: string
+              required:
+                - lastTimeReconciled
+                - status
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/cmd/ingestor/thread_affinity.go
+++ b/cmd/ingestor/thread_affinity.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func pinToCPU(cpu int) error {}

--- a/cmd/ingestor/thread_affinity_linux.go
+++ b/cmd/ingestor/thread_affinity_linux.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func pinToCPU(cpu int) error {
+	var newMask unix.CPUSet
+	newMask.Set(cpu)
+	return unix.SchedSetaffinity(cpu, &newMask)
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/valyala/fastjson v1.6.4
 	golang.org/x/net v0.30.0
 	golang.org/x/sync v0.8.0
+	golang.org/x/sys v0.26.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80
 	google.golang.org/protobuf v1.35.1
 	k8s.io/api v0.30.3
@@ -100,7 +101,6 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
-	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/ingestor/cluster/batcher.go
+++ b/ingestor/cluster/batcher.go
@@ -425,10 +425,12 @@ func prioritizeOldest(a []string) []string {
 	var b []string
 
 	// Find the index that is roughly 10% from the end of the list
-	idx := len(a) - int(math.Round(float64(len(a))*0.1))
-	// Move last 10% of batches to the front of the list
+	idx := len(a) - int(math.Round(float64(len(a))*0.2))
+	// Move last 20% of batches to the front of the list
 	b = append(b, a[idx:]...)
-	// Move first 90% of batches to the end of the list
+	// Reverse the list so the oldest batches are first
+	slices.Reverse(b)
+	// Move first 80% of batches to the end of the list
 	b = append(b, a[:idx]...)
 	return b
 }

--- a/ingestor/cluster/client.go
+++ b/ingestor/cluster/client.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrPeerOverloaded = fmt.Errorf("peer overloaded")
 	ErrSegmentExists  = fmt.Errorf("segment already exists")
+	ErrSegmentLocked  = fmt.Errorf("segment is locked")
 )
 
 type ErrBadRequest struct {
@@ -162,6 +163,10 @@ func (c *Client) Write(ctx context.Context, endpoint string, filename string, bo
 
 		if resp.StatusCode == http.StatusConflict {
 			return ErrSegmentExists
+		}
+
+		if resp.StatusCode == http.StatusLocked {
+			return ErrSegmentLocked
 		}
 
 		if resp.StatusCode == http.StatusBadRequest {

--- a/ingestor/cluster/replicator.go
+++ b/ingestor/cluster/replicator.go
@@ -172,6 +172,9 @@ func (r *replicator) transfer(ctx context.Context) {
 							logger.Errorf("Failed to remove segment: %s", err)
 						}
 						return nil
+					} else if errors.Is(err, ErrSegmentLocked) {
+						// Segment is locked, retry later.
+						return nil
 					} else if errors.Is(err, ErrPeerOverloaded) {
 						// Ingestor is overloaded, mark the peer as unhealthy and retry later.
 						r.Health.SetPeerUnhealthy(owner)

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -375,6 +375,9 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 		m.WithLabelValues(strconv.Itoa(http.StatusTooManyRequests)).Inc()
 		http.Error(w, "Overloaded. Retry later", http.StatusTooManyRequests)
 		return
+	} else if errors.Is(err, wal.ErrSegmentLocked) {
+		http.Error(w, err.Error(), http.StatusLocked)
+		return
 	} else if err != nil {
 		logger.Errorf("Failed to import %s: %s", filename, err.Error())
 		m.WithLabelValues(strconv.Itoa(http.StatusInternalServerError)).Inc()

--- a/pkg/sync/rwmutex.go
+++ b/pkg/sync/rwmutex.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// CountingRWMutex is a RWMutex that keeps track of the number of goroutines waiting for the lock.
+type CountingRWMutex struct {
+	mu      sync.RWMutex
+	waiting int64
+	limit   int64
+}
+
+func NewCountingRWMutex(limit int) *CountingRWMutex {
+	return &CountingRWMutex{limit: int64(limit)}
+}
+
+// RLock locks rw for reading.
+func (rw *CountingRWMutex) RLock() {
+	atomic.AddInt64(&rw.waiting, 1)
+	rw.mu.RLock()
+}
+
+// RUnlock undoes a single RLock call; it does not affect other simultaneous readers.
+func (rw *CountingRWMutex) RUnlock() {
+	atomic.AddInt64(&rw.waiting, -1)
+	rw.mu.RUnlock()
+}
+
+// Lock locks rw for writing.
+func (rw *CountingRWMutex) Lock() {
+	atomic.AddInt64(&rw.waiting, 1)
+	rw.mu.Lock()
+}
+
+// Unlock undoes a single Lock call; it does not affect other simultaneous readers.
+func (rw *CountingRWMutex) Unlock() {
+	atomic.AddInt64(&rw.waiting, -1)
+	rw.mu.Unlock()
+}
+
+// TryLock tries to lock rw for writing if the pending waitinger is less than the limit.
+func (rw *CountingRWMutex) TryLock() bool {
+	if atomic.LoadInt64(&rw.waiting) > rw.limit {
+		return false
+	}
+	return rw.mu.TryLock()
+}
+
+// Waiters returns the number of goroutines waiting for the lock.
+func (rw *CountingRWMutex) Waiters() int64 {
+	return atomic.LoadInt64(&rw.waiting)
+}

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -21,11 +21,12 @@ var (
 	ErrMaxDiskUsageExceeded = fmt.Errorf("max disk usage exceeded")
 	ErrMaxSegmentsExceeded  = fmt.Errorf("max segments exceeded")
 	ErrSegmentClosed        = fmt.Errorf("segment closed")
+	ErrSegmentLocked        = fmt.Errorf("segment locked")
 
 	idgen *flake.Flake
 
 	bwPool = pool.NewGeneric(10000, func(sz int) interface{} {
-		return bufio.NewWriterSize(nil, 4*1024)
+		return bufio.NewWriterSize(nil, 8*1024)
 	})
 )
 


### PR DESCRIPTION
Under higher write load, the segment write lock can cause
long delays for a goroutine to acquire it for a write and append
operation.  This causes ingestor to report "slow request" at times
because multiple locks are getting blocked for while and the request
goes slower.

For collector shipping segments, it generally has many segements
on disk that it needs to send.  So instead of blocking when a segment
is locked, we now just return a locked error and let collector move
to the next segment.  It will retry the prior segment again in a few
seconds.  This allows for better and reduces the slow requests warnings
quite a bit.