### PR TITLE
Ingestor support for Kustainer

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Azure/adx-mon/pkg/tls"
 	"github.com/Azure/adx-mon/schema"
 	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/ingest"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
 	"k8s.io/client-go/dynamic"
@@ -495,9 +494,12 @@ func newKubeClient(cCtx *cli.Context) (dynamic.Interface, kubernetes.Interface, 
 	return dyCli, client, ctrlCli, nil
 }
 
-func newKustoClient(endpoint string) (ingest.QueryClient, error) {
+func newKustoClient(endpoint string) (*kusto.Client, error) {
 	kcsb := kusto.NewConnectionStringBuilder(endpoint)
-	kcsb.WithDefaultAzureCredential()
+
+	if strings.HasPrefix(endpoint, "https://") {
+		kcsb.WithDefaultAzureCredential()
+	}
 
 	return kusto.New(kcsb)
 }

--- a/ingestor/adx/uploader_test.go
+++ b/ingestor/adx/uploader_test.go
@@ -1,0 +1,31 @@
+package adx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func TestClusterRequiresDirectIngest(t *testing.T) {
+	ctx := context.Background()
+	k, err := kustainer.Run(ctx, "mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest", kustainer.WithStarted())
+	testcontainers.CleanupContainer(t, k)
+	require.NoError(t, err)
+
+	cb := kusto.NewConnectionStringBuilder(k.ConnectionUrl())
+	client, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	u := &uploader{
+		KustoCli: client,
+		database: "NetDefaultDB",
+	}
+	requiresDirectIngest, err := u.clusterRequiresDirectIngest(ctx)
+	require.NoError(t, err)
+	require.True(t, requiresDirectIngest)
+}

--- a/pkg/testutils/kql_verify.go
+++ b/pkg/testutils/kql_verify.go
@@ -1,0 +1,146 @@
+package testutils
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+	"github.com/stretchr/testify/require"
+)
+
+func TableExists(ctx context.Context, t *testing.T, database, table, uri string) bool {
+	t.Helper()
+
+	cb := kusto.NewConnectionStringBuilder(uri)
+	client, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	stmt := kql.New(".show tables")
+	rows, err := client.Mgmt(ctx, database, stmt)
+	require.NoError(t, err)
+	defer rows.Stop()
+
+	for {
+		row, errInline, errFinal := rows.NextRowOrError()
+		if errFinal == io.EOF {
+			break
+		}
+		if errInline != nil {
+			t.Logf("Partial failure to retrieve tables: %v", errInline)
+			continue
+		}
+		if errFinal != nil {
+			t.Errorf("Failed to retrieve tables: %v", errFinal)
+		}
+
+		var tbl Table
+		if err := row.ToStruct(&tbl); err != nil {
+			t.Errorf("Failed to convert row to struct: %v", err)
+			continue
+		}
+		if tbl.TableName == table {
+			return true
+		}
+	}
+
+	return false
+}
+
+type Table struct {
+	TableName    string `kusto:"TableName"`
+	DatabaseName string `kusto:"DatabaseName"`
+	Folder       string `kusto:"Folder"`
+	DocString    string `kusto:"DocString"`
+}
+
+func FunctionExists(ctx context.Context, t *testing.T, database, function, uri string) bool {
+	t.Helper()
+
+	cb := kusto.NewConnectionStringBuilder(uri)
+	client, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	stmt := kql.New(".show functions")
+	rows, err := client.Mgmt(ctx, database, stmt)
+	require.NoError(t, err)
+	defer rows.Stop()
+
+	for {
+		row, errInline, errFinal := rows.NextRowOrError()
+		if errFinal == io.EOF {
+			break
+		}
+		if errInline != nil {
+			t.Logf("Partial failure to retrieve functions: %v", errInline)
+			continue
+		}
+		if errFinal != nil {
+			t.Errorf("Failed to retrieve functions: %v", errFinal)
+		}
+
+		var fn Function
+		if err := row.ToStruct(&fn); err != nil {
+			t.Errorf("Failed to convert row to struct: %v", err)
+			continue
+		}
+		if fn.Name == function {
+			return true
+		}
+	}
+
+	return false
+}
+
+type Function struct {
+	Name       string `kusto:"Name"`
+	Parameters string `kusto:"Parameters"`
+	Body       string `kusto:"Body"`
+	Folder     string `kusto:"Folder"`
+	DocString  string `kusto:"DocString"`
+}
+
+func TableHasRows(ctx context.Context, t *testing.T, database, table, uri string) bool {
+	t.Helper()
+
+	cb := kusto.NewConnectionStringBuilder(uri)
+	client, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	query := kql.New("").AddUnsafe(table).AddLiteral(" | count")
+	rows, err := client.Query(ctx, database, query)
+	require.NoError(t, err)
+	defer rows.Stop()
+
+	for {
+		row, errInline, errFinal := rows.NextRowOrError()
+		if errFinal == io.EOF {
+			break
+		}
+		if errInline != nil {
+			t.Logf("Partial failure to retrieve row count: %v", errInline)
+			continue
+		}
+		if errFinal != nil {
+			t.Errorf("Failed to retrieve row count: %v", errFinal)
+		}
+
+		var count RowCount
+		if err := row.ToStruct(&count); err != nil {
+			t.Errorf("Failed to convert row to struct: %v", err)
+			continue
+		}
+		return count.Count > 0
+	}
+
+	t.Logf("Table %s has no rows", table)
+	return false
+}
+
+type RowCount struct {
+	Count int64 `kusto:"Count"`
+}

--- a/pkg/testutils/kql_verify_test.go
+++ b/pkg/testutils/kql_verify_test.go
@@ -1,0 +1,28 @@
+package testutils_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/adx-mon/pkg/testutils"
+	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func TestTableExists(t *testing.T) {
+	k, err := kustainer.Run(context.Background(), "mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest", kustainer.WithStarted())
+	testcontainers.CleanupContainer(t, k)
+	require.NoError(t, err)
+
+	require.False(t, testutils.TableExists(context.Background(), t, "NetDefaultDB", "Foo", k.ConnectionUrl()))
+	require.True(t, testutils.TableExists(context.Background(), t, "NetDefaultDB", "Table_0", k.ConnectionUrl()))
+}
+
+func TestTableHasRows(t *testing.T) {
+	k, err := kustainer.Run(context.Background(), "mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest", kustainer.WithStarted())
+	testcontainers.CleanupContainer(t, k)
+	require.NoError(t, err)
+
+	require.False(t, testutils.TableHasRows(context.Background(), t, "NetDefaultDB", "Table_0", k.ConnectionUrl()))
+}

--- a/pkg/testutils/uploader.go
+++ b/pkg/testutils/uploader.go
@@ -1,0 +1,51 @@
+package testutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/ingest"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+)
+
+type Uploader struct {
+	client   *kusto.Client
+	database string
+	table    string
+}
+
+// NewUploadReader implements ingest.Ingestor
+func NewUploadReader(client *kusto.Client, database string, table string) *Uploader {
+	return &Uploader{
+		client:   client,
+		database: database,
+		table:    table,
+	}
+}
+
+func (u *Uploader) Close() error {
+	return nil
+}
+
+func (u *Uploader) FromFile(ctx context.Context, fPath string, options ...ingest.FileOption) (*ingest.Result, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (u *Uploader) FromReader(ctx context.Context, reader io.Reader, options ...ingest.FileOption) (*ingest.Result, error) {
+	// Kustainer is not able to using a streaming ingestor as there is no storage containers backing the Kusto cluster.
+	// We must instead ingest inline and thus consume the reader.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data: %w", err)
+	}
+
+	stmt := kql.New(".ingest inline into table ").AddTable(u.table).AddLiteral(" <| ").AddUnsafe(string(data))
+	if _, err = u.client.Mgmt(ctx, u.database, stmt); err != nil {
+		return nil, fmt.Errorf("failed to ingest data: %w", err)
+	}
+
+	return &ingest.Result{}, nil
+}

--- a/pkg/testutils/uploader_test.go
+++ b/pkg/testutils/uploader_test.go
@@ -1,0 +1,50 @@
+package testutils_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/adx-mon/pkg/testutils"
+	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func TestUploader(t *testing.T) {
+	var (
+		database = "NetDefaultDB"
+		table    = "Table_0"
+		ctx      = context.Background()
+	)
+	k, err := kustainer.Run(ctx, "mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest", kustainer.WithStarted())
+	testcontainers.CleanupContainer(t, k)
+	require.NoError(t, err)
+
+	cb := kusto.NewConnectionStringBuilder(k.ConnectionUrl())
+	client, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer client.Close()
+
+	t.Run("Ingest", func(t *testing.T) {
+		uploader := testutils.NewUploadReader(client, database, table)
+		r := strings.NewReader("a")
+		result, err := uploader.FromReader(ctx, r)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("Table exists in Kusto", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			return testutils.TableExists(ctx, t, database, table, k.ConnectionUrl())
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("Table has rows", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			return testutils.TableHasRows(ctx, t, database, table, k.ConnectionUrl())
+		}, time.Minute, time.Second)
+	})
+}


### PR DESCRIPTION
Kustainer has several limitations that impact Ingestor's interaction with Kusto.
- Kustainer has no auth
- Kustainer only supports inline ingestion

To support the lack of auth, this change inspects the Kusto cluster URL and if it's an insecure connection, we do not attempt to add auth to the Kusto connection object.

To support inline ingestion, we query Kusto's cluster details and if the cluster is marked as "KustoPersonal", we use this as a trigger to switch into an inline ingestion mode.