### PR TITLE
Only use systemd libs if we are building with CGo

### DIFF
--- a/collector/logs/sources/journal/journal.go
+++ b/collector/logs/sources/journal/journal.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux || !cgo
 
 package journal
 
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/logger"
 )
 
-// Dummy impl for all non-linux platforms
+// Dummy impl for all non-linux or non-CGo platforms
 
 type Source struct{}
 

--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo
+
 package journal
 
 import (

--- a/collector/logs/sources/journal/journal_linux_test.go
+++ b/collector/logs/sources/journal/journal_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo
+
 package journal
 
 import (

--- a/collector/logs/sources/journal/tailer_linux.go
+++ b/collector/logs/sources/journal/tailer_linux.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo
+
 package journal
 
 import (


### PR DESCRIPTION
If statically linking (or testing with static linking), do not require CGo if we don't have it enabled.