### PR TITLE
Implement KQL CRD informer to better handle deletions

### DIFF
--- a/ingestor/adx/kql.go
+++ b/ingestor/adx/kql.go
@@ -1,0 +1,190 @@
+package adx
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/azure-kusto-go/kusto/data/errors"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+)
+
+// KQLHandler implements cache.ResourceEventHandler and receives
+// KQL CRD events and reconciles them with Kusto.
+type KQLHandler struct {
+	opts   KQLHandlerOpts
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu         sync.RWMutex
+	retryQueue []*retry
+}
+
+type UpdateStatusFunc func(ctx context.Context, fn *v1.Function, status v1.FunctionStatusEnum, err error)
+
+type retry struct {
+	fn       *v1.Function
+	attempts int
+	delete   bool
+}
+
+type KQLHandlerOpts struct {
+	KustoCli      mgmt
+	Database      string
+	StatusFn      UpdateStatusFunc
+	MaxRetry      int
+	RetryInterval time.Duration
+}
+
+// TODO: Need leader election so that only 1 operator is mutating Kusto's state
+// Can we make use of the way we determine if we're the owner of a particular table? See uploader.go
+
+func NewKQLHandler(opts KQLHandlerOpts) *KQLHandler {
+	if opts.StatusFn == nil {
+		opts.StatusFn = noopUpdateStatusFn
+	}
+	if opts.RetryInterval == 0 {
+		opts.RetryInterval = 10 * time.Minute
+	}
+	return &KQLHandler{
+		opts: opts,
+	}
+}
+
+func (h *KQLHandler) Open(ctx context.Context) error {
+	h.ctx, h.cancel = context.WithCancel(ctx)
+
+	go h.retries()
+	return nil
+}
+
+func (h *KQLHandler) Close() error {
+	h.cancel()
+	return nil
+}
+
+func (h *KQLHandler) executeStmt(stmt *kql.Builder, fn *v1.Function) {
+	status := v1.Success
+	_, err := h.opts.KustoCli.Mgmt(h.ctx, h.opts.Database, stmt)
+	if err != nil {
+
+		if !errors.Retry(err) {
+			status = v1.PermanentFailure
+		} else {
+			status = v1.Failed
+		}
+
+		// We want to retry even if Kusto thinks this is a permanent failure.
+		// There are several reasons why Kusto might think it's a permanent failure,
+		// like a Table not yet existing, where we will want to retry. However, we'll
+		// make the CRD object as having the appropriate failure status so that
+		// opertors can take appropriate action.
+		h.mu.Lock()
+		h.retryQueue = append(h.retryQueue, &retry{
+			fn:     fn,
+			delete: strings.HasPrefix(stmt.String(), ".drop"),
+		})
+		h.mu.Unlock()
+	}
+
+	h.opts.StatusFn(h.ctx, fn, status, err)
+}
+
+func (h *KQLHandler) OnAdd(obj interface{}, isInInitialList bool) {
+	fn, ok := obj.(*v1.Function)
+	if !ok {
+		logger.Errorf("Invalid object type: %T", obj)
+		return
+	}
+	stmt := kql.New("").AddUnsafe(fn.Spec.Body)
+	h.executeStmt(stmt, fn)
+}
+
+func (h *KQLHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldFn := oldObj.(*v1.Function)
+	newFn := newObj.(*v1.Function)
+	if oldFn.GetGeneration() == newFn.GetGeneration() {
+		return
+	}
+	h.OnAdd(newObj, false)
+}
+
+func (h *KQLHandler) OnDelete(obj interface{}) {
+	fn, ok := obj.(*v1.Function)
+	if !ok {
+		logger.Errorf("Invalid object type: %T", obj)
+		return
+	}
+	stmt := kql.New(".drop function ").AddUnsafe(fn.GetName()).AddLiteral(" ifexists")
+	h.executeStmt(stmt, fn)
+}
+
+func (h *KQLHandler) retries() {
+	ticker := time.NewTicker(h.opts.RetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			h.mu.Lock()
+			var (
+				retries    []*retry
+				deadLetter []*retry
+			)
+			for _, retry := range h.retryQueue {
+				retry.attempts++
+				if retry.attempts < h.opts.MaxRetry {
+					retries = append(retries, retry)
+				} else {
+					deadLetter = append(deadLetter, retry)
+				}
+			}
+			h.mu.Unlock()
+
+			for _, retry := range deadLetter {
+				h.opts.StatusFn(h.ctx, retry.fn, v1.PermanentFailure, nil)
+			}
+
+			var deleteIndexes []int
+			for idx, retry := range retries {
+				var stmt *kql.Builder
+				if retry.delete {
+					stmt = kql.New(".drop function ").AddUnsafe(retry.fn.GetName()).AddLiteral(" ifexists")
+				} else {
+					stmt = kql.New("").AddUnsafe(retry.fn.Spec.Body)
+				}
+				if _, err := h.opts.KustoCli.Mgmt(h.ctx, h.opts.Database, stmt); err == nil {
+					h.opts.StatusFn(h.ctx, retry.fn, v1.Success, nil)
+					deleteIndexes = append(deleteIndexes, idx)
+				}
+			}
+
+			h.mu.Lock()
+			h.retryQueue = nil
+			for idx, retry := range retries {
+				if slices.Contains(deleteIndexes, idx) {
+					continue
+				}
+				h.retryQueue = append(h.retryQueue, retry)
+			}
+			h.mu.Unlock()
+		case <-h.ctx.Done():
+			return
+		}
+	}
+}
+
+func noopUpdateStatusFn(ctx context.Context, fn *v1.Function, status v1.FunctionStatusEnum, err error) {
+	switch status {
+	case v1.Success:
+		logger.Infof("Successfully %s.%s reconciled function", fn.Spec.Database, fn.Name)
+	case v1.Failed:
+		logger.Errorf("Failed to reconcile function %s.%s", fn.Spec.Database, fn.Name)
+	case v1.PermanentFailure:
+		logger.Errorf("PermanentFailure reconciling function %s.%s", fn.Spec.Database, fn.Name)
+	}
+}

--- a/ingestor/adx/kql_test.go
+++ b/ingestor/adx/kql_test.go
@@ -1,0 +1,181 @@
+//go:build !disableDocker
+
+package adx
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/ingestor/crd"
+	"github.com/Azure/adx-mon/pkg/testutils"
+	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/k3s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestKQLHandler(t *testing.T) {
+	crdPath := filepath.Join(t.TempDir(), "crd.yaml")
+	require.NoError(t, testutils.CopyFile("../../kustomize/bases/functions_crd.yaml", crdPath))
+
+	ctx := context.Background()
+	k3sContainer, err := k3s.Run(ctx, "rancher/k3s:v1.31.2-k3s1")
+	testcontainers.CleanupContainer(t, k3sContainer)
+	require.NoError(t, err)
+	require.NoError(t, k3sContainer.CopyFileToContainer(ctx, crdPath, filepath.Join(testutils.K3sManifests, "crd.yaml"), 0644))
+
+	kustoContainer, err := kustainer.Run(ctx, "mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest", kustainer.WithCluster(ctx, k3sContainer))
+	testcontainers.CleanupContainer(t, kustoContainer)
+	require.NoError(t, err)
+
+	restConfig, _, err := testutils.GetKubeConfig(ctx, k3sContainer)
+	require.NoError(t, err)
+	require.NoError(t, kustoContainer.PortForward(ctx, restConfig))
+
+	cb := kusto.NewConnectionStringBuilder(kustoContainer.ConnectionUrl())
+	kustoClient, err := kusto.New(cb)
+	require.NoError(t, err)
+	defer kustoClient.Close()
+
+	k8sClient, err := client.New(restConfig, client.Options{})
+	require.NoError(t, err)
+
+	databaseName := "NetDefaultDB"
+	handler := NewKQLHandler(KQLHandlerOpts{
+		KustoCli:      kustoClient,
+		Database:      databaseName,
+		RetryInterval: time.Second,
+		MaxRetry:      3,
+	})
+	require.NoError(t, handler.Open(ctx))
+	defer handler.Close()
+
+	opts := crd.Options{
+		RestConfig:    restConfig,
+		Handler:       handler,
+		PollFrequency: time.Second,
+	}
+	c := crd.New(opts)
+	require.NoError(t, c.Open(ctx))
+	defer c.Close()
+
+	t.Run("add", func(t *testing.T) {
+		fnName := "testadd"
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fnName,
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     fmt.Sprintf(".create-or-alter function %s () {print now();}", fnName),
+				Database: databaseName,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, fn))
+		require.Eventually(t, func() bool {
+			return testutils.FunctionExists(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		fnName := "testupdate"
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fnName,
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     fmt.Sprintf(".create-or-alter function %s () {print now();}", fnName),
+				Database: databaseName,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, fn))
+		require.Eventually(t, func() bool {
+			return testutils.FunctionExists(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+		}, time.Minute, time.Second)
+
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(fn), fn))
+		fn.Spec.Body = fmt.Sprintf(".create-or-alter function %s () {print 'Updated';}", fnName)
+		require.NoError(t, k8sClient.Update(ctx, fn))
+
+		require.Eventually(t, func() bool {
+			fn := testutils.GetFunction(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+			return strings.Contains(fn.Body, "Updated")
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		fnName := "testdelete"
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fnName,
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     fmt.Sprintf(".create-or-alter function %s () {print now();}", fnName),
+				Database: databaseName,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, fn))
+		require.Eventually(t, func() bool {
+			return testutils.FunctionExists(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+		}, time.Minute, time.Second)
+
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(fn), fn))
+		require.NoError(t, k8sClient.Delete(ctx, fn))
+
+		require.Eventually(t, func() bool {
+			return !testutils.FunctionExists(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("retry", func(t *testing.T) {
+		// To test retries, we'll create a function that references a
+		// table that doesn't yet exist. We'll then create the table
+		// and poll until the function is able to be created via the
+		// retry queue.
+
+		// Create the CRD. The associated function will reference a table
+		// that doesn't yet exist, so the function will fail to create.
+		fnName := "testretry"
+		tableName := "testtable"
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fnName,
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     fmt.Sprintf(".create-or-alter function %s () {%s}", fnName, tableName),
+				Database: databaseName,
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, fn))
+
+		// Wait for our function to be added to the retry queue.
+		require.Eventually(t, func() bool {
+			handler.mu.Lock()
+			defer handler.mu.Unlock()
+
+			return len(handler.retryQueue) > 0
+		}, time.Minute, time.Second)
+
+		// Now create the table that our function references
+		stmt := kql.New(".create-merge table ").AddUnsafe(tableName).AddLiteral(" (x:int)")
+		_, err := kustoClient.Mgmt(ctx, databaseName, stmt)
+		require.NoError(t, err)
+
+		// Wait for the function to be successfully created
+		require.Eventually(t, func() bool {
+			return testutils.FunctionExists(ctx, t, databaseName, fnName, kustoContainer.ConnectionUrl())
+		}, time.Minute, time.Second)
+	})
+}

--- a/ingestor/crd/crd.go
+++ b/ingestor/crd/crd.go
@@ -1,0 +1,116 @@
+package crd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	v1 "github.com/Azure/adx-mon/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Options struct {
+	RestConfig    *rest.Config
+	PollFrequency time.Duration
+	Handler       cache.ResourceEventHandler
+}
+
+type CRD struct {
+	opts Options
+	stop chan struct{}
+}
+
+func New(opts Options) *CRD {
+	return &CRD{
+		opts: opts,
+	}
+}
+
+// TODO Do we need some sort of leader election here? We probably only want
+// one operator mutating Kusto's state.
+
+func (c *CRD) Open(ctx context.Context) error {
+	if c.opts.RestConfig == nil {
+		return errors.New("no client provided")
+	}
+	if c.opts.Handler == nil {
+		return errors.New("no handler provided")
+	}
+
+	dynClient, err := dynamic.NewForConfig(c.opts.RestConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    v1.GroupVersion.Group,
+		Version:  v1.GroupVersion.Version,
+		Resource: v1.GroupVersion.WithKind("functions").Kind,
+	}
+
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			unstructuredList, err := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			list := &v1.FunctionList{}
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredList.UnstructuredContent(), list)
+			return list, err
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			watcher, err := dynClient.Resource(gvr).Namespace(metav1.NamespaceAll).Watch(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+
+			return watch.Filter(watcher, func(event watch.Event) (watch.Event, bool) {
+				if event.Type == watch.Error {
+					return event, true
+				}
+
+				unstructuredObj, ok := event.Object.(*unstructured.Unstructured)
+				if !ok {
+					return event, false
+				}
+
+				function := &v1.Function{}
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), function)
+				if err != nil {
+					return watch.Event{Type: watch.Error, Object: &metav1.Status{
+						Status:  metav1.StatusFailure,
+						Message: err.Error(),
+					}}, true
+				}
+
+				event.Object = function
+				return event, true
+			}), nil
+		},
+	}
+
+	crdInformer := cache.NewSharedIndexInformer(listWatch, &v1.Function{}, c.opts.PollFrequency, cache.Indexers{})
+	crdInformer.AddEventHandlerWithResyncPeriod(c.opts.Handler, c.opts.PollFrequency)
+
+	c.stop = make(chan struct{})
+	go crdInformer.Run(c.stop)
+
+	if !cache.WaitForCacheSync(c.stop, crdInformer.HasSynced) {
+		return fmt.Errorf("failed to sync caches")
+	}
+
+	return nil
+}
+
+func (c *CRD) Close() error {
+	close(c.stop)
+	return nil
+}

--- a/ingestor/crd/crd_test.go
+++ b/ingestor/crd/crd_test.go
@@ -1,0 +1,206 @@
+//go:build !disableDocker
+
+package crd_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/ingestor/crd"
+	"github.com/Azure/adx-mon/pkg/testutils"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/k3s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCRD(t *testing.T) {
+	crdPath := filepath.Join(t.TempDir(), "crd.yaml")
+	require.NoError(t, testutils.CopyFile("../../kustomize/bases/functions_crd.yaml", crdPath))
+	fnCrdPath := filepath.Join(t.TempDir(), "fn-crd.yaml")
+	os.WriteFile(fnCrdPath, []byte(fnCrd), 0644)
+
+	ctx := context.Background()
+	k3sContainer, err := k3s.Run(ctx, "rancher/k3s:v1.31.2-k3s1")
+	testcontainers.CleanupContainer(t, k3sContainer)
+	require.NoError(t, err)
+
+	require.NoError(t, k3sContainer.CopyFileToContainer(ctx, crdPath, filepath.Join(testutils.K3sManifests, "crd.yaml"), 0644))
+	require.NoError(t, k3sContainer.CopyFileToContainer(ctx, fnCrdPath, filepath.Join(testutils.K3sManifests, "fn-crd.yaml"), 0644))
+
+	restConfig, _, err := testutils.GetKubeConfig(ctx, k3sContainer)
+	require.NoError(t, err)
+
+	k8sClient, err := client.New(restConfig, client.Options{})
+	require.NoError(t, err)
+
+	testHandler := newHandler(t, k8sClient)
+
+	opts := crd.Options{
+		RestConfig:    restConfig,
+		Handler:       testHandler,
+		PollFrequency: time.Second,
+	}
+	c := crd.New(opts)
+	require.NoError(t, c.Open(ctx))
+
+	t.Run("cache hydration", func(t *testing.T) {
+		testHandler.VerifyHydrate()
+	})
+
+	t.Run("add", func(t *testing.T) {
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testadd",
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     "some-function-body",
+				Database: "some-database",
+			},
+		}
+		testHandler.CreateAndVerify(ctx, fn)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		a := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testupdate",
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     "some-function-body",
+				Database: "some-database",
+			},
+		}
+		b := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testupdate",
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     "some-function-body-2",
+				Database: "some-database",
+			},
+		}
+		testHandler.UpdateAndVerify(ctx, a, b)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		fn := &v1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testdelete",
+				Namespace: "default",
+			},
+			Spec: v1.FunctionSpec{
+				Body:     "some-function-body",
+				Database: "some-database",
+			},
+		}
+		testHandler.DeleteAndVerify(ctx, fn)
+	})
+
+	require.NoError(t, c.Close())
+}
+
+type Handler struct {
+	t      *testing.T
+	client client.Client
+
+	OnAddChan    chan interface{}
+	OnUpdateChan chan interface{}
+	OnDeleteChan chan interface{}
+}
+
+func newHandler(t *testing.T, client client.Client) *Handler {
+	return &Handler{
+		t:            t,
+		client:       client,
+		OnAddChan:    make(chan interface{}, 1),
+		OnUpdateChan: make(chan interface{}, 1),
+		OnDeleteChan: make(chan interface{}, 1),
+	}
+}
+
+func (h *Handler) VerifyHydrate() {
+	h.t.Helper()
+
+	obj := <-h.OnAddChan
+	_, ok := obj.(*v1.Function)
+	require.True(h.t, ok)
+}
+
+func (h *Handler) CreateAndVerify(ctx context.Context, fn *v1.Function) {
+	h.t.Helper()
+
+	require.NoError(h.t, h.client.Create(ctx, fn))
+
+	obj := <-h.OnAddChan
+	rfn, ok := obj.(*v1.Function)
+	require.True(h.t, ok)
+	require.Equal(h.t, fn.GetName(), rfn.GetName())
+	require.Equal(h.t, fn.GetNamespace(), rfn.GetNamespace())
+}
+
+func (h *Handler) OnAdd(obj interface{}, isInInitialList bool) {
+	h.OnAddChan <- obj
+}
+
+func (h *Handler) UpdateAndVerify(ctx context.Context, old, new *v1.Function) {
+	h.t.Helper()
+
+	h.CreateAndVerify(ctx, old)
+	require.NoError(h.t, h.client.Get(ctx, client.ObjectKeyFromObject(old), old))
+	new.SetGroupVersionKind(old.GroupVersionKind())
+	new.SetResourceVersion(old.GetResourceVersion())
+
+	require.NoError(h.t, h.client.Update(ctx, new))
+	obj := <-h.OnUpdateChan
+	fn, ok := obj.(*v1.Function)
+	require.True(h.t, ok)
+	require.Equal(h.t, new.GetName(), fn.GetName())
+	require.Equal(h.t, new.GetNamespace(), fn.GetNamespace())
+	require.Equal(h.t, int64(2), fn.GetGeneration())
+}
+
+func (h *Handler) OnUpdate(old, new interface{}) {
+	oldFn := old.(*v1.Function)
+	newFn := new.(*v1.Function)
+	if oldFn.GetGeneration() == newFn.GetGeneration() {
+		return
+	}
+
+	h.OnUpdateChan <- new
+}
+
+func (h *Handler) DeleteAndVerify(ctx context.Context, fn *v1.Function) {
+	h.t.Helper()
+
+	h.CreateAndVerify(ctx, fn)
+	require.NoError(h.t, h.client.Delete(ctx, fn))
+
+	obj := <-h.OnDeleteChan
+	rfn, ok := obj.(*v1.Function)
+	require.True(h.t, ok)
+	require.Equal(h.t, fn.GetName(), rfn.GetName())
+	require.Equal(h.t, fn.GetNamespace(), rfn.GetNamespace())
+}
+
+func (h *Handler) OnDelete(obj interface{}) {
+	h.OnDeleteChan <- obj
+}
+
+var fnCrd = `---
+apiVersion: adx-mon.azure.com/v1
+kind: Function
+metadata:
+  name: some-crd
+spec:
+  body: some-function-body
+  database: some-database
+---`


### PR DESCRIPTION
This PR introduces dead code that will replace the existing listing mechanism for KQL CRDs. We want to be able to react to CRD deletions by deleting the associated resource in Kusto; however, by simply listing the CRDs on a set cadance leaves us with a lot of ambiguity about how we properly identify resources that have been deleted. By using an informer, we can safely distinguish between create, update and deletion events and respond accordingly. This PR also leaves open the question of leader election. It's not safe to have many actors mutating Kusto resource state. We can either use leader election or the partitioning schema used for batch ownership to limit the number of actors mutating the same resources in Kusto.