### PR TITLE
Consistent metric output

### DIFF
--- a/collector/otlp/metrics.go
+++ b/collector/otlp/metrics.go
@@ -13,7 +13,7 @@ import (
 	metricsv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/metrics/v1"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/prompb"
-	"github.com/Azure/adx-mon/pkg/promremote"
+	"github.com/Azure/adx-mon/pkg/remote"
 	"github.com/Azure/adx-mon/transform"
 	"golang.org/x/sync/errgroup"
 )
@@ -88,13 +88,13 @@ type OltpMetricWriterOpts struct {
 
 	Endpoints []string
 
-	Client *promremote.Client
+	Client remote.RemoteWriteClient
 }
 
 type OltpMetricWriter struct {
 	requestTransformer       *transform.RequestTransformer
 	endpoints                []string
-	remoteClient             *promremote.Client
+	remoteClient             remote.RemoteWriteClient
 	maxBatchSize             int
 	disableMetricsForwarding bool
 }

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -187,8 +187,11 @@ func (s *Scraper) scrape(ctx context.Context) {
 	defer s.wg.Done()
 
 	// Sleep for a random amount of time to avoid thundering herd
-	if s.opts.ScrapeInterval > 0 {
-		time.Sleep(time.Duration(rand.Intn(int(s.opts.ScrapeInterval.Seconds()))) * time.Second)
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(time.Duration(rand.Intn(int(s.opts.ScrapeInterval.Seconds()))) * time.Second):
+		// continue
 	}
 
 	reconnectTimer := time.NewTicker(5 * time.Minute)

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -123,8 +123,6 @@ type Scraper struct {
 
 	mu      sync.RWMutex
 	targets map[string]ScrapeTarget
-
-	wr *prompb.WriteRequest
 }
 
 func NewScraper(opts *ScraperOpts) *Scraper {

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/k8s"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/pkg/remote"
 	"github.com/Azure/adx-mon/transform"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
@@ -65,12 +66,7 @@ type ScraperOpts struct {
 
 	Endpoints []string
 
-	RemoteClient RemoteWriteClient
-}
-
-type RemoteWriteClient interface {
-	Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error
-	CloseIdleConnections()
+	RemoteClient remote.RemoteWriteClient
 }
 
 func (s *ScraperOpts) RequestTransformer() *transform.RequestTransformer {
@@ -114,7 +110,7 @@ type Scraper struct {
 	informerRegistration cache.ResourceEventHandlerRegistration
 
 	requestTransformer *transform.RequestTransformer
-	remoteClient       RemoteWriteClient
+	remoteClient       remote.RemoteWriteClient
 	scrapeClient       *MetricsClient
 	seriesCreator      *seriesCreator
 

--- a/collector/service.go
+++ b/collector/service.go
@@ -30,9 +30,6 @@ type Service struct {
 
 	cancel context.CancelFunc
 
-	// remoteClient is the metrics client used to send metrics to ingestor.
-	remoteClient *promremote.Client
-
 	// metricsSvc is the internal metrics component for collector specific metrics.
 	metricsSvc metrics.Service
 
@@ -225,7 +222,6 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 	var grpcHandlers []*http.GRPCHandler
 	workerSvcs := []service.Component{}
 	for _, handlerOpts := range opts.PromMetricsHandlers {
-		// proxy := promremote.NewRemoteWriteProxy(remoteClient, opts.Endpoints, opts.MaxBatchSize, handlerOpts.MetricOpts.DisableMetricsForwarding)
 		metricsProxySvc := metricsHandler.NewHandler(metricsHandler.HandlerOpts{
 			Path:               handlerOpts.Path,
 			RequestTransformer: handlerOpts.MetricOpts.RequestTransformer(),
@@ -236,7 +232,6 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 			Path:    handlerOpts.Path,
 			Handler: metricsProxySvc.HandleReceive,
 		})
-		// workerSvcs = append(workerSvcs, proxy)
 	}
 
 	for _, handlerOpts := range opts.OtlpMetricsHandlers {
@@ -344,7 +339,6 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 		grpcHandlers: grpcHandlers,
 		batcher:      batcher,
 		replicator:   replicator,
-		remoteClient: remoteClient,
 	}
 
 	return svc, nil

--- a/pkg/promremote/client.go
+++ b/pkg/promremote/client.go
@@ -22,11 +22,6 @@ var (
 	}
 )
 
-type RemoteWriteClient interface {
-	Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error
-	CloseIdleConnections()
-}
-
 // Client is a client for the prometheus remote write API.  It is safe to be shared between goroutines.
 type Client struct {
 	httpClient *http.Client

--- a/pkg/promremote/proxy.go
+++ b/pkg/promremote/proxy.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/pkg/remote"
 	"golang.org/x/sync/errgroup"
 )
 
 type RemoteWriteProxy struct {
-	client                   RemoteWriteClient
+	client                   remote.RemoteWriteClient
 	endpoints                []string
 	maxBatchSize             int
 	disableMetricsForwarding bool
@@ -27,7 +28,7 @@ type RemoteWriteProxy struct {
 	cancelFn context.CancelFunc
 }
 
-func NewRemoteWriteProxy(client RemoteWriteClient, endpoints []string, maxBatchSize int, disableMetricsForwarding bool) *RemoteWriteProxy {
+func NewRemoteWriteProxy(client remote.RemoteWriteClient, endpoints []string, maxBatchSize int, disableMetricsForwarding bool) *RemoteWriteProxy {
 	p := &RemoteWriteProxy{
 		client:                   client,
 		endpoints:                endpoints,

--- a/pkg/remote/types.go
+++ b/pkg/remote/types.go
@@ -1,0 +1,12 @@
+package remote
+
+import (
+	"context"
+
+	"github.com/Azure/adx-mon/pkg/prompb"
+)
+
+type RemoteWriteClient interface {
+	Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error
+	CloseIdleConnections()
+}


### PR DESCRIPTION
A bit of cleanup before some further changes.

1. Remove commented out or unused code.
2. Use `select` during the initial `sleep` in scraper. This allows shutting down scraper much quicker and makes the tests 3x faster.
3. Extract a common `RemoteWriteClient` type and configure the OtelMetricWriter to use it. This was the only metrics implementation that was still using the old `promremote.Client` type.