### PR TITLE
Transition metric writers away from accepting endpoint arg

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -120,21 +120,20 @@ func realMain(ctx *cli.Context) error {
 
 	cfg.ReplaceVariable("$(HOSTNAME)", hostname)
 
-	var endpoints []string
+	var endpoint string
 	if cfg.Endpoint != "" {
-		for _, endpoint := range []string{cfg.Endpoint} {
-			u, err := url.Parse(endpoint)
-			if err != nil {
-				return fmt.Errorf("failed to parse endpoint %s: %w", endpoint, err)
-			}
+		endpoint = cfg.Endpoint
 
-			if u.Scheme != "http" && u.Scheme != "https" {
-				return fmt.Errorf("endpoint %s must be http or https", endpoint)
-			}
-
-			logger.Infof("Using remote write endpoint %s", endpoint)
-			endpoints = append(endpoints, endpoint)
+		u, err := url.Parse(cfg.Endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to parse endpoint %s: %w", endpoint, err)
 		}
+
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return fmt.Errorf("endpoint %s must be http or https", endpoint)
+		}
+
+		logger.Infof("Using remote write endpoint %s", endpoint)
 	}
 
 	if cfg.StorageDir == "" {
@@ -298,7 +297,7 @@ func realMain(ctx *cli.Context) error {
 		Scraper:            scraperOpts,
 		ListenAddr:         cfg.ListenAddr,
 		NodeName:           hostname,
-		Endpoints:          endpoints,
+		Endpoint:           endpoint,
 		LiftLabels:         sortedLiftedLabels,
 		AddAttributes:      addAttributes,
 		LiftAttributes:     liftAttributes,

--- a/collector/otlp/logs_proxy.go
+++ b/collector/otlp/logs_proxy.go
@@ -30,7 +30,7 @@ import (
 type LogsProxyServiceOpts struct {
 	AddAttributes      map[string]string
 	LiftAttributes     []string
-	Endpoints          []string
+	Endpoint           string
 	InsecureSkipVerify bool
 }
 
@@ -60,7 +60,8 @@ func NewLogsProxyService(opts LogsProxyServiceOpts) *LogsProxyService {
 	}
 
 	rpcClients := make(map[string]logsv1connect.LogsServiceClient)
-	for _, endpoint := range opts.Endpoints {
+	if opts.Endpoint != "" {
+		endpoint := opts.Endpoint
 		// We have to strip the path component from our endpoint so gRPC can correctly setup its routing
 		uri, err := url.Parse(endpoint)
 		if err != nil {

--- a/pkg/promremote/client.go
+++ b/pkg/promremote/client.go
@@ -25,6 +25,7 @@ var (
 // Client is a client for the prometheus remote write API.  It is safe to be shared between goroutines.
 type Client struct {
 	httpClient *http.Client
+	endpoint   string
 	opts       ClientOpts
 }
 
@@ -64,6 +65,9 @@ type ClientOpts struct {
 
 	// DisableKeepAlives controls whether the client disables HTTP keep-alives.
 	DisableKeepAlives bool
+
+	// Endpoint for writing to the prometheus remote write API.
+	Endpoint string
 }
 
 func (c ClientOpts) WithDefaults() ClientOpts {
@@ -112,6 +116,7 @@ func NewClient(opts ClientOpts) (*Client, error) {
 
 	return &Client{
 		httpClient: httpClient,
+		endpoint:   opts.Endpoint,
 		opts:       opts,
 	}, nil
 }
@@ -131,7 +136,7 @@ func (c *Client) Write(ctx context.Context, endpoint string, wr *prompb.WriteReq
 	encoded := snappy.Encode(b1[:0], b)
 	body := bytes.NewReader(encoded)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/receive", endpoint), body)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/receive", c.endpoint), body)
 	if err != nil {
 		return fmt.Errorf("new request: %w", err)
 	}

--- a/pkg/promremote/promremote_test.go
+++ b/pkg/promremote/promremote_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/pkg/remote"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSendBatchWithValidData(t *testing.T) {
 	client := &MockClient{}
-	proxy := NewRemoteWriteProxy(client, []string{"http://example.com"}, 10, false)
+	proxy := NewRemoteWriteProxy([]remote.RemoteWriteClient{client}, 10, false)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -41,7 +42,7 @@ func TestSendBatchWithValidData(t *testing.T) {
 
 func TestSendBatchWithEmptyBatch(t *testing.T) {
 	client := &MockClient{}
-	proxy := NewRemoteWriteProxy(client, []string{"http://example.com"}, 1, false)
+	proxy := NewRemoteWriteProxy([]remote.RemoteWriteClient{client}, 1, false)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -76,6 +77,6 @@ type MockClient struct{}
 
 func (m *MockClient) CloseIdleConnections() {}
 
-func (m *MockClient) Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error {
+func (m *MockClient) Write(ctx context.Context, wr *prompb.WriteRequest) error {
 	return nil
 }

--- a/pkg/remote/types.go
+++ b/pkg/remote/types.go
@@ -7,6 +7,6 @@ import (
 )
 
 type RemoteWriteClient interface {
-	Write(ctx context.Context, endpoint string, wr *prompb.WriteRequest) error
+	Write(ctx context.Context, wr *prompb.WriteRequest) error
 	CloseIdleConnections()
 }

--- a/tools/cmd/write-load/main.go
+++ b/tools/cmd/write-load/main.go
@@ -145,6 +145,7 @@ func writer(ctx context.Context, endpoint string, stats *stats, ch chan *prompb.
 	cli, err := promremote.NewClient(promremote.ClientOpts{
 		InsecureSkipVerify: true,
 		Timeout:            30 * time.Second,
+		Endpoint:           endpoint,
 	})
 	if err != nil {
 		logger.Fatalf("prom client: %v", err)


### PR DESCRIPTION
The writers we have used have de-facto only written to one endpoint. Some implementations such as the storage writer only ever supported one endpoint and ignored the endpoint argument provided to the Write method. This split was confusing and error prone.

Future work involves adding alternate forwarders which will use potentially different protocols than our normal collector to ingestor flow. Instead of metric collectors having one instance of a writer and multiple endpoints configured, these metric writers now have a collection of writers to send their data to.