### PR TITLE
Add "Publish container images" GH workflow

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: 1.22
 
-    - name: Install depdenencies
+    - name: Install dependencies
       run: sudo apt install -y libsystemd-dev # for collector journal input
 
     - name: Build

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       with:
         go-version: 1.22
 
-    - name: Install depdenencies
+    - name: Install dependencies
       run: sudo apt install -y libsystemd-dev # for collector journal input
 
     - name: Test

--- a/.github/workflows/publish-container-images.yaml
+++ b/.github/workflows/publish-container-images.yaml
@@ -1,0 +1,68 @@
+name: Publish container images
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # github.repository as <account>/<repo>
+          - dockerfile: build/images/Dockerfile.alerter
+            image: ghcr.io/${{ github.repository }}/alerter
+          - dockerfile: build/images/Dockerfile.collector
+            image: ghcr.io/${{ github.repository }}/collector
+          - dockerfile: build/images/Dockerfile.ingestor
+            image: ghcr.io/${{ github.repository }}/ingestor
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          # Use latest tag on default branch (main), otherwise use the tag
+          tags: |
+            type=raw, value=latest, enable={{is_default_branch}}
+            type=ref, event=tag
+          flavor: |
+            latest=false
+
+      # Build and push Docker image with Buildx
+      - name: Build and push image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,24 @@
+# Release flow
+
+## Publishing artifacts
+The release process involves building and publishing container images for the following components of adx-mon:
+- Alerter
+- Collector
+- Ingestor
+
+This part of the release process has been automated using the [Publish container images](https://github.com/Azure/adx-mon/actions/workflows/publish-container-images.yaml) GitHub action.
+This action is triggered when either of these conditions are met:
+- A new commit is pushed to the `main` branch
+- A new tag is pushed to the repository
+
+The trigger determines what tag will be used for the container images:
+- `latest`: for when a new commit is pushed to the `main` branch
+- `vX.Y.Z`: for when a new tag is pushed to the repository
+
+> Note: For the `vX.Y.Z` tag, the version number is extracted from the tag name and used to tag the container images.
+> Example - If the tag is `v1.0.0`, the collector image created will be `ghcr.io/azure/adx-mon/collector:v1.0.0`
+
+## Versioning
+This project uses [Semantic Versioning](https://semver.org/).
+
+Example: `v1.0.0`


### PR DESCRIPTION
This change adds a workflow which:
- Builds container images for the alerter, collector, and ingestor.
- Tags them latest if triggered by a push to main branch or with the release tag if being triggered by a tag push to the repository.
- Pushes the images to the GitHub Container Registry.

Also adds a RELEASE.md file explaining the release process.