### PR TITLE
Add error exception for CRD type not found

### DIFF
--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -191,7 +191,7 @@ func TestFunctions(t *testing.T) {
 	require.Eventually(t, func() bool {
 		crd := &adxmonv1.Function{}
 		err := ctrlCli.Get(ctx, types.NamespacedName{Namespace: "default"}, crd)
-		return !errors.Is(err, &meta.NoKindMatchError{})
+		return !errors.Is(err, &meta.NoKindMatchError{}) && !errors.Is(err, &meta.NoResourceMatchError{})
 	}, time.Minute, time.Second)
 
 	executor := &KustoStatementExecutor{

--- a/ingestor/storage/kql_functions.go
+++ b/ingestor/storage/kql_functions.go
@@ -72,7 +72,7 @@ func (f *functions) List(ctx context.Context) ([]*adxmonv1.Function, error) {
 
 	list := &adxmonv1.FunctionList{}
 	if err := f.Client.List(ctx, list); err != nil {
-		if errors.Is(err, &meta.NoKindMatchError{}) {
+		if errors.Is(err, &meta.NoKindMatchError{}) || errors.Is(err, &meta.NoResourceMatchError{}) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to list functions: %w", err)

--- a/ingestor/storage/kql_functions_test.go
+++ b/ingestor/storage/kql_functions_test.go
@@ -53,7 +53,7 @@ func TestFunctions(t *testing.T) {
 	require.Eventually(t, func() bool {
 		crd := &adxmonv1.Function{}
 		err := ctrlCli.Get(ctx, types.NamespacedName{Namespace: "default"}, crd)
-		return !errors.Is(err, &meta.NoKindMatchError{})
+		return !errors.Is(err, &meta.NoKindMatchError{}) && !errors.Is(err, &meta.NoResourceMatchError{})
 	}, time.Minute, time.Second)
 
 	functionStore := storage.NewFunctions(ctrlCli, nil)

--- a/pkg/testutils/alerter/alerter_test.go
+++ b/pkg/testutils/alerter/alerter_test.go
@@ -54,5 +54,5 @@ func TestInCluster(t *testing.T) {
 		}
 
 		return false
-	}, 10*time.Minute, time.Second)
+	}, 30*time.Minute, time.Second)
 }

--- a/pkg/testutils/collector/collector_test.go
+++ b/pkg/testutils/collector/collector_test.go
@@ -57,6 +57,6 @@ func TestCollector(t *testing.T) {
 				return false
 			}
 			return pods.Items[0].Status.Phase == "Running"
-		}, 10*time.Minute, time.Second)
+		}, 30*time.Minute, time.Second)
 	})
 }

--- a/pkg/testutils/ingestor/ingestor_test.go
+++ b/pkg/testutils/ingestor/ingestor_test.go
@@ -52,6 +52,6 @@ func TestIngestor(t *testing.T) {
 				return false
 			}
 			return pods.Items[0].Status.Phase == "Running"
-		}, 10*time.Minute, time.Second)
+		}, 30*time.Minute, time.Second)
 	})
 }


### PR DESCRIPTION
By upgrading our dependencies the way that CRD kind not found has changed to include error type NoResourceMatchError. This PR updates the error handling expectations to include NoResourceMatchError when interacting with CRDs, mostly from a testing perspective.