### PR TITLE
Reduce allocations in Index.Get

### DIFF
--- a/pkg/wal/index.go
+++ b/pkg/wal/index.go
@@ -32,13 +32,13 @@ func (i *Index) Add(s SegmentInfo) {
 }
 
 // Get returns all segments for a given prefix.
-func (i *Index) Get(prefix string) []SegmentInfo {
+func (i *Index) Get(infos []SegmentInfo, prefix string) []SegmentInfo {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
-	a := make([]SegmentInfo, len(i.segments[prefix]))
-	copy(a, i.segments[prefix])
-	return a
+	infos = append(infos[:0], i.segments[prefix]...)
+
+	return infos
 }
 
 // Remove removes a segment from the index.

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -357,7 +357,7 @@ func (w *WAL) RemoveAll() error {
 		return fmt.Errorf("wal not closed")
 	}
 
-	closed := w.index.Get(w.opts.Prefix)
+	closed := w.index.Get(nil, w.opts.Prefix)
 	for _, info := range closed {
 		if err := w.Remove(info.Path); err != nil {
 			return err


### PR DESCRIPTION
When there are lot of pending segments, Get creates a bunch of slices as garbage that grows the heap.  This reuses a temp slice to reduce allocations and GC.