### PR TITLE
Wire up health monitoring in collector

### DIFF
--- a/collector/otlp/logs_transfer_test.go
+++ b/collector/otlp/logs_transfer_test.go
@@ -25,7 +25,8 @@ func TestLogsService(t *testing.T) {
 	require.NoError(t, store.Open(context.Background()))
 	defer store.Close()
 	s := NewLogsService(LogsServiceOpts{
-		Store: store,
+		Store:         store,
+		HealthChecker: fakeHealthChecker{true},
 	})
 	require.NoError(t, s.Open(context.Background()))
 	defer s.Close()
@@ -49,4 +50,41 @@ func TestLogsService(t *testing.T) {
 	keys := store.PrefixesByAge()
 	require.Equal(t, 1, len(keys))
 	require.Equal(t, "ADatabase_ATable", string(keys[0]))
+}
+
+func TestLogsService_Overloaded(t *testing.T) {
+	dir := t.TempDir()
+
+	store := storage.NewLocalStore(
+		storage.StoreOpts{
+			StorageDir: dir,
+		})
+
+	require.NoError(t, store.Open(context.Background()))
+	defer store.Close()
+	s := NewLogsService(LogsServiceOpts{
+		Store:         store,
+		HealthChecker: fakeHealthChecker{false},
+	})
+	require.NoError(t, s.Open(context.Background()))
+	defer s.Close()
+
+	var msg v1.ExportLogsServiceRequest
+	require.NoError(t, protojson.Unmarshal(rawlog, &msg))
+
+	b, err := proto.Marshal(&msg)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/v1/logs", bytes.NewReader(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	resp := httptest.NewRecorder()
+	s.Handler(resp, req)
+	require.Equal(t, http.StatusTooManyRequests, resp.Code)
+
+	require.NoError(t, store.Close())
+
+	keys := store.PrefixesByAge()
+	require.Equal(t, 0, len(keys))
 }


### PR DESCRIPTION
This adds the health monitor used by ingestor to determine when collector is overloaded and should start rejecting writes due to being overloaded.