### PR TITLE
Create a new input and output queue per journal target

### DIFF
--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -55,9 +55,6 @@ func (s *Source) Open(ctx context.Context) error {
 	ctx, closeFn := context.WithCancel(ctx)
 	s.closeFn = closeFn
 
-	batchQueue := make(chan *types.Log, 512)
-	outputQueue := make(chan *types.LogBatch, 1)
-
 	ackGenerator := func(*types.Log) func() { return func() {} }
 	if s.cursorDirectory != "" {
 		ackGenerator = func(log *types.Log) func() {
@@ -92,6 +89,9 @@ func (s *Source) Open(ctx context.Context) error {
 				return fmt.Errorf("journal source open addMatch %s: %w", match, err)
 			}
 		}
+
+		batchQueue := make(chan *types.Log, 512)
+		outputQueue := make(chan *types.LogBatch, 1)
 
 		cPath := cursorPath(s.cursorDirectory, target.Matches, target.Database, target.Table)
 		tailer := &tailer{


### PR DESCRIPTION
We create individual batchConfig and workers for each journal source, so we need to create individual channels for this to ensure we don't interfere with one another.

Fixes some panics on shutdown.