### PR TITLE
Remove some overly verbose debug logging

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -21,7 +21,6 @@ import (
 	transform2 "github.com/Azure/adx-mon/transform"
 	gbp "github.com/libp2p/go-buffer-pool"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var (
@@ -157,11 +156,6 @@ func (s *LocalStore) WriteOTLPLogs(ctx context.Context, database, table string, 
 
 	if logger.IsDebug() {
 		logger.Debugf("Store received %d logs for %s.%s", len(logs.Logs), sanitizedDB, sanitizedTable)
-		for _, log := range logs.Logs {
-			if l, err := protojson.Marshal(log); err == nil {
-				logger.Debugf("Log: %s", l)
-			}
-		}
 	}
 
 	key = fmt.Appendf(key[:0], "%s_%s", sanitizedDB, sanitizedTable)
@@ -176,10 +170,6 @@ func (s *LocalStore) WriteOTLPLogs(ctx context.Context, database, table string, 
 	enc.Reset()
 	if err := enc.MarshalLog(logs); err != nil {
 		return err
-	}
-
-	if logger.IsDebug() {
-		logger.Debugf("Marshaled logs: %s", enc.Bytes())
 	}
 
 	wo := wal.WithSampleMetadata(wal.LogSampleType, uint32(len(logs.Logs)))


### PR DESCRIPTION
When DEBUG level is enabled, the logs are flooded with the contents of all the logs collector is shipping which makes them to noisy to be useful.