### PR TITLE
Json parser should fail when not provided json

### DIFF
--- a/collector/logs/transforms/parser/json.go
+++ b/collector/logs/transforms/parser/json.go
@@ -29,7 +29,7 @@ func NewJsonParser(config JsonParserConfig) (*JsonParser, error) {
 // Not safe for concurrent use.
 func (p *JsonParser) Parse(log *types.Log, msg string) error {
 	if len(msg) == 0 || msg[0] != '{' {
-		return nil
+		return ErrNotJson
 	}
 
 	clear(p.parsed)

--- a/collector/logs/transforms/parser/json_test.go
+++ b/collector/logs/transforms/parser/json_test.go
@@ -8,14 +8,53 @@ import (
 )
 
 func TestJsonParse(t *testing.T) {
+	type testcase struct {
+		name         string
+		input        string
+		expectedBody map[string]interface{}
+		expectErr    bool
+	}
+
+	tests := []testcase{
+		{
+			name:         "empty",
+			input:        "",
+			expectedBody: map[string]interface{}{},
+			expectErr:    true,
+		},
+		{
+			name:         "invalid plain string",
+			input:        "not-a-string",
+			expectedBody: map[string]interface{}{},
+			expectErr:    true,
+		},
+		{
+			name:         "invalid json",
+			input:        "{",
+			expectedBody: map[string]interface{}{},
+			expectErr:    true,
+		},
+		{
+			name:         "valid json",
+			input:        `{"a": 1, "b": "2", "c": {"d": 3}}`,
+			expectedBody: map[string]interface{}{"a": 1.0, "b": "2", "c": map[string]interface{}{"d": 3.0}},
+			expectErr:    false,
+		},
+	}
+
 	parser, _ := NewJsonParser(JsonParserConfig{})
-	msg := `{"a": 1, "b": "2", "c": {"d": 3}}`
-	log := types.NewLog()
-	err := parser.Parse(log, msg)
-	require.NoError(t, err)
-	require.Equal(t, 1.0, log.Body["a"])
-	require.Equal(t, "2", log.Body["b"])
-	require.Equal(t, map[string]interface{}{"d": 3.0}, log.Body["c"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := types.NewLog()
+			err := parser.Parse(log, tt.input)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedBody, log.Body)
+			}
+		})
+	}
 }
 
 func BenchmarkJsonParse(b *testing.B) {

--- a/collector/logs/transforms/parser/parser_test.go
+++ b/collector/logs/transforms/parser/parser_test.go
@@ -142,6 +142,14 @@ func TestExecuteParsers(t *testing.T) {
 			},
 		},
 		{
+			name:    "plain text, json should fail and body fall back to the message field",
+			parsers: []Parser{&JsonParser{}},
+			message: `Hello world`,
+			expectedBody: map[string]interface{}{
+				types.BodyKeyMessage: `Hello world`,
+			},
+		},
+		{
 			name:    "empty parser list",
 			parsers: []Parser{},
 			message: `{"a": 1, "b": "2", "c": {"d": 3}}`,


### PR DESCRIPTION
Not doing so prevents falling back to other parsers.