### PR TITLE
Add custom CodeQL action

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,44 @@
+name: "Custom CodeQL analysis"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  analyze:
+    name: Analyze Go code
+    runs-on: 'ubuntu-latest'
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install extra dependencies required for building collector
+      - name: Install dependencies
+        run: sudo apt-get install -y libsystemd-dev
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: manual  # autobuild causes integration tests to run, which we don't want
+
+      # Manually build the Go code
+      - name: Build binaries
+        run: make build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build-ingestor:
 
 build-collector:
 	mkdir -p bin
-	CGO_ENABLED=1 go build -o bin/collector ./cmd/collector/...
+	CGO_ENABLED=1 go build -o bin/collector ./cmd/collector/
 .PHONY: build
 
 build: build-alerter build-ingestor build-collector


### PR DESCRIPTION
- This custom action doesn't run integration tests as part of the build step as opposed to the default CodeQL workflow setup using Github. This should reduce our PR build times significantly.
- Updates the `build-collector` Make target as building collector was causing the following error: `go: cannot write multiple packages to non-directory
bin/collector`.