### PR TITLE
Reduce the poll interval for function syncing

### DIFF
--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -271,14 +271,14 @@ func (s *Service) Open(ctx context.Context) error {
 		})
 
 		f := adx.NewSyncFunctionsTask(fnStore, v)
-		s.scheduler.ScheduleEvery(5*time.Minute, "sync-metrics-functions", func(ctx context.Context) error {
+		s.scheduler.ScheduleEvery(time.Minute, "sync-metrics-functions", func(ctx context.Context) error {
 			return f.Run(ctx)
 		})
 	}
 
 	for _, v := range s.opts.LogsKustoCli {
 		f := adx.NewSyncFunctionsTask(fnStore, v)
-		s.scheduler.ScheduleEvery(5*time.Minute, "sync-logs-functions", func(ctx context.Context) error {
+		s.scheduler.ScheduleEvery(time.Minute, "sync-logs-functions", func(ctx context.Context) error {
 			return f.Run(ctx)
 		})
 	}


### PR DESCRIPTION
Reduce the poll interval to match Alerter. The idea is that we want to discover functions a bit quicker because we don't want Alerter to evaluate a moniter that references a table / view that hasen't yet been created. An alternative approach would be to use an informer, but my experience with informers is that we would need a manual cache hydration anyways, so I think it makes sense to just reduce the poll interval and if the issue persists we can look into adding an informer.