### PR TITLE
Add read-only permissions to workflows

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
 
   build:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions: read-all
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Add read-only permission to two GitHub actions:
- Nightly tests
- Go

This change is made in an effort to adhere to the principle of least privilege for the workflows we run.