### PR TITLE
Clear error status in function update and add corresponding test

### DIFF
--- a/ingestor/storage/kql_functions.go
+++ b/ingestor/storage/kql_functions.go
@@ -44,6 +44,7 @@ func (f *functions) UpdateStatus(ctx context.Context, fn *adxmonv1.Function) err
 
 	if fn.Status.Status == adxmonv1.Success {
 		fn.Status.ObservedGeneration = fn.GetGeneration()
+		fn.Status.Error = ""
 
 		if !fn.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(fn, FinalizerName) {
 			// remove our finalizer from the list and update it.

--- a/ingestor/storage/kql_functions_test.go
+++ b/ingestor/storage/kql_functions_test.go
@@ -115,6 +115,7 @@ func TestFunctions(t *testing.T) {
 		require.Equal(t, fn.Status.Status, adxmonv1.Success)
 		require.Equal(t, fn.Status.ObservedGeneration, fn.GetGeneration())
 		require.False(t, fn.Status.LastTimeReconciled.IsZero())
+		require.Empty(t, fn.Status.Error)
 
 		fns, err := functionStore.List(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
This pull request includes updates to the `ingestor/storage/kql_functions.go` and its corresponding test file to handle the `Error` field in the function status.

Changes to `ingestor/storage/kql_functions.go`:

* Updated the `UpdateStatus` function to clear the `Error` field when the function status is successful.

Changes to `ingestor/storage/kql_functions_test.go`:

* Added a test assertion to ensure the `Error` field is empty when the function status is successful.