### PR TITLE
[proposal] static Pods log scraping configuration

### DIFF
--- a/docs/designs/static-pods.md
+++ b/docs/designs/static-pods.md
@@ -1,0 +1,24 @@
+# Static Pods
+
+## Background
+
+In some scenarios, Pods cannot be annotated for log collection, particularly in cases involving static Pod manifests (such as kube-apiserver). This document describes a mechanism to configure log scraping for these Pods without requiring changes to their manifests.
+
+### Proposed Solution
+
+Introduce a configuration block that specifies which Pod log targets should be collected. When a target configuration matches a static Pod, the appropriate logs will be included in the overall log collection pipeline.
+
+## Configuration
+
+A sample configuration that aims to scrape kube-apiserver logs is provided below. The configuration itself remains unchanged:
+
+```toml
+[[host-log.static-pod-target]]
+namespace = "kube-system"
+label-targets = { "component" = "kube-apiserver" }
+container = "apiserver"
+log-type = "kubernetes"
+database = "Logs"
+table = "KubeAPIServer"
+parsers = ["klog"]
+```


### PR DESCRIPTION
This pull request introduces a new document to the `docs/designs` directory, detailing the configuration of log collection for static Pods. The document provides background information, a proposed solution, and a sample configuration for scraping logs from static Pods, such as the `kube-apiserver`.

Key changes:

* Added a new document `static-pods.md` to the `docs/designs` directory, describing the mechanism for configuring log scraping for static Pods without modifying their manifests.
* Included a sample configuration block in the new document to illustrate how to scrape logs for the `kube-apiserver`.