### PR TITLE
Default max idle conns to max conncurrency

### DIFF
--- a/ingestor/cluster/replicator.go
+++ b/ingestor/cluster/replicator.go
@@ -62,12 +62,17 @@ type replicator struct {
 }
 
 func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
+	transferConcurrency := 5
+	if opts.MaxTransferConcurrency > 0 {
+		transferConcurrency = opts.MaxTransferConcurrency
+	}
+
 	cli, err := NewClient(ClientOpts{
 		Timeout:               30 * time.Second,
 		InsecureSkipVerify:    opts.InsecureSkipVerify,
 		Close:                 false,
 		MaxIdleConnsPerHost:   1,
-		MaxIdleConns:          5,
+		MaxIdleConns:          transferConcurrency,
 		IdleConnTimeout:       90 * time.Second,
 		ResponseHeaderTimeout: 20 * time.Second,
 		DisableHTTP2:          true,
@@ -76,12 +81,6 @@ func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	transferConcurrency := 5
-	if opts.MaxTransferConcurrency > 0 {
-		transferConcurrency = opts.MaxTransferConcurrency
-	}
-
 
 	return &replicator{
 		queue:               make(chan *Batch, 10000),


### PR DESCRIPTION
This fixes an increase in transfer errors on ingestor such as "net/http: HTTP/1.x transport connection broken: http: putIdleConn: too many idle connections"

This occurred because ingestor increase transfer conccurency to 50, but max idle conns was still 5.  When a transfer was completed and idle, there was a higher chance the idle conn pool was already full and the connection would need to be dropped.