### PR TITLE
Disable fsyncing segments on close by default

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -62,6 +62,7 @@ func main() {
 			&cli.Int64Flag{Name: "max-segment-count", Usage: "Maximum segment files allowed before signaling back-pressure", Value: 10000},
 			&cli.DurationFlag{Name: "max-transfer-age", Usage: "Maximum segment age of a segment before direct kusto upload", Value: 90 * time.Second},
 			&cli.DurationFlag{Name: "max-segment-age", Usage: "Maximum segment age", Value: 5 * time.Minute},
+			&cli.BoolFlag{Name: "enable-wal-fsync", Usage: "Enable WAL fsync", Value: false},
 			&cli.IntFlag{Name: "max-transfer-concurrency", Usage: "Maximum transfer requests in flight", Value: 50},
 			&cli.IntFlag{Name: "partition-size", Usage: "Maximum number of nodes in a partition", Value: 25},
 			&cli.StringSliceFlag{Name: "add-labels", Usage: "Static labels in the format of <name>=<value> applied to all metrics"},
@@ -136,6 +137,7 @@ func realMain(ctx *cli.Context) error {
 	region := ctx.String("region")
 	disablePeerTransfer = ctx.Bool("disable-peer-transfer")
 	maxTransferConcurrency := ctx.Int("max-transfer-concurrency")
+	enableWALFsync := ctx.Bool("enable-wal-fsync")
 
 	if namespace == "" {
 		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
@@ -343,6 +345,7 @@ func realMain(ctx *cli.Context) error {
 		MaxTransferAge:         maxTransferAge,
 		MaxSegmentCount:        maxSegmentCount,
 		MaxDiskUsage:           maxDiskUsage,
+		EnableWALFsync:         enableWALFsync,
 		MaxTransferConcurrency: maxTransferConcurrency,
 		InsecureSkipVerify:     insecureSkipVerify,
 		LiftedColumns:          sortedLiftedLabels,

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -136,6 +136,9 @@ type ServiceOpts struct {
 
 	// MaxTransferConcurrency is the maximum number of concurrent transfers allowed in flight at the same time.
 	MaxTransferConcurrency int
+
+	// EnableWALFsync enables fsync of segments before closing the segment.
+	EnableWALFsync bool
 }
 
 func NewService(opts ServiceOpts) (*Service, error) {
@@ -143,6 +146,7 @@ func NewService(opts ServiceOpts) (*Service, error) {
 		StorageDir:     opts.StorageDir,
 		SegmentMaxSize: opts.MaxSegmentSize,
 		SegmentMaxAge:  opts.MaxSegmentAge,
+		EnableWALFsync: opts.EnableWALFsync,
 		LiftedLabels:   opts.LiftedColumns,
 	})
 

--- a/pkg/wal/repository.go
+++ b/pkg/wal/repository.go
@@ -32,6 +32,7 @@ type RepositoryOpts struct {
 	MaxDiskUsage     int64
 	MaxSegmentCount  int
 	WALFlushInterval time.Duration
+	EnableWALFsync   bool
 }
 
 func NewRepository(opts RepositoryOpts) *Repository {
@@ -177,6 +178,7 @@ func (s *Repository) newWAL(ctx context.Context, prefix string) (*WAL, error) {
 		MaxDiskUsage:     s.opts.MaxDiskUsage,
 		Index:            s.index,
 		WALFlushInterval: s.opts.WALFlushInterval,
+		EnableWALFsync:   s.opts.EnableWALFsync,
 	}
 
 	wal, err := NewWAL(walOpts)

--- a/pkg/wal/segment_test.go
+++ b/pkg/wal/segment_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	flakeutil "github.com/Azure/adx-mon/pkg/flake"
 	"github.com/Azure/adx-mon/pkg/wal"
@@ -550,6 +551,13 @@ func TestSegment_Write_Concurrent(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func TestSegmentOptions(t *testing.T) {
+	_, err := wal.NewSegment(t.TempDir(), "Foo",
+		wal.WithFsync(true),
+		wal.WithFlushIntervale(time.Second))
+	require.NoError(t, err)
 }
 
 func BenchmarkSegment_Write(b *testing.B) {

--- a/storage/store.go
+++ b/storage/store.go
@@ -74,6 +74,7 @@ type StoreOpts struct {
 	LiftedAttributes []string
 	LiftedResources  []string
 	WALFlushInterval time.Duration
+	EnableWALFsync   bool
 }
 
 func NewLocalStore(opts StoreOpts) *LocalStore {
@@ -85,6 +86,7 @@ func NewLocalStore(opts StoreOpts) *LocalStore {
 			SegmentMaxAge:    opts.SegmentMaxAge,
 			MaxDiskUsage:     opts.MaxDiskUsage,
 			WALFlushInterval: opts.WALFlushInterval,
+			EnableWALFsync:   opts.EnableWALFsync,
 		}),
 		metrics: make(map[string]prometheus.Counter),
 	}


### PR DESCRIPTION
This changes the behavior of closing segments to not fsync by default to reduce disk IO incurred by fsyncing thousands of segment files in larger deployments.  This allows for tuning the page cache through OS tunables more easily.