### PR TITLE
Add nightly release workflow triggered by successful Nightly Tests

### DIFF
--- a/.github/workflows/nightly-releases.yaml
+++ b/.github/workflows/nightly-releases.yaml
@@ -1,0 +1,41 @@
+name: Nightly Release
+
+# Trigger this workflow when "Nightly Tests" completes successfully
+on:
+  workflow_run:
+    workflows: ["Nightly Tests"] # Name of the workflow to depend on
+    types:
+      - completed # Trigger when the workflow finishes
+    branches:
+      - main # Adjust to the branch where "Nightly Tests" runs
+
+jobs:
+  release:
+    # Only run if the "Nightly Tests" workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for versioning if needed
+
+      # Generate a version (e.g., date-based like v2025.03.11)
+      - name: Generate version
+        id: generate_version
+        run: |
+          VERSION="v$(date +%Y.%m.%d)"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Create a GitHub release
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.generate_version.outputs.version }}
+          release_name: "Nightly Release ${{ steps.generate_version.outputs.version }}"
+          body: "Automated nightly release for ${{ steps.generate_version.outputs.version }} triggered by successful Nightly Tests"
+          draft: false
+          prerelease: true # Mark as pre-release since it's nightly


### PR DESCRIPTION
This pull request introduces a new workflow for nightly releases in the `.github/workflows/nightly-releases.yaml` file. The workflow is designed to trigger automatically upon the successful completion of the "Nightly Tests" workflow.

Key changes:

* Added a new workflow named "Nightly Release" that triggers when the "Nightly Tests" workflow completes successfully.
* Configured the workflow to run on the `main` branch and only if the "Nightly Tests" workflow succeeded.
* Included steps to check out the code, generate a version based on the current date, and create a GitHub release with the generated version.