### PR TITLE
Enable distributed CRD processing

### DIFF
--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -31,6 +31,16 @@ var (
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
+	// ControllerOwnerKey is the annotation key used to identify the owner of a controller.
+	// Enables distributed ownership of resources, allowing multiple controllers to
+	// manage the same resource type.
+	ControllerOwnerKey = "controller.adx-mon.azure.com/owner"
+
+	// LastUpdatedKey is the annotation key used to track the last update time of a resource
+	// in an effort to detect staleness or a controller owner that no longer exists or has
+	// failed to make forward progress.
+	LastUpdatedKey = "controller.adx-mon.azure.com/last-updated"
+
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -177,7 +177,7 @@ func TestFunctions(t *testing.T) {
 		client:   kustoClient,
 	}
 
-	functionStore := storage.NewFunctions(ctrlCli, nil)
+	functionStore := storage.NewFunctions(ctrlCli)
 	task := NewSyncFunctionsTask(functionStore, executor)
 
 	resourceName := "testtest"
@@ -318,7 +318,7 @@ func TestManagementCommands(t *testing.T) {
 		client:   kustoClient,
 	}
 
-	store := storage.NewCRDHandler(ctrlCli, nil)
+	store := storage.NewCRDHandler(ctrlCli)
 	task := NewManagementCommandsTask(store, executor)
 
 	resourceName := "testtest"
@@ -416,7 +416,7 @@ func TestSummaryRules(t *testing.T) {
 		client:   kustoClient,
 	}
 
-	store := storage.NewCRDHandler(ctrlCli, nil)
+	store := storage.NewCRDHandler(ctrlCli)
 	task := NewSummaryRuleTask(store, executor)
 
 	resourceName := "testtest"

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -267,8 +267,8 @@ func (s *Service) Open(ctx context.Context) error {
 		return nil
 	})
 
-	fnStore := ingestorstorage.NewFunctions(s.opts.K8sCtrlCli, s.coordinator)
-	crdStore := ingestorstorage.NewCRDHandler(s.opts.K8sCtrlCli, s.coordinator)
+	fnStore := ingestorstorage.NewFunctions(s.opts.K8sCtrlCli)
+	crdStore := ingestorstorage.NewCRDHandler(s.opts.K8sCtrlCli)
 	for _, v := range s.opts.MetricsKustoCli {
 		t := adx.NewDropUnusedTablesTask(v)
 		s.scheduler.ScheduleEvery(12*time.Hour, "delete-unused-tables", func(ctx context.Context) error {


### PR DESCRIPTION
There are two primary changes in this PR. 

1. Use the intended controller-manager's caching mechanism to prevent redundant list invocations. 
2. Support leaderless distributed processing of our CRDs, of which there can be a great many. 

The first change isn't really worth explanation, it's an optimization and the intended use of a controller-manager client.

The second is more interesting. We're leveraging an established pattern that enables leaderless distributed processing of CRDs while ensuring only one controller processes any given CRD at a time. 

We introduce two annotations, one to track ownership and one to track the last updated time. 
1. If a CRD is not owned, controller(s) will attempt to claim ownership by setting the necessary annotations. Kubernetes guarantees that only one controller can set these annotations due to the immutable ResourceVersion on the CRDs.
2. If a CRD is not owned by a controller but the last updated time is > 5 minutes, we consider the CRD to be stale, either due to a controller no longer existing or otherwise not making forward progress. In this case we fall back to step 1, where we attempt to claim owership of the CRD.
3. If a CRD is not owned by a controller and has been updated recently, the CRD is ignored by the controller during the current iteration. 
4. If a CRD is owned by a controller it is processed.

This pull request introduces several changes to the `ingestor` package to enhance the handling of controller ownership and improve the testing framework. The key changes involve the addition of ownership annotations, the removal of leader election logic, and the introduction of new tests for ownership handling.

### Enhancements to Ownership Handling:
* Added `ControllerOwnerKey` and `LastUpdatedKey` annotations to track ownership and update times for resources in `api/v1/groupversion_info.go`.
* Implemented a `CheckOwnership` function in `ingestor/storage/crds.go` to verify and claim resource ownership, ensuring that controllers can manage resources effectively.
* Modified `NewCRDHandler` and `NewFunctions` constructors to initialize `ControllerId` instead of using an elector. [[1]](diffhunk://#diff-0459fd51666979fe00992ea917f060d24cebae11f653678aaa64914b5699f106L40-L62) [[2]](diffhunk://#diff-53ca3f64d88bbe9e987f96c6b1f85fd8820b53b97255b51d1471f425d0c5e873L30-R36)

### Codebase Simplification:
* Removed leader election logic from `ingestor/storage/crds.go` and `ingestor/storage/kql_functions.go` to simplify the codebase. [[1]](diffhunk://#diff-0459fd51666979fe00992ea917f060d24cebae11f653678aaa64914b5699f106R66-R84) [[2]](diffhunk://#diff-53ca3f64d88bbe9e987f96c6b1f85fd8820b53b97255b51d1471f425d0c5e873L70-L73)
* Updated various test files to reflect the removal of leader election and to use the new constructors. [[1]](diffhunk://#diff-e984fe8711d099d1f3fe28c5fd4b3ea01a814a4ae3d41ebe27783ad00ba25147L180-R180) [[2]](diffhunk://#diff-e984fe8711d099d1f3fe28c5fd4b3ea01a814a4ae3d41ebe27783ad00ba25147L321-R321) [[3]](diffhunk://#diff-e984fe8711d099d1f3fe28c5fd4b3ea01a814a4ae3d41ebe27783ad00ba25147L419-R419) [[4]](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4L270-R271) [[5]](diffhunk://#diff-6b42ceee599d85dc6380b057e5b99c9bebfd9147dea76b4e45c4b90280a6fd04L35-R36) [[6]](diffhunk://#diff-c94738844369af11fca2d510cc4e7be994a2d90ea7244dd558e9594e372eb7f4L45-R45)

### Improvements to Testing Framework:
* Added a comprehensive test for ownership handling in `ingestor/storage/crds_test.go` to ensure correct behavior when claiming and checking resource ownership.
* Removed tests related to leader election from `ingestor/storage/kql_functions_test.go` as they are no longer relevant.

These changes collectively enhance the robustness of resource management in the `ingestor` package by ensuring proper ownership handling and simplifying the codebase.