### PR TITLE
Add drop-prefix list argument to ingestor

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -62,6 +62,7 @@ func main() {
 			&cli.Int64Flag{Name: "max-segment-count", Usage: "Maximum segment files allowed before signaling back-pressure", Value: 10000},
 			&cli.DurationFlag{Name: "max-transfer-age", Usage: "Maximum segment age of a segment before direct kusto upload", Value: 90 * time.Second},
 			&cli.DurationFlag{Name: "max-segment-age", Usage: "Maximum segment age", Value: 5 * time.Minute},
+			&cli.StringSliceFlag{Name: "drop-prefix", Usage: "Drop transfers that match the file prefix. Transfer filenames are in the form of DestinationDB_Table_..."},
 			&cli.BoolFlag{Name: "enable-wal-fsync", Usage: "Enable WAL fsync", Value: false},
 			&cli.IntFlag{Name: "max-transfer-concurrency", Usage: "Maximum transfer requests in flight", Value: 50},
 			&cli.IntFlag{Name: "partition-size", Usage: "Maximum number of nodes in a partition", Value: 25},
@@ -126,6 +127,7 @@ func realMain(ctx *cli.Context) error {
 	maxTransferSize = ctx.Int64("max-transfer-size")
 	maxTransferAge = ctx.Duration("max-transfer-age")
 	maxSegmentCount := ctx.Int64("max-segment-count")
+	dropPrefixes := ctx.StringSlice("drop-prefix")
 	maxDiskUsage := ctx.Int64("max-disk-usage")
 	partitionSize := ctx.Int("partition-size")
 	maxConns = int(ctx.Uint("max-connections"))
@@ -351,6 +353,7 @@ func realMain(ctx *cli.Context) error {
 		LiftedColumns:          sortedLiftedLabels,
 		DropLabels:             dropLabels,
 		DropMetrics:            dropMetrics,
+		DropFilePrefixes:       dropPrefixes,
 	})
 	if err != nil {
 		logger.Fatalf("Failed to create service: %s", err)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,6 +23,13 @@ var (
 		Help:      "Counter of requests received from an ingestor instance",
 	}, []string{"path", "code"})
 
+	IngestorDroppedPrefixes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "ingestor",
+		Name:      "dropped_prefixes_total",
+		Help:      "Counter of dropped prefixes for an ingestor instance",
+	}, []string{"prefix"})
+
 	SamplesStored = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "ingestor",


### PR DESCRIPTION
This argument provides a prefix for transfer filenames that will be rejected on transfer. This provides a break-glass mechanism for rejecting certain logs or metrics from being processed by a given Ingestor cluster.