### PR TITLE
Create keyvalue log parser

### DIFF
--- a/collector/logs/transforms/parser/keyvalue.go
+++ b/collector/logs/transforms/parser/keyvalue.go
@@ -1,0 +1,165 @@
+package parser
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+const ParserTypeKeyValue ParserType = "keyvalue"
+
+type KeyValueParserConfig struct{}
+
+type KeyValueParser struct {
+	parsed       map[string]interface{}
+	tokens       []string
+	currentToken strings.Builder
+}
+
+func NewKeyValueParser(config KeyValueParserConfig) (*KeyValueParser, error) {
+	return &KeyValueParser{
+		parsed:       make(map[string]interface{}),
+		tokens:       make([]string, 0),
+		currentToken: strings.Builder{},
+	}, nil
+}
+
+// Parse parses a space-separated string of key-value pairs and standalone keys
+// and adds them to the log.Body map.
+func (p *KeyValueParser) Parse(log *types.Log, msg string) error {
+	clear(p.parsed)
+
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return nil
+	}
+
+	tokens := p.tokenize(msg)
+
+	for _, token := range tokens {
+		parts := strings.SplitN(token, "=", 2)
+		if len(parts) == 2 {
+			key, value := parts[0], unquote(parts[1])
+			log.Body[key] = reflectValue(value)
+		} else {
+			log.Body[parts[0]] = ""
+		}
+	}
+
+	return nil
+}
+
+// tokenize splits a string into tokens, preserving quoted values
+func (p *KeyValueParser) tokenize(s string) []string {
+	// Reset tokens slice while preserving capacity
+	p.tokens = p.tokens[:0]
+	// Reset the current token
+	p.currentToken.Reset()
+
+	inQuotes := false
+	var quoteChar rune
+
+	for i, char := range s {
+		switch {
+		// Handle quote characters, toggling the inQuotes state
+		case (char == '"' || char == '\'') && (i == 0 || s[i-1] != '\\'):
+			if inQuotes && char == quoteChar {
+				inQuotes = false // Closing quote found
+			} else if !inQuotes {
+				inQuotes = true  // Opening quote found
+				quoteChar = char // Remember the type of quote used
+			}
+			p.currentToken.WriteRune(char)
+		// Token boundary detected (whitespace outside quotes)
+		case unicode.IsSpace(char) && !inQuotes:
+			if p.currentToken.Len() > 0 {
+				p.tokens = append(p.tokens, p.currentToken.String())
+				p.currentToken.Reset()
+			}
+		// Regular character, append to current token
+		default:
+			p.currentToken.WriteRune(char)
+		}
+	}
+
+	// Append the last token if present
+	if p.currentToken.Len() > 0 {
+		p.tokens = append(p.tokens, p.currentToken.String())
+	}
+
+	return p.tokens
+}
+
+// unquote removes surrounding quotes from a string, if present
+func unquote(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// reflectValue attempts to convert a string to an appropriate Go type
+// Optimized to reduce allocations and improve performance
+func reflectValue(value string) interface{} {
+	if len(value) == 0 {
+		return ""
+	}
+
+	// Fast path for boolean detection based on first character and length
+	first := value[0]
+	if (first == 't' || first == 'T') && len(value) == 4 {
+		if strings.EqualFold(value, "true") {
+			return true
+		}
+	} else if (first == 'f' || first == 'F') && len(value) == 5 {
+		if strings.EqualFold(value, "false") {
+			return false
+		}
+	}
+
+	// Quickly determine if the string represents a numeric value
+	isNumber := true
+	isFloat := false
+
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		// Allow leading sign characters
+		if i == 0 && (c == '+' || c == '-') {
+			continue
+		}
+		// Check for decimal point to identify floats
+		if c == '.' {
+			if isFloat { // Multiple decimal points invalidate number
+				isNumber = false
+				break
+			}
+			isFloat = true
+			continue
+		}
+		// Non-digit character invalidates number
+		if c < '0' || c > '9' {
+			isNumber = false
+			break
+		}
+	}
+
+	// Attempt numeric conversion if valid number detected
+	if isNumber {
+		if isFloat {
+			if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
+				return floatVal
+			}
+		} else {
+			if intVal, err := strconv.Atoi(value); err == nil {
+				return intVal
+			}
+		}
+	}
+
+	// Default to returning the original string if no conversion succeeded
+	return value
+}

--- a/collector/logs/transforms/parser/keyvalue_test.go
+++ b/collector/logs/transforms/parser/keyvalue_test.go
@@ -1,0 +1,146 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseToJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "simple key-value pairs",
+			input:    "foo=bar baz=boop",
+			expected: map[string]interface{}{"foo": "bar", "baz": "boop"},
+		},
+		{
+			name:     "keys without values",
+			input:    "standalone flag another",
+			expected: map[string]interface{}{"standalone": "", "flag": "", "another": ""},
+		},
+		{
+			name:     "mixed keys with and without values",
+			input:    "key=value standalone another=thing",
+			expected: map[string]interface{}{"key": "value", "standalone": "", "another": "thing"},
+		},
+		{
+			name:     "values with spaces",
+			input:    "something=something else even=more",
+			expected: map[string]interface{}{"something": "something", "else": "", "even": "more"},
+		},
+		{
+			name:     "spaces in input",
+			input:    "   spaced   out   key=value   ",
+			expected: map[string]interface{}{"spaced": "", "out": "", "key": "value"},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "special characters in values",
+			input:    "url=http://example.com path=/some/path",
+			expected: map[string]interface{}{"url": "http://example.com", "path": "/some/path"},
+		},
+		{
+			name:     "equals sign in value",
+			input:    "equation=1+1=2 key=value",
+			expected: map[string]interface{}{"equation": "1+1=2", "key": "value"},
+		},
+		{
+			name:     "multiple equals signs",
+			input:    "complex=key=with=equals",
+			expected: map[string]interface{}{"complex": "key=with=equals"},
+		},
+		{
+			name:     "duplicate keys",
+			input:    "dup=first dup=second other=value",
+			expected: map[string]interface{}{"dup": "second", "other": "value"},
+		},
+		{
+			name:     "quoted values are preserved",
+			input:    `key="quoted value" other='single quotes'`,
+			expected: map[string]interface{}{"key": "quoted value", "other": "single quotes"},
+		},
+		{
+			name:     "numeric values",
+			input:    "count=123 float=45.67",
+			expected: map[string]interface{}{"count": 123, "float": 45.67},
+		},
+		{
+			name:     "bools values",
+			input:    "t=True f=False",
+			expected: map[string]interface{}{"t": true, "f": false},
+		},
+		{
+			name:     "invalid number",
+			input:    "n=3.2.4.8",
+			expected: map[string]interface{}{"n": "3.2.4.8"},
+		},
+		{
+			name:     "preserve empty values",
+			input:    "foo= baz=boop",
+			expected: map[string]interface{}{"foo": "", "baz": "boop"},
+		},
+	}
+
+	parser, err := NewKeyValueParser(KeyValueParserConfig{})
+	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := types.NewLog()
+			require.NoError(t, parser.Parse(log, tt.input))
+			require.Equal(t, tt.expected, log.Body)
+		})
+	}
+}
+
+func TestParseToJSON_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "only spaces",
+			input:    "     ",
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "key with empty value",
+			input:    "key=",
+			expected: map[string]interface{}{"key": ""},
+		},
+		{
+			name:     "equals sign only",
+			input:    "=",
+			expected: map[string]interface{}{"": ""},
+		},
+		{
+			name:     "starts with equals sign",
+			input:    "=value key2=value2",
+			expected: map[string]interface{}{"": "value", "key2": "value2"},
+		},
+		{
+			name:     "special characters in keys",
+			input:    "key-with-hyphens=value key_with_underscores=value2",
+			expected: map[string]interface{}{"key-with-hyphens": "value", "key_with_underscores": "value2"},
+		},
+	}
+
+	parser, err := NewKeyValueParser(KeyValueParserConfig{})
+	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := types.NewLog()
+			require.NoError(t, parser.Parse(log, tt.input))
+			require.Equal(t, tt.expected, log.Body)
+		})
+	}
+}

--- a/collector/logs/transforms/parser/parser.go
+++ b/collector/logs/transforms/parser/parser.go
@@ -24,6 +24,8 @@ func newParser(parserType ParserType) (Parser, error) {
 	switch parserType {
 	case ParserTypeJson:
 		return NewJsonParser(JsonParserConfig{})
+	case ParserTypeKeyValue:
+		return NewKeyValueParser(KeyValueParserConfig{})
 	default:
 		return nil, fmt.Errorf("unknown parser type: %s", parserType)
 	}
@@ -47,6 +49,8 @@ func NewParsers(parserTypes []string, source string) []Parser {
 func IsValidParser(parserType string) bool {
 	switch parserType {
 	case string(ParserTypeJson):
+		return true
+	case string(ParserTypeKeyValue):
 		return true
 	default:
 		return false

--- a/collector/logs/transforms/parser/parser_test.go
+++ b/collector/logs/transforms/parser/parser_test.go
@@ -16,8 +16,8 @@ func TestNewParsers(t *testing.T) {
 	}{
 		{
 			name:     "valid parser",
-			input:    []string{"json"},
-			expected: []Parser{&JsonParser{}},
+			input:    []string{"json", "keyvalue"},
+			expected: []Parser{&JsonParser{}, &KeyValueParser{}},
 		},
 		{
 			name:     "empty",
@@ -54,8 +54,13 @@ func TestIsValidParser(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "valid",
+			name:     "valid json",
 			input:    "json",
+			expected: true,
+		},
+		{
+			name:     "valid keyvalue",
+			input:    "keyvalue",
 			expected: true,
 		},
 		{
@@ -108,6 +113,17 @@ func TestExecuteParsers(t *testing.T) {
 			},
 		},
 		{
+			name:    "successful keyvalue parse",
+			parsers: []Parser{&KeyValueParser{}},
+			message: `a=1.1 b="abc" c=true message="hello"`,
+			expectedBody: map[string]interface{}{
+				"a":       1.1,
+				"b":       "abc",
+				"c":       true,
+				"message": "hello",
+			},
+		},
+		{
 			name:    "skips failing parser",
 			parsers: []Parser{&alwaysFailingParser{}, &JsonParser{}},
 			message: `{"a": 1, "b": "2", "c": {"d": 3}}`,
@@ -155,6 +171,15 @@ func TestExecuteParsers(t *testing.T) {
 			message: `{"a": 1, "b": "2", "c": {"d": 3}}`,
 			expectedBody: map[string]interface{}{
 				types.BodyKeyMessage: `{"a": 1, "b": "2", "c": {"d": 3}}`,
+			},
+		},
+		{
+			name:    "json and keyvalue parsers",
+			parsers: []Parser{&JsonParser{}, &KeyValueParser{}},
+			message: `a=b c=d`,
+			expectedBody: map[string]interface{}{
+				"a": "b",
+				"c": "d",
 			},
 		},
 	}


### PR DESCRIPTION
This pull request introduces a new key-value parser to the `collector/logs/transforms/parser` package. The main changes include the implementation of the parser itself, the addition of corresponding tests, and the integration of the parser into the existing parser framework.

Key changes:

### Implementation of Key-Value Parser:

* [`collector/logs/transforms/parser/keyvalue.go`](diffhunk://#diff-2470a5a61aeab3d23b951d2762abc5530cad5301dba4504d54f903b9522dd433R1-R159): Added the `KeyValueParser` class and its associated methods, including `Parse`, `tokenize`, `unquote`, and `reflectValue`. This parser handles the parsing of space-separated key-value pairs and standalone keys.

### Test Cases for Key-Value Parser:

* [`collector/logs/transforms/parser/keyvalue_test.go`](diffhunk://#diff-6b0a84d5af4f4657adc15a1f1cfbd4c542cefa285b6b0071f7cb338d9bb3f347R1-R141): Added comprehensive test cases to validate the functionality of the `KeyValueParser`, covering various scenarios such as simple key-value pairs, keys without values, quoted values, and numeric values.

### Integration with Existing Parser Framework:

* [`collector/logs/transforms/parser/parser.go`](diffhunk://#diff-50bba9684ea67d823297e8274d0edee3b00a714417153ada5e1b6b28ae6db3eeR27-R28): Updated `newParser` and `IsValidParser` functions to support the new `KeyValueParser`. [[1]](diffhunk://#diff-50bba9684ea67d823297e8274d0edee3b00a714417153ada5e1b6b28ae6db3eeR27-R28) [[2]](diffhunk://#diff-50bba9684ea67d823297e8274d0edee3b00a714417153ada5e1b6b28ae6db3eeR53-R54)

### Test Updates for Parser Framework:

* [`collector/logs/transforms/parser/parser_test.go`](diffhunk://#diff-53352b31cf60bb1b87d00fc4cb46ab9ee3666b86a0cb819719f48ab94a84cd64L19-R20): Modified existing tests to include the `KeyValueParser` in the list of valid parsers and added new test cases to ensure the parser framework correctly handles key-value parsing. [[1]](diffhunk://#diff-53352b31cf60bb1b87d00fc4cb46ab9ee3666b86a0cb819719f48ab94a84cd64L19-R20) [[2]](diffhunk://#diff-53352b31cf60bb1b87d00fc4cb46ab9ee3666b86a0cb819719f48ab94a84cd64L57-R65) [[3]](diffhunk://#diff-53352b31cf60bb1b87d00fc4cb46ab9ee3666b86a0cb819719f48ab94a84cd64R115-R125) [[4]](diffhunk://#diff-53352b31cf60bb1b87d00fc4cb46ab9ee3666b86a0cb819719f48ab94a84cd64R176-R184)