### PR TITLE
Record table size data regularly

### DIFF
--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -190,10 +190,15 @@ func NewService(opts ServiceOpts) (*Service, error) {
 
 	health.QueueSizer = batcher
 
+	allKustoCli := make([]metrics.StatementExecutor, 0, len(opts.MetricsKustoCli)+len(opts.LogsKustoCli))
+	allKustoCli = append(allKustoCli, opts.MetricsKustoCli...)
+	allKustoCli = append(allKustoCli, opts.LogsKustoCli...)
+
 	metricsSvc := metrics.NewService(metrics.ServiceOpts{
 		Hostname:         opts.Hostname,
 		Elector:          coord,
-		KustoCli:         opts.MetricsKustoCli,
+		MetricsKustoCli:  opts.MetricsKustoCli,
+		KustoCli:         allKustoCli,
 		PeerHealthReport: health,
 	})
 

--- a/metrics/service.go
+++ b/metrics/service.go
@@ -104,6 +104,23 @@ func (s *service) collect(ctx context.Context) {
 							iter.Stop()
 						}
 					}
+
+					stmt = kusto.NewStmt("", kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(
+						".set-or-append async AdxmonIngestorTableSize <| .show tables details" +
+							"| extend PreciseTimeStamp = now() " +
+							"| project PreciseTimeStamp, DatabaseName, TableName, TotalExtents, TotalExtentSize, TotalOriginalSize, TotalRowCount, HotExtents, HotExtentSize, HotOriginalSize," +
+							"HotRowCount, RetentionPolicy, CachingPolicy, ShardingPolicy, MergePolicy, IngestionBatchingPolicy, MinExtentsCreationTime, MaxExtentsCreationTime, TableId",
+					)
+
+					for _, cli := range s.kustoClis {
+						iter, err := cli.Mgmt(ctx, stmt)
+						if err != nil {
+							logger.Errorf("Failed to execute table sizes: %s", err)
+						} else {
+							iter.Stop()
+						}
+					}
+
 				}
 			}
 


### PR DESCRIPTION
This will be useful to understand large table growth and how much each table contributes to hot cache/cluster size.

This runs `.show tables details` every minute and stores the output in `AdxmonIngestorTableDetails` so we can have this data tracked over time.