### PR TITLE
Large segment handling changes

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -65,6 +65,7 @@ func main() {
 			&cli.BoolFlag{Name: "enable-wal-fsync", Usage: "Enable WAL fsync", Value: false},
 			&cli.IntFlag{Name: "max-transfer-concurrency", Usage: "Maximum transfer requests in flight", Value: 50},
 			&cli.IntFlag{Name: "partition-size", Usage: "Maximum number of nodes in a partition", Value: 25},
+			&cli.DurationFlag{Name: "slow-request-threshold", Usage: "Threshold for slow requests. Set to 0 to disable.", Value: 10 * time.Second},
 
 			&cli.StringFlag{Name: "ca-cert", Usage: "CA certificate file"},
 			&cli.StringFlag{Name: "key", Usage: "Server key file"},
@@ -136,6 +137,7 @@ func realMain(ctx *cli.Context) error {
 	disablePeerTransfer = ctx.Bool("disable-peer-transfer")
 	maxTransferConcurrency := ctx.Int("max-transfer-concurrency")
 	enableWALFsync := ctx.Bool("enable-wal-fsync")
+	slowRequestThreshold := ctx.Duration("slow-request-threshold")
 
 	if namespace == "" {
 		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
@@ -284,6 +286,7 @@ func realMain(ctx *cli.Context) error {
 		MaxTransferConcurrency: maxTransferConcurrency,
 		InsecureSkipVerify:     insecureSkipVerify,
 		DropFilePrefixes:       dropPrefixes,
+		SlowRequestThreshold:   slowRequestThreshold.Seconds(),
 	})
 	if err != nil {
 		logger.Fatalf("Failed to create service: %s", err)

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -269,7 +269,7 @@ func (w *WAL) rotate(ctx context.Context) {
 }
 
 func (w *WAL) requiresRotation() bool {
-	return (w.opts.SegmentMaxSize > 0 && atomic.LoadInt64(&w.segmentSize) >= w.opts.SegmentMaxSize) ||
+	return (w.opts.SegmentMaxSize > 0 && atomic.LoadInt64(&w.segmentSize)+atomic.LoadInt64(&w.inflightWriteBytes) >= w.opts.SegmentMaxSize) ||
 		(w.opts.SegmentMaxAge.Seconds() > 0 && time.Since(time.Unix(w.segmentCreatedAt, 0)) >= w.opts.SegmentMaxAge)
 }
 


### PR DESCRIPTION
This pull request introduces a new feature to log slow requests and includes a few other improvements. The most important changes are the addition of a `slow-request-threshold` flag, modifications to handle this new flag, and an enhancement to the WAL rotation logic.

### New Feature: Slow Request Logging

* [`cmd/ingestor/main.go`](diffhunk://#diff-5ab380573a6eb9c62fc65adafbeb865ad5677e5aab550a7dfe9bf65b4e0ab711R68): Added a new CLI flag `slow-request-threshold` to set the threshold for slow requests. This flag is read and passed to the `ServiceOpts` structure. [[1]](diffhunk://#diff-5ab380573a6eb9c62fc65adafbeb865ad5677e5aab550a7dfe9bf65b4e0ab711R68) [[2]](diffhunk://#diff-5ab380573a6eb9c62fc65adafbeb865ad5677e5aab550a7dfe9bf65b4e0ab711R140) [[3]](diffhunk://#diff-5ab380573a6eb9c62fc65adafbeb865ad5677e5aab550a7dfe9bf65b4e0ab711R289)
* [`ingestor/service.go`](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4R138-R140): Added `SlowRequestThreshold` to the `ServiceOpts` structure and updated the `HandleTransfer` method to log slow requests based on this threshold. [[1]](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4R138-R140) [[2]](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4L365-R368)

### WAL Rotation Bugfix

* [`pkg/wal/wal.go`](diffhunk://#diff-d1376e7d1b7d397f29bcda9a052cd90550cd8f4139fe3f89657070b1c56b3c7dL272-R272): Enhanced the `requiresRotation` method to consider in-flight write bytes when determining if a WAL segment requires rotation.  This was not previously checked consistently so the segment was not rotated during the right back at times.