### PR TITLE
Disable readfile test because of container inconsistencies

### DIFF
--- a/collector/logs/sources/journal/tailer_linux_test.go
+++ b/collector/logs/sources/journal/tailer_linux_test.go
@@ -16,6 +16,7 @@ import (
 // Can view in journalctl with journalctl --file test_file.journal
 
 func TestReadFile(t *testing.T) {
+	t.Skip("skipping test because of inconsistent journalctl feature support in some build containers. Some will error out with 'protocol not supported' based on compiled features.")
 	tmpdir := t.TempDir()
 	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable")
 	queue := make(chan *types.Log, 1000)


### PR DESCRIPTION
Having a golden test file for journald tests is challenging due to incompatabilities with compiled journal library features. Certain distros enable some features which others do not (such as zstd, etc), making it challenging to read journal files from other distros. Skip this test for now, as it has limited value anyhow.