### PR TITLE
Request size tracking

### DIFF
--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/adx-mon/ingestor/cluster"
 	ingestorstorage "github.com/Azure/adx-mon/ingestor/storage"
 	"github.com/Azure/adx-mon/metrics"
+	"github.com/Azure/adx-mon/pkg/debug"
 	adxhttp "github.com/Azure/adx-mon/pkg/http"
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/reader"
@@ -327,6 +328,18 @@ func (s *Service) Close() error {
 	}
 
 	return s.store.Close()
+}
+
+func (s *Service) HandleDebugStore(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	if debugWriter, ok := s.store.(debug.DebugWriter); ok {
+		if err := debugWriter.WriteDebug(w); err != nil {
+			logger.Errorf("Failed to write debug info: %s", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		return
+	}
 }
 
 // HandleReady handles the readiness probe.

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -366,11 +366,13 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 
 	body := reader.NewCounterReader(r.Body)
 	defer func() {
+		io.Copy(io.Discard, body)
+
+		metrics.RequestsBytesReceived.Add(float64(body.Count()))
 		dur := time.Since(start)
 		if s.opts.SlowRequestThreshold > 0 && dur.Seconds() > s.opts.SlowRequestThreshold {
 			logger.Warnf("slow request: path=/transfer duration=%s from=%s size=%d file=%s", dur.String(), originalIP, body.Count(), filename)
 		}
-		io.Copy(io.Discard, body)
 		if err := body.Close(); err != nil {
 			logger.Errorf("close http body: %s, path=/transfer duration=%s from=%s", err.Error(), dur.String(), originalIP)
 		}

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -371,10 +371,10 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 		metrics.RequestsBytesReceived.Add(float64(body.Count()))
 		dur := time.Since(start)
 		if s.opts.SlowRequestThreshold > 0 && dur.Seconds() > s.opts.SlowRequestThreshold {
-			logger.Warnf("slow request: path=/transfer duration=%s from=%s size=%d file=%s", dur.String(), originalIP, body.Count(), filename)
+			logger.Warnf("Slow request: path=/transfer duration=%s from=%s size=%d file=%s", dur.String(), originalIP, body.Count(), filename)
 		}
 		if err := body.Close(); err != nil {
-			logger.Errorf("close http body: %s, path=/transfer duration=%s from=%s", err.Error(), dur.String(), originalIP)
+			logger.Errorf("Close http body: %s, path=/transfer duration=%s from=%s", err.Error(), dur.String(), originalIP)
 		}
 	}()
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,6 +23,13 @@ var (
 		Help:      "Counter of requests received from an ingestor instance",
 	}, []string{"path", "code"})
 
+	RequestsBytesReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "ingestor",
+		Name:      "requests_received_bytes_total",
+		Help:      "Counter of bytes received from an ingestor instance",
+	})
+
 	IngestorDroppedPrefixes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "ingestor",

--- a/pkg/debug/writer.go
+++ b/pkg/debug/writer.go
@@ -1,0 +1,9 @@
+package debug
+
+import "io"
+
+// DebugWriter is an interface that defines a method for writing debug information.  Implementers
+// should write a textual representation of their state to the provided io.Writer.
+type DebugWriter interface {
+	WriteDebug(w io.Writer) error
+}

--- a/pkg/reader/counter.go
+++ b/pkg/reader/counter.go
@@ -1,0 +1,33 @@
+package reader
+
+import (
+	"io"
+)
+
+// CounterReader wraps an io.ReadCloser and counts the bytes read.
+type CounterReader struct {
+	rc    io.ReadCloser
+	count int64
+}
+
+// NewCounterReader creates a new CounterReader.
+func NewCounterReader(rc io.ReadCloser) *CounterReader {
+	return &CounterReader{rc: rc}
+}
+
+// Read reads from the wrapped io.ReadCloser and counts the bytes read.
+func (cr *CounterReader) Read(p []byte) (int, error) {
+	n, err := cr.rc.Read(p)
+	cr.count += int64(n)
+	return n, err
+}
+
+// Close closes the wrapped io.ReadCloser.
+func (cr *CounterReader) Close() error {
+	return cr.rc.Close()
+}
+
+// Count returns the total number of bytes read.
+func (cr *CounterReader) Count() int64 {
+	return cr.count
+}

--- a/pkg/reader/counter_test.go
+++ b/pkg/reader/counter_test.go
@@ -1,0 +1,60 @@
+package reader_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Azure/adx-mon/pkg/reader"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounterReader_Read(t *testing.T) {
+	data := "Hello, World!"
+	r := strings.NewReader(data)
+	cr := reader.NewCounterReader(io.NopCloser(r))
+
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "Hello", string(buf[:n]))
+	require.Equal(t, int64(5), cr.Count())
+
+	n, err = cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, ", Wor", string(buf[:n]))
+	require.Equal(t, int64(10), cr.Count())
+
+	n, err = cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "ld!", string(buf[:n]))
+	require.Equal(t, int64(13), cr.Count())
+}
+
+func TestCounterReader_Read_Empty(t *testing.T) {
+	data := ""
+	r := strings.NewReader(data)
+	cr := reader.NewCounterReader(io.NopCloser(r))
+
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+	require.Error(t, io.EOF, err)
+	require.Equal(t, 0, n)
+	require.Equal(t, int64(0), cr.Count())
+}
+
+func TestCounterReader_Read_Partial(t *testing.T) {
+	data := "Hi"
+	r := strings.NewReader(data)
+	cr := reader.NewCounterReader(io.NopCloser(r))
+
+	buf := make([]byte, 5)
+	n, err := cr.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, "Hi", string(buf[:n]))
+	require.Equal(t, int64(2), cr.Count())
+}

--- a/pkg/wal/repository.go
+++ b/pkg/wal/repository.go
@@ -246,3 +246,11 @@ func (s *Repository) RemoveSegment(si SegmentInfo) {
 func (s *Repository) PrefixesByAge() []string {
 	return s.index.PrefixesByAge()
 }
+
+func (s *Repository) WriteDebug(w io.Writer) error {
+	_, _ = fmt.Fprintf(w, "Index: Disk Usage: %d, Segments: %d, Prefixes: %d\n\n", s.Index().TotalSize(), s.Index().TotalSegments(), s.Index().TotalPrefixes())
+	return s.wals.Each(func(key string, value *WAL) error {
+		_, _ = fmt.Fprintf(w, "├ Prefix: %s, Path: %s, Disk Usage: %d\n", key, value.Path(), value.Size())
+		return nil
+	})
+}

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -243,7 +243,7 @@ func (w *WAL) Size() int {
 	if w.segment == nil {
 		return 0
 	}
-	return 1
+	return int(w.segment.Size())
 }
 
 func (w *WAL) Segment() Segment {

--- a/pkg/wal/wal_test.go
+++ b/pkg/wal/wal_test.go
@@ -38,7 +38,7 @@ func TestNewWAL(t *testing.T) {
 			w.Write(context.Background(), []byte("foo"))
 			w.Write(context.Background(), []byte("foo"))
 			w.Write(context.Background(), []byte("foo"))
-			require.Equal(t, 1, w.Size())
+			require.True(t, w.Size() > 0)
 		})
 	}
 }
@@ -62,7 +62,7 @@ func TestWAL_Segment(t *testing.T) {
 			w.Write(context.Background(), []byte("1970-01-01T00:00:00.001Z,-414304664621325809,{},1.000000000\n"))
 			w.Write(context.Background(), []byte("1970-01-01T00:00:00.002Z,-414304664621325809,{},2.000000000\n"))
 
-			require.Equal(t, 1, w.Size())
+			require.True(t, w.Size() > 0)
 
 			path := w.Path()
 
@@ -97,7 +97,7 @@ func TestWAL_Open(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, w.Open(context.Background()))
 			w.Write(context.Background(), []byte("foo"))
-			require.Equal(t, 1, w.Size())
+			require.True(t, w.Size() > 0)
 
 			require.NoError(t, w.Close())
 
@@ -110,7 +110,7 @@ func TestWAL_Open(t *testing.T) {
 			require.Equal(t, 0, w.Size())
 
 			w.Write(context.Background(), []byte("foo"))
-			require.Equal(t, 1, w.Size())
+			require.True(t, w.Size() > 0)
 		})
 	}
 }


### PR DESCRIPTION
This pull request introduces a new `CounterReader` to track the number of bytes read from HTTP requests in the `ingestor` service. Additionally, it adds a new Prometheus metric to record the total bytes received. The most important changes include the creation of the `CounterReader` class, modifications to the `HandleTransfer` function to use this new reader, and the addition of the new metric.

### Introduction of `CounterReader`:

* [`pkg/reader/counter.go`](diffhunk://#diff-0db29dd549f123173a2ddaac228482ba788f22066d5f48bfe9757e701aaf6ab2R1-R33): Added a new `CounterReader` class that wraps an `io.ReadCloser` and counts the bytes read.
* [`pkg/reader/counter_test.go`](diffhunk://#diff-73e6a5a44dfa8c654c9398b49f66ceeeb6afc9ffff287a4a123a60e473f69e0aR1-R60): Added tests for the `CounterReader` class to ensure it correctly counts bytes read in various scenarios.

### Modifications to `HandleTransfer` function:

* [`ingestor/service.go`](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4R367-R383): Updated the `HandleTransfer` function to use `CounterReader` instead of directly reading from the request body. This change allows the counting of bytes read and improves logging and metrics collection. [[1]](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4R367-R383) [[2]](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4L402-R407)

### Addition of new metric:

* [`metrics/metrics.go`](diffhunk://#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4R26-R32): Added a new Prometheus counter `RequestsBytesReceived` to track the total bytes received from an ingestor instance.

### Import changes:

* [`ingestor/service.go`](diffhunk://#diff-cdc4c0859afc8f4c1fa3efb19ee6d9f8d57fbcf6a553951683735670d7d016d4R21): Added import for the new `reader` package.