### PR TITLE
ManagementCommands should use correct scope

### DIFF
--- a/api/v1/conditions.go
+++ b/api/v1/conditions.go
@@ -4,6 +4,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ConditionedObject defines interface for objects that can have conditions
+// +k8s:deepcopy-gen=false
 type ConditionedObject interface {
 	GetCondition() *metav1.Condition
 	SetCondition(condition metav1.Condition)

--- a/api/v1/managementcommand_types.go
+++ b/api/v1/managementcommand_types.go
@@ -17,7 +17,7 @@ type ManagementCommandSpec struct {
 	// Database is the target database for a management command. Not all management commands
 	// are database specific.
 	// +kubebuilder:validation:Optional
-	Database string `json:"foo,omitempty"`
+	Database string `json:"database,omitempty"`
 
 	// Body is the management command to execute
 	Body string `json:"body"`

--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -215,7 +215,12 @@ func (t *ManagementCommandTask) Run(ctx context.Context) error {
 			continue
 		}
 
-		stmt := kql.New(".execute script<|").AddUnsafe(command.Spec.Body)
+		var stmt *kql.Builder
+		if command.Spec.Database == "" {
+			stmt = kql.New(".execute cluster script <|").AddUnsafe(command.Spec.Body)
+		} else {
+			stmt = kql.New(".execute database script <|").AddUnsafe(command.Spec.Body)
+		}
 		if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
 			logger.Errorf("Failed to execute management command %s.%s: %v", command.Spec.Database, command.Name, err)
 			if err = t.store.UpdateStatus(ctx, &command, err); err != nil {

--- a/kustomize/bases/managementcommands_crd.yaml
+++ b/kustomize/bases/managementcommands_crd.yaml
@@ -42,7 +42,7 @@ spec:
               body:
                 description: Body is the management command to execute
                 type: string
-              foo:
+              database:
                 description: |-
                   Database is the target database for a management command. Not all management commands
                   are database specific.


### PR DESCRIPTION
ManagementCommands can be scoped to either a Database or Cluster. If scoped to the Cluster, we have to alter the script execution to include the correct scope `.execute cluster script`.

This pull request includes several changes to the management commands functionality in the `ingestor/adx` package, as well as updates to the API definitions and tests. The most important changes include the addition of the `ConditionedObject` interface, renaming the `Database` field in `ManagementCommandSpec`, adjusting the command execution logic based on the presence of a database, and updating the test cases to cover new scenarios.

### API Changes:
* Added `ConditionedObject` interface to `api/v1/conditions.go` to define objects that can have conditions.
* Renamed the `Database` field in `ManagementCommandSpec` from `foo` to `database` in `api/v1/managementcommand_types.go`.

### Command Execution Logic:
* Updated the `Run` method in `ingestor/adx/tasks.go` to handle command execution differently based on whether a database is specified.

### Tests:
* Added test case for creating database management commands in `ingestor/adx/tasks_test.go`.
* Added test case for creating cluster management commands in `ingestor/adx/tasks_test.go`.

### Documentation:
* Updated `kustomize/bases/managementcommands_crd.yaml` to reflect the renaming of the `Database` field.