### PR TITLE
(fix) Crash in Ingestor when disk fills up

### DIFF
--- a/build/k8s/ingestor.yaml
+++ b/build/k8s/ingestor.yaml
@@ -29,6 +29,8 @@ rules:
       - adx-mon.azure.com
     resources:
       - functions
+      - managementcommands
+      - summaryrules
     verbs:
       - get
       - list
@@ -45,6 +47,8 @@ rules:
       - adx-mon.azure.com
     resources:
       - functions/finalizers
+      - managementcommands/finalizers
+      - summaryrules/finalizers
     verbs:
       - get
       - update

--- a/pkg/testutils/ingestor/ingestor.go
+++ b/pkg/testutils/ingestor/ingestor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,12 +17,14 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimacherrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,6 +91,20 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 func WithStarted() testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Started = true
+		return nil
+	}
+}
+
+// WithTmpfsMount configures a tmpfs volume with specific size for the ingestor
+func WithTmpfsMount(sizeBytes int64) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		// Store the size in a custom field in the Env map
+		// We'll use a special key that won't conflict with actual environment variables
+		if req.Env == nil {
+			req.Env = make(map[string]string)
+		}
+		req.Env["__TMPFS_SIZE_BYTES__"] = fmt.Sprintf("%d", sizeBytes)
+
 		return nil
 	}
 }
@@ -172,12 +189,26 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 					// 	},
 					// }
 
+					// Extract the size if this was configured
+					var (
+						mountSizeBytes int64 = 21474836480 // Default 20GB
+						storageDir           = "/mnt/data" // Default path
+						hasVolumeMount       = false
+					)
+					// Check if a tmpfs size was specified
+					if sizeStr, ok := req.Env["__TMPFS_SIZE_BYTES__"]; ok {
+						if size, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
+							mountSizeBytes = size
+							hasVolumeMount = true
+						}
+					}
+
 					statefulSet.Spec.Template.Spec.Containers[0].Image = img
 					statefulSet.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
 					statefulSet.Spec.Template.Spec.Containers[0].Args = []string{
-						"--storage-dir=/mnt/data",
+						fmt.Sprintf("--storage-dir=%s", storageDir),
 						"--max-segment-age=5s",
-						"--max-disk-usage=21474836480",
+						fmt.Sprintf("--max-disk-usage=%d", mountSizeBytes),
 						"--max-transfer-size=10485760",
 						"--max-connections=1000",
 						"--insecure-skip-verify",
@@ -186,6 +217,43 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 					}
 					statefulSet.Spec.Template.Spec.Affinity = nil
 					statefulSet.Spec.Template.Spec.Tolerations = nil
+
+					// Update StatefulSet to use hostPath volume
+					if hasVolumeMount {
+						// First, find and remove the existing "metrics" volume if it exists
+						for i, vol := range statefulSet.Spec.Template.Spec.Volumes {
+							if vol.Name == "metrics" {
+								// Remove the existing volume by reslicing
+								statefulSet.Spec.Template.Spec.Volumes = append(
+									statefulSet.Spec.Template.Spec.Volumes[:i],
+									statefulSet.Spec.Template.Spec.Volumes[i+1:]...,
+								)
+								break
+							}
+						}
+
+						// Now add our tmpfs volume
+						statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, corev1.Volume{
+							Name: "metrics", // Use "metrics" to match the existing volumeMount
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+									SizeLimit: &[]resource.Quantity{
+										resource.MustParse(fmt.Sprintf("%dMi", mountSizeBytes/1024/1024)),
+									}[0],
+								},
+							},
+						})
+
+						// Add the filler container to the pod spec
+						fillerContainer := createFillerContainer(storageDir)
+						statefulSet.Spec.Template.Spec.Containers = append(
+							statefulSet.Spec.Template.Spec.Containers,
+							fillerContainer,
+						)
+
+						// We're keeping the existing volumeMount since it's already pointing to /mnt/data
+					}
 
 					restConfig, _, err := testutils.GetKubeConfig(ctx, k)
 					if err != nil {
@@ -210,17 +278,39 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 						return fmt.Errorf("failed to wait for namespace: %w", err)
 					}
 
-					patchBytes, err := json.Marshal(statefulSet)
-					if err != nil {
-						return fmt.Errorf("failed to marshal statefulset: %w", err)
-					}
-					_, err = clientset.AppsV1().StatefulSets(statefulSet.Namespace).Patch(ctx, statefulSet.Name, types.ApplyPatchType, patchBytes, metav1.PatchOptions{
-						FieldManager: "testcontainers",
-					})
-					if err != nil {
-						return fmt.Errorf("failed to patch statefulset: %w", err)
+					// Check if StatefulSet already exists
+					existingStatefulSet := &appsv1.StatefulSet{}
+					err = ctrlCli.Get(ctx, types.NamespacedName{
+						Namespace: statefulSet.Namespace,
+						Name:      statefulSet.Name,
+					}, existingStatefulSet)
+
+					// If it exists, delete it first
+					if err == nil {
+						// StatefulSet exists, delete it
+						if err := ctrlCli.Delete(ctx, existingStatefulSet); err != nil {
+							return fmt.Errorf("failed to delete existing statefulset: %w", err)
+						}
+
+						// Wait for deletion to complete
+						err = kwait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+							err := ctrlCli.Get(ctx, types.NamespacedName{
+								Namespace: statefulSet.Namespace,
+								Name:      statefulSet.Name,
+							}, &appsv1.StatefulSet{})
+							return apimacherrors.IsNotFound(err), nil
+						})
+						if err != nil {
+							return fmt.Errorf("failed to wait for statefulset deletion: %w", err)
+						}
 					}
 
+					// Create the new StatefulSet
+					if err := ctrlCli.Create(ctx, &statefulSet); err != nil {
+						return fmt.Errorf("failed to create statefulset: %w", err)
+					}
+
+					// Continue with Function creation...
 					if err := ctrlCli.Get(ctx, types.NamespacedName{Namespace: ingestorFunction.Namespace, Name: ingestorFunction.Name}, ingestorFunction); err != nil {
 						if err := ctrlCli.Create(ctx, ingestorFunction); err != nil {
 							return fmt.Errorf("failed to create function: %w", err)
@@ -233,6 +323,123 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 		})
 
 		return nil
+	}
+}
+
+// IngestorStatus contains details about the ingestor pods
+type IngestorStatus struct {
+	TotalPods      int                 // Total number of ingestor pods
+	RunningPods    int                 // Number of running pods
+	UnhealthyPods  int                 // Number of pods not in running state
+	PodStatuses    map[string]string   // Map of pod name to status
+	RestartCounts  map[string]int32    // Map of pod name to restart count
+	ContainerState map[string][]string // Map of pod name to container states
+}
+
+// VerifyIngestorRunning checks if ingestor pods are running properly
+func VerifyIngestorRunning(ctx context.Context, restConfig *rest.Config) (bool, *IngestorStatus, error) {
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	namespace := "adx-mon" // Namespace where ingestor is deployed
+	labelSelector := "app=ingestor"
+
+	// List pods with the ingestor label
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to list ingestor pods: %w", err)
+	}
+
+	status := &IngestorStatus{
+		TotalPods:      len(pods.Items),
+		RunningPods:    0,
+		UnhealthyPods:  0,
+		PodStatuses:    make(map[string]string),
+		RestartCounts:  make(map[string]int32),
+		ContainerState: make(map[string][]string),
+	}
+
+	// If no pods found, return false
+	if status.TotalPods == 0 {
+		return false, status, fmt.Errorf("no ingestor pods found")
+	}
+
+	// Check each pod's status
+	for _, pod := range pods.Items {
+		podName := pod.Name
+		status.PodStatuses[podName] = string(pod.Status.Phase)
+
+		// Count running pods
+		if pod.Status.Phase == corev1.PodRunning {
+			status.RunningPods++
+		} else {
+			status.UnhealthyPods++
+		}
+
+		// Track container restart counts and states
+		totalRestarts := int32(0)
+		containerStates := make([]string, 0)
+
+		// Check container statuses
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			totalRestarts += containerStatus.RestartCount
+
+			// Determine container state
+			state := "unknown"
+			if containerStatus.State.Running != nil {
+				state = fmt.Sprintf("running (started at %s)", containerStatus.State.Running.StartedAt.Format(time.RFC3339))
+			} else if containerStatus.State.Waiting != nil {
+				state = fmt.Sprintf("waiting: %s - %s",
+					containerStatus.State.Waiting.Reason,
+					containerStatus.State.Waiting.Message)
+			} else if containerStatus.State.Terminated != nil {
+				state = fmt.Sprintf("terminated: %s (exit code %d) - %s",
+					containerStatus.State.Terminated.Reason,
+					containerStatus.State.Terminated.ExitCode,
+					containerStatus.State.Terminated.Message)
+			}
+
+			containerStates = append(containerStates,
+				fmt.Sprintf("%s: %s", containerStatus.Name, state))
+		}
+
+		status.RestartCounts[podName] = totalRestarts
+		status.ContainerState[podName] = containerStates
+	}
+
+	// All pods should be running and have no excessive restarts
+	allPodsRunning := status.RunningPods == status.TotalPods
+
+	return allPodsRunning, status, nil
+}
+
+// createFillerContainer returns a container spec that continuously creates 1MB files
+// in the specified directory and handles disk-full scenarios gracefully
+func createFillerContainer(mountPath string) corev1.Container {
+	return corev1.Container{
+		Name:            "storage-filler",
+		Image:           "mcr.microsoft.com/cbl-mariner/base/core:2.0.20250304",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"/bin/bash",
+			"-c",
+		},
+		Args: []string{
+			`while true; do
+                dd if=/dev/zero of="` + mountPath + `/filler-$(date +%s).dat" bs=10K count=1 2>/dev/null || true
+                sleep 1
+            done`,
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "metrics",
+				MountPath: mountPath,
+			},
+		},
 	}
 }
 

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -290,9 +290,12 @@ func (w *WAL) rotateSegmentIfNecessary() {
 		if err != nil {
 			logger.Errorf("Failed to create new segment: %s", err.Error())
 			w.segment = nil
+			atomic.StoreInt64(&w.segmentSize, 0)
+			atomic.StoreInt64(&w.segmentCreatedAt, 0)
+		} else {
+			atomic.StoreInt64(&w.segmentSize, w.segment.Size())
+			atomic.StoreInt64(&w.segmentCreatedAt, w.segment.CreatedAt().Unix())
 		}
-		atomic.StoreInt64(&w.segmentSize, w.segment.Size())
-		atomic.StoreInt64(&w.segmentCreatedAt, w.segment.CreatedAt().Unix())
 		w.mu.Unlock()
 
 		if toClose != nil {


### PR DESCRIPTION
Fix a crash in Ingestor when the disk fills up and introduce an integration test to verify Ingestor remains running after a disk fills up by simulating a full disk when a small tempfs volume attached to its container.

```bash
{"ts":"2025-03-27T17:54:52.152949Z","lvl":"ERR","msg":"Failed to create new segment: write /mnt/data/Logs_Collector_3la1vyef1yww1_2946d24b3c650000.wal: no space left on device"}
{"ts":"2025-03-27T17:54:52.152945Z","lvl":"ERR","msg":"Failed to create new segment: write /mnt/data/Logs_Ingestor_3la1vyef1yww1_2946d24b3c650001.wal: no space left on device"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0xc03d04]

goroutine 256 [running]:
github.com/Azure/adx-mon/pkg/wal.(*WAL).rotateSegmentIfNecessary(0xc0005501c0)
        /code/pkg/wal/wal.go:294 +0x1e4
github.com/Azure/adx-mon/pkg/wal.(*WAL).rotate(0xc0005501c0, {0x2cf0fa8, 0xc000376c80})
        /code/pkg/wal/wal.go:266 +0xb5
created by github.com/Azure/adx-mon/pkg/wal.(*WAL).Open in goroutine 342
        /code/pkg/wal/wal.go:141 +0x11c
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0xc03d04]

goroutine 260 [running]:
github.com/Azure/adx-mon/pkg/wal.(*WAL).rotateSegmentIfNecessary(0xc00021ae00)
        /code/pkg/wal/wal.go:294 +0x1e4
github.com/Azure/adx-mon/pkg/wal.(*WAL).rotate(0xc00021ae00, {0x2cf0fa8, 0xc0004c8550})
        /code/pkg/wal/wal.go:266 +0xb5
created by github.com/Azure/adx-mon/pkg/wal.(*WAL).Open in goroutine 343
        /code/pkg/wal/wal.go:141 +0x11c
```

This pull request includes several changes to the Kubernetes ingestor configuration and test utilities to enhance functionality and improve testing capabilities. The most important changes include adding new resources to the ingestor's configuration, introducing a new function to configure tmpfs mounts, and adding comprehensive status verification for ingestor pods.

### Kubernetes Ingestor Configuration:
* [`build/k8s/ingestor.yaml`](diffhunk://#diff-db3f544bfec944cee115443c95c1fa26d84d83d727f34a71c887cf8fd0dc1e47R32-R33): Added `managementcommands` and `summaryrules` resources to the `rules:` section to expand the ingestor's capabilities. [[1]](diffhunk://#diff-db3f544bfec944cee115443c95c1fa26d84d83d727f34a71c887cf8fd0dc1e47R32-R33) [[2]](diffhunk://#diff-db3f544bfec944cee115443c95c1fa26d84d83d727f34a71c887cf8fd0dc1e47R50-R51)

### Test Utilities Enhancements:
* [`pkg/testutils/ingestor/ingestor.go`](diffhunk://#diff-924d413d646dbf16f3d2adae6fdef6fed629d10ba4c8365bf5d973097cdf46b4R98-R111): Introduced `WithTmpfsMount` function to configure tmpfs volumes, updated `WithCluster` function to handle tmpfs volumes, and added a new `IngestorStatus` struct along with `VerifyIngestorRunning` function to verify the status of ingestor pods. [[1]](diffhunk://#diff-924d413d646dbf16f3d2adae6fdef6fed629d10ba4c8365bf5d973097cdf46b4R98-R111) [[2]](diffhunk://#diff-924d413d646dbf16f3d2adae6fdef6fed629d10ba4c8365bf5d973097cdf46b4R192-R211) [[3]](diffhunk://#diff-924d413d646dbf16f3d2adae6fdef6fed629d10ba4c8365bf5d973097cdf46b4L213-R313) [[4]](diffhunk://#diff-924d413d646dbf16f3d2adae6fdef6fed629d10ba4c8365bf5d973097cdf46b4R329-R445)
* [`pkg/testutils/integration_test.go`](diffhunk://#diff-00ba9b7418961cff0fd3ab3e72465cca23aa9329139bba209b66cf192ded740aR195-R260): Added `TestDiskFull` test to verify ingestor behavior when disk space is full and `WaitForNoSpaceLeftError` function to check for disk full errors in pod logs. [[1]](diffhunk://#diff-00ba9b7418961cff0fd3ab3e72465cca23aa9329139bba209b66cf192ded740aR195-R260) [[2]](diffhunk://#diff-00ba9b7418961cff0fd3ab3e72465cca23aa9329139bba209b66cf192ded740aR322-R385)

### Codebase Maintenance:
* [`pkg/wal/wal.go`](diffhunk://#diff-d1376e7d1b7d397f29bcda9a052cd90550cd8f4139fe3f89657070b1c56b3c7dL293-R296): Fixed a bug in `rotateSegmentIfNecessary` function to ensure proper segment size and creation time updates.

These changes improve the robustness and functionality of the Kubernetes ingestor and enhance the testing framework to better handle and verify edge cases.