### PR TITLE
fix(ingestor): Readiness probe missing https scheme

### DIFF
--- a/build/k8s/ingestor.yaml
+++ b/build/k8s/ingestor.yaml
@@ -150,6 +150,7 @@ spec:
             httpGet:
               path: /readyz
               port: 9090
+              scheme: HTTPS
             initialDelaySeconds: 10
             periodSeconds: 5
       affinity:


### PR DESCRIPTION
Ingestor pods do not become ready because readiness probe fails with the error: `2025/03/28 13:08:04 http: TLS handshake error from 10.224.0.6:37448: client sent an HTTP request to an HTTPS server`

This is because the readiness probe defaults to http scheme and the server is configured for tls. 