### PR TITLE
Freeze logs prior to sending to sinks

### DIFF
--- a/collector/logs/engine/worker.go
+++ b/collector/logs/engine/worker.go
@@ -12,8 +12,6 @@ type worker struct {
 	Input      <-chan *types.LogBatch
 	Transforms []types.Transformer
 	Sink       types.Sink
-	Database   string
-	Table      string
 }
 
 type WorkerCreatorFunc func(string, <-chan *types.LogBatch) *worker
@@ -29,6 +27,8 @@ func WorkerCreator(transforms []types.Transformer, sink types.Sink) func(string,
 	}
 }
 
+// Run starts the worker and processes incoming log batches.
+// It will block until the input channel is closed.
 func (w *worker) Run() {
 	for msg := range w.Input {
 		w.processBatch(context.Background(), msg)
@@ -55,7 +55,7 @@ func (w *worker) processBatch(ctx context.Context, batch *types.LogBatch) {
 		// Nack batch?
 		return
 	}
-	metrics.LogsCollectorLogsSent.WithLabelValues(w.SourceName, w.Sink.Name(), w.Database, w.Table).Add(float64(len(batch.Logs)))
+	metrics.LogsCollectorLogsSent.WithLabelValues(w.SourceName, w.Sink.Name()).Add(float64(len(batch.Logs)))
 	disposeBatch(batch)
 }
 

--- a/collector/logs/engine/worker.go
+++ b/collector/logs/engine/worker.go
@@ -47,6 +47,11 @@ func (w *worker) processBatch(ctx context.Context, batch *types.LogBatch) {
 			return
 		}
 	}
+
+	// Freeze the logs in the batch to prevent further modifications
+	for _, log := range batch.Logs {
+		log.Freeze()
+	}
 	err = w.Sink.Send(ctx, batch)
 	if err != nil {
 		metrics.LogsCollectorLogsDropped.WithLabelValues(w.SourceName, w.Sink.Name()).Add(float64(len(batch.Logs)))

--- a/collector/logs/sinks/store.go
+++ b/collector/logs/sinks/store.go
@@ -8,19 +8,16 @@ import (
 )
 
 type StoreSinkConfig struct {
-	Store         storage.Store
-	AddAttributes map[string]string
+	Store storage.Store
 }
 
 type StoreSink struct {
-	store         storage.Store
-	addAttributes map[string]string
+	store storage.Store
 }
 
 func NewStoreSink(config StoreSinkConfig) (*StoreSink, error) {
 	return &StoreSink{
-		store:         config.Store,
-		addAttributes: config.AddAttributes,
+		store: config.Store,
 	}, nil
 }
 
@@ -29,11 +26,6 @@ func (s *StoreSink) Open(ctx context.Context) error {
 }
 
 func (s *StoreSink) Send(ctx context.Context, batch *types.LogBatch) error {
-	for _, l := range batch.Logs {
-		for k, v := range s.addAttributes {
-			l.SetResourceValue(k, v)
-		}
-	}
 	err := s.store.WriteNativeLogs(ctx, batch)
 	if err != nil {
 		return err

--- a/collector/logs/sources/tail/tailer.go
+++ b/collector/logs/sources/tail/tailer.go
@@ -100,8 +100,6 @@ func StartTailing(config TailerConfig) (*Tailer, error) {
 	}()
 
 	worker := config.WorkerCreator(config.WorkerName, outputQueue)
-	worker.Database = config.Target.Database
-	worker.Table = config.Target.Table
 	tailer.wg.Add(1)
 	go func() {
 		defer tailer.wg.Done()

--- a/collector/logs/transforms/plugin/addattributes/add_attributes.go
+++ b/collector/logs/transforms/plugin/addattributes/add_attributes.go
@@ -1,0 +1,54 @@
+package addattributes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+type Config struct {
+	ResourceValues map[string]string
+}
+
+type Transform struct {
+	resourceValues map[string]string
+}
+
+func NewTransform(config Config) *Transform {
+	return &Transform{
+		resourceValues: config.ResourceValues,
+	}
+}
+
+func FromConfigMap(config map[string]interface{}) (types.Transformer, error) {
+	resourceValues, ok := config["ResourceValues"].(map[string]string)
+	if !ok {
+		return nil, fmt.Errorf("ResourceValues is required")
+	}
+
+	return &Transform{
+		resourceValues: resourceValues,
+	}, nil
+}
+
+func (t *Transform) Open(ctx context.Context) error {
+	return nil
+}
+
+func (t *Transform) Transform(ctx context.Context, batch *types.LogBatch) (*types.LogBatch, error) {
+	for _, log := range batch.Logs {
+		for key, value := range t.resourceValues {
+			log.SetResourceValue(key, value)
+		}
+	}
+	return batch, nil
+}
+
+func (t *Transform) Close() error {
+	return nil
+}
+
+func (t *Transform) Name() string {
+	return "AddAttributesTransform"
+}

--- a/collector/logs/transforms/plugin/addattributes/add_attributes_test.go
+++ b/collector/logs/transforms/plugin/addattributes/add_attributes_test.go
@@ -1,0 +1,184 @@
+package addattributes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAttributesTransform_New(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		expectedAttrs map[string]string
+	}{
+		{
+			name: "with values",
+			config: Config{
+				ResourceValues: map[string]string{
+					"environment": "test",
+					"service":     "adx-mon",
+				},
+			},
+			expectedAttrs: map[string]string{
+				"environment": "test",
+				"service":     "adx-mon",
+			},
+		},
+		{
+			name: "empty config",
+			config: Config{
+				ResourceValues: map[string]string{},
+			},
+			expectedAttrs: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := NewTransform(tt.config)
+			assert.Equal(t, tt.expectedAttrs, transformer.resourceValues)
+		})
+	}
+}
+
+func TestAddAttributesTransform_FromConfigMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		configMap   map[string]interface{}
+		expectError bool
+	}{
+		{
+			name: "valid config",
+			configMap: map[string]interface{}{
+				"ResourceValues": map[string]string{
+					"environment": "test",
+					"service":     "adx-mon",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "missing resource_values",
+			configMap: map[string]interface{}{
+				"wrong_key": "value",
+			},
+			expectError: true,
+		},
+		{
+			name: "resource_values not a map",
+			configMap: map[string]interface{}{
+				"ResourceValues": "not a map",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer, err := FromConfigMap(tt.configMap)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, transformer)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, transformer)
+				assert.IsType(t, &Transform{}, transformer)
+			}
+		})
+	}
+}
+
+func TestAddAttributesTransform_Transform(t *testing.T) {
+	tests := []struct {
+		name              string
+		resourceValues    map[string]string
+		inputResources    map[string]interface{}
+		expectedResources map[string]interface{}
+	}{
+		{
+			name: "add new attributes",
+			resourceValues: map[string]string{
+				"environment": "test",
+				"service":     "adx-mon",
+			},
+			inputResources: map[string]interface{}{
+				"existing": "value",
+			},
+			expectedResources: map[string]interface{}{
+				"existing":    "value",
+				"environment": "test",
+				"service":     "adx-mon",
+			},
+		},
+		{
+			name: "override existing attributes",
+			resourceValues: map[string]string{
+				"existing": "new-value",
+			},
+			inputResources: map[string]interface{}{
+				"existing": "old-value",
+			},
+			expectedResources: map[string]interface{}{
+				"existing": "new-value",
+			},
+		},
+		{
+			name:           "no attributes to add",
+			resourceValues: map[string]string{},
+			inputResources: map[string]interface{}{
+				"existing": "value",
+			},
+			expectedResources: map[string]interface{}{
+				"existing": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transformer := &Transform{
+				resourceValues: tt.resourceValues,
+			}
+
+			err := transformer.Open(context.Background())
+			require.NoError(t, err)
+			defer func() {
+				err := transformer.Close()
+				require.NoError(t, err)
+			}()
+
+			// Create a log batch with one log
+			log := types.NewLog()
+			for k, v := range tt.inputResources {
+				log.SetResourceValue(k, v)
+			}
+
+			batch := &types.LogBatch{
+				Logs: []*types.Log{log},
+			}
+
+			// Transform the batch
+			ctx := context.Background()
+			resultBatch, err := transformer.Transform(ctx, batch)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(resultBatch.Logs))
+
+			// Check that the resources match the expected values
+			for k, expectedVal := range tt.expectedResources {
+				val, ok := resultBatch.Logs[0].GetResourceValue(k)
+				require.True(t, ok, "Expected resource key %s not found", k)
+				require.Equal(t, expectedVal, val)
+			}
+		})
+	}
+}
+
+func TestAddAttributesTransform_Name(t *testing.T) {
+	transformer := &Transform{}
+	assert.Equal(t, "AddAttributesTransform", transformer.Name())
+}

--- a/collector/logs/transforms/transform.go
+++ b/collector/logs/transforms/transform.go
@@ -4,17 +4,20 @@ import (
 	"fmt"
 
 	"github.com/Azure/adx-mon/collector/logs/transforms/plugin"
+	"github.com/Azure/adx-mon/collector/logs/transforms/plugin/addattributes"
 	"github.com/Azure/adx-mon/collector/logs/types"
 )
 
 type TransformCreator func(config map[string]any) (types.Transformer, error)
 
 const (
-	TransformTypePlugin = "plugin"
+	TransformTypePlugin        = "plugin"
+	TransformTypeAddAttributes = "addattributes"
 )
 
 var transformCreators = map[string]TransformCreator{
-	TransformTypePlugin: plugin.FromConfigMap,
+	TransformTypePlugin:        plugin.FromConfigMap,
+	TransformTypeAddAttributes: addattributes.FromConfigMap,
 }
 
 func IsValidTransformType(transformType string) bool {

--- a/collector/otlp/logs_transfer.go
+++ b/collector/otlp/logs_transfer.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
+	"github.com/Azure/adx-mon/collector/logs/engine"
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
@@ -21,6 +22,7 @@ import (
 )
 
 type LogsServiceOpts struct {
+	WorkerCreator engine.WorkerCreatorFunc
 	Sink          types.Sink
 	HealthChecker interface{ IsHealthy() bool }
 }

--- a/collector/otlp/logs_transfer_test.go
+++ b/collector/otlp/logs_transfer_test.go
@@ -12,6 +12,7 @@ import (
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
 	logsv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/logs/v1"
 	resourcev1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/resource/v1"
+	"github.com/Azure/adx-mon/collector/logs/engine"
 	"github.com/Azure/adx-mon/collector/logs/sinks"
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/Azure/adx-mon/storage"
@@ -146,7 +147,7 @@ func TestLogsService_Overloaded(t *testing.T) {
 	sink, err := sinks.NewStoreSink(sinks.StoreSinkConfig{Store: store})
 	require.NoError(t, err)
 	s := NewLogsService(LogsServiceOpts{
-		Sink:          sink,
+		WorkerCreator: engine.WorkerCreator(nil, sink),
 		HealthChecker: fakeHealthChecker{false},
 	})
 	require.NoError(t, s.Open(context.Background()))
@@ -186,7 +187,7 @@ func BenchmarkLogsService(b *testing.B) {
 	sink, err := sinks.NewStoreSink(sinks.StoreSinkConfig{Store: store})
 	require.NoError(b, err)
 	s := NewLogsService(LogsServiceOpts{
-		Sink:          sink,
+		WorkerCreator: engine.WorkerCreator(nil, sink),
 		HealthChecker: fakeHealthChecker{true},
 	})
 	require.NoError(b, s.Open(context.Background()))
@@ -448,7 +449,7 @@ func TestConvertToLogBatch(t *testing.T) {
 			sink, err := sinks.NewStoreSink(sinks.StoreSinkConfig{Store: store})
 			require.NoError(t, err)
 			s := NewLogsService(LogsServiceOpts{
-				Sink:          sink,
+				WorkerCreator: engine.WorkerCreator(nil, sink),
 				HealthChecker: fakeHealthChecker{false},
 			})
 			logBatch := types.LogBatchPool.Get(1).(*types.LogBatch)
@@ -1142,7 +1143,7 @@ func makeRequest(t *testing.T, msg *v1.ExportLogsServiceRequest) (*httptest.Resp
 	sink, err := sinks.NewStoreSink(sinks.StoreSinkConfig{Store: store})
 	require.NoError(t, err)
 	s := NewLogsService(LogsServiceOpts{
-		Sink:          sink,
+		WorkerCreator: engine.WorkerCreator(nil, sink),
 		HealthChecker: fakeHealthChecker{true},
 	})
 	require.NoError(t, s.Open(context.Background()))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -198,7 +198,7 @@ var (
 		Subsystem: "collector",
 		Name:      "logs_sent",
 		Help:      "Counter of the number of logs successfully sent by the collector",
-	}, []string{"source", "sink", "database", "table"})
+	}, []string{"source", "sink"})
 
 	LogsCollectorLogsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,

--- a/pkg/testutils/collector/collector.go
+++ b/pkg/testutils/collector/collector.go
@@ -178,6 +178,7 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 						return fmt.Errorf("failed to wait for namespace: %w", err)
 					}
 
+					collectorConfigMap := makeCollectorConfigMap()
 					patchBytes, err := json.Marshal(collectorConfigMap)
 					if err != nil {
 						return fmt.Errorf("failed to marshal configmap: %w", err)
@@ -200,6 +201,8 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 						return fmt.Errorf("failed to patch daemonset: %w", err)
 					}
 
+					// create new function instance since Create will modify the passed-in object
+					collectorFunction := makeCollectorFunction()
 					if err := ctrlCli.Get(ctx, types.NamespacedName{Namespace: collectorFunction.Namespace, Name: collectorFunction.Name}, collectorFunction); err != nil {
 						if err := ctrlCli.Create(ctx, collectorFunction); err != nil {
 							return fmt.Errorf("failed to create function: %w", err)
@@ -233,18 +236,19 @@ func (k *KustoTableSchema) CslColumns() []string {
 	}
 }
 
-var collectorFunction = &adxmonv1.Function{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "adx-mon.azure.com/v1",
-		Kind:       "Function",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "collector",
-		Namespace: "adx-mon",
-	},
-	Spec: adxmonv1.FunctionSpec{
-		Database: "Logs",
-		Body: `.create-or-alter function with (view=true, folder='views') Collector () {
+func makeCollectorFunction() *adxmonv1.Function {
+	return &adxmonv1.Function{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "adx-mon.azure.com/v1",
+			Kind:       "Function",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "collector",
+			Namespace: "adx-mon",
+		},
+		Spec: adxmonv1.FunctionSpec{
+			Database: "Logs",
+			Body: `.create-or-alter function with (view=true, folder='views') Collector () {
   table('Collector')
   | extend msg = tostring(Body.msg),
 		   lvl = tostring(Body.lvl),
@@ -255,21 +259,23 @@ var collectorFunction = &adxmonv1.Function{
 		   host = tostring(Resource.host)
   | project-away Timestamp, ObservedTimestamp, TraceId, SpanId, SeverityText, SeverityNumber, Body, Resource, Attributes
 }`,
-	},
+		},
+	}
 }
 
 // collectorConfigMap is a minimal config suitable for use by kustainer
-var collectorConfigMap = &corev1.ConfigMap{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "ConfigMap",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "collector-config",
-		Namespace: "adx-mon",
-	},
-	Data: map[string]string{
-		"config.toml": `
+func makeCollectorConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "collector-config",
+			Namespace: "adx-mon",
+		},
+		Data: map[string]string{
+			"config.toml": `
 # We have to keep our scape targets very light due to the capacity
 # constraints of kustainer
 
@@ -375,5 +381,6 @@ disable-metrics-forwarding = false
     { database = 'Logs', table = 'Kernel', priority = 'warning' }
   ]
 `,
-	},
+		},
+	}
 }

--- a/pkg/testutils/ingestor/ingestor.go
+++ b/pkg/testutils/ingestor/ingestor.go
@@ -310,6 +310,8 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 						return fmt.Errorf("failed to create statefulset: %w", err)
 					}
 
+					// create new function instance since Create will modify the passed-in object
+					ingestorFunction := makeIngestorFunction()
 					// Continue with Function creation...
 					if err := ctrlCli.Get(ctx, types.NamespacedName{Namespace: ingestorFunction.Namespace, Name: ingestorFunction.Name}, ingestorFunction); err != nil {
 						if err := ctrlCli.Create(ctx, ingestorFunction); err != nil {
@@ -461,18 +463,19 @@ func (k *KustoTableSchema) CslColumns() []string {
 	}
 }
 
-var ingestorFunction = &adxmonv1.Function{
-	TypeMeta: metav1.TypeMeta{
-		APIVersion: "adx-mon.azure.com/v1",
-		Kind:       "Function",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "ingestor",
-		Namespace: "adx-mon",
-	},
-	Spec: adxmonv1.FunctionSpec{
-		Database: "Logs",
-		Body: `.create-or-alter function with (view=true, folder='views') Ingestor () {
+func makeIngestorFunction() *adxmonv1.Function {
+	return &adxmonv1.Function{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "adx-mon.azure.com/v1",
+			Kind:       "Function",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingestor",
+			Namespace: "adx-mon",
+		},
+		Spec: adxmonv1.FunctionSpec{
+			Database: "Logs",
+			Body: `.create-or-alter function with (view=true, folder='views') Ingestor () {
   table('Ingestor')
   | extend msg = tostring(Body.msg),
 		   lvl = tostring(Body.lvl),
@@ -483,5 +486,6 @@ var ingestorFunction = &adxmonv1.Function{
 		   host = tostring(Resource.host)
   | project-away Timestamp, ObservedTimestamp, TraceId, SpanId, SeverityText, SeverityNumber, Body, Resource, Attributes
 }`,
-	},
+		},
+	}
 }


### PR DESCRIPTION
Sinks should not modify logs, as they will soon run in parallel. We now freeze logs before sending them to sinks to prevent further modifications. We replace the old mechanism with a new `addattributes` transformer plugin.

Additionally, fix the integration tests by not reusing k8s resource definition pointers, as they get modified by the container library we use in place.

### Introduction of `addattributes` transformer plugin:
* [`collector/logs/transforms/plugin/addattributes/add_attributes.go`](diffhunk://#diff-203bc53956eb868bea46822c26aa337d5cd2f09217908ba2b3a00f00ec009d27R1-R54): Added a new transformer plugin to handle the addition of attributes to log entries.
* [`collector/logs/transforms/plugin/addattributes/add_attributes_test.go`](diffhunk://#diff-e7b625faf52827334ad88c7991c63ce25bdff0d2b405dc8fa46da1294cfbbaf7R1-R184): Added unit tests for the new `addattributes` transformer plugin.

### Refactoring of log attribute handling:
* [`cmd/collector/main.go`](diffhunk://#diff-7d157977eb72544a4475cb8da9a7439ca630dc14251889e87843e7fdee0acfcdR26): Integrated the `addattributes` transformer into the main collector logic. [[1]](diffhunk://#diff-7d157977eb72544a4475cb8da9a7439ca630dc14251889e87843e7fdee0acfcdR26) [[2]](diffhunk://#diff-7d157977eb72544a4475cb8da9a7439ca630dc14251889e87843e7fdee0acfcdR572-L573) [[3]](diffhunk://#diff-7d157977eb72544a4475cb8da9a7439ca630dc14251889e87843e7fdee0acfcdR618-L614)
* [`collector/logs/engine/worker.go`](diffhunk://#diff-a20a0e307123983904d0e9bd1fb37a66480fade01a6e36de8d7b133b1bbe5654L15-L16): Removed `Database` and `Table` fields from the `worker` struct and added a method to freeze logs in a batch before sending them to the sink. [[1]](diffhunk://#diff-a20a0e307123983904d0e9bd1fb37a66480fade01a6e36de8d7b133b1bbe5654L15-L16) [[2]](diffhunk://#diff-a20a0e307123983904d0e9bd1fb37a66480fade01a6e36de8d7b133b1bbe5654R50-R54) [[3]](diffhunk://#diff-a20a0e307123983904d0e9bd1fb37a66480fade01a6e36de8d7b133b1bbe5654L58-R63)

### Updates to metrics collection:
* [`metrics/metrics.go`](diffhunk://#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4L201-R201): Updated the `LogsCollectorLogsSent` metric to remove `database` and `table` labels.

### Changes to `LogsService`:
* [`collector/otlp/logs_transfer.go`](diffhunk://#diff-658b70ab78422b0b28ef694cccc56a47fb6ac3b16f24b7b561a4744c0040fc80R10-R41): Refactored `LogsService` to use a worker creator function and an output queue for processing log batches. [[1]](diffhunk://#diff-658b70ab78422b0b28ef694cccc56a47fb6ac3b16f24b7b561a4744c0040fc80R10-R41) [[2]](diffhunk://#diff-658b70ab78422b0b28ef694cccc56a47fb6ac3b16f24b7b561a4744c0040fc80R53-R64) [[3]](diffhunk://#diff-658b70ab78422b0b28ef694cccc56a47fb6ac3b16f24b7b561a4744c0040fc80L104-R117)
* [`collector/otlp/logs_transfer_test.go`](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321R15): Updated tests to reflect changes in `LogsService`. [[1]](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321R15) [[2]](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321L149-R150) [[3]](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321L189-R190) [[4]](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321L451-R452) [[5]](diffhunk://#diff-1fff8febead5cbab23146b1ff316a341d016974c58782be9ff166b0a9a794321L1145-R1146)

### Other changes:
* [`collector/service.go`](diffhunk://#diff-dcf3a410ebc2ab76b38109ea1a97c67b5e22bf0ae3c0a93491bc2bd4509f5708R14-R17): Added support for the `addattributes` transformer in the service creation logic. [[1]](diffhunk://#diff-dcf3a410ebc2ab76b38109ea1a97c67b5e22bf0ae3c0a93491bc2bd4509f5708R14-R17) [[2]](diffhunk://#diff-dcf3a410ebc2ab76b38109ea1a97c67b5e22bf0ae3c0a93491bc2bd4509f5708R225-R240)
* [`collector/logs/sinks/store.go`](diffhunk://#diff-b44695d116f3b80294b977fbc414948814d1cb3d6e4eb5a135c4058a44d2f921L12-L23): Removed handling of additional attributes in the `StoreSink` implementation. [[1]](diffhunk://#diff-b44695d116f3b80294b977fbc414948814d1cb3d6e4eb5a135c4058a44d2f921L12-L23) [[2]](diffhunk://#diff-b44695d116f3b80294b977fbc414948814d1cb3d6e4eb5a135c4058a44d2f921L32-L36)