### PR TITLE
Implement LogToFluentExporter

### DIFF
--- a/collector/export/log_fluent_test.go
+++ b/collector/export/log_fluent_test.go
@@ -22,11 +22,12 @@ func BenchmarkMsgp(b *testing.B) {
 }
 
 func TestEncode(t *testing.T) {
-	logbatch := types.LogBatch{}
+	logbatch := &types.LogBatch{}
 	logbatch.AddLiterals(testlogs)
+	freezeLogsInBatch(logbatch)
 
 	e := newFluentEncoder("destTag")
-	b, err := e.encode(&logbatch)
+	b, err := e.encode(logbatch)
 	require.NoError(t, err)
 	require.Greater(t, len(b), 0)
 
@@ -71,8 +72,9 @@ func TestEncode(t *testing.T) {
 	}
 	logbatch.Reset()
 	logbatch.AddLiterals(newLogs)
+	freezeLogsInBatch(logbatch)
 
-	b, err = e.encode(&logbatch)
+	b, err = e.encode(logbatch)
 	require.NoError(t, err)
 	require.Greater(t, len(b), 0)
 	rest = validateArrayHeaderForwardMode(t, b)
@@ -285,4 +287,10 @@ func validateEntries(t *testing.T, entries []entrytuple, expectedentries []entry
 
 	// Compare the slices ignoring their order
 	require.ElementsMatch(t, expectedentries, entries, "entries differ ignoring order")
+}
+
+func freezeLogsInBatch(logBatch *types.LogBatch) {
+	for _, log := range logBatch.Logs {
+		log.Freeze()
+	}
 }

--- a/collector/logs/transforms/plugin/github_com-Azure-adx-mon-collector-logs-types.go
+++ b/collector/logs/transforms/plugin/github_com-Azure-adx-mon-collector-logs-types.go
@@ -25,95 +25,15 @@ func init() {
 		"Log":         reflect.ValueOf((*types.Log)(nil)),
 		"LogBatch":    reflect.ValueOf((*types.LogBatch)(nil)),
 		"LogLiteral":  reflect.ValueOf((*types.LogLiteral)(nil)),
-		"ROLog":       reflect.ValueOf((*types.ROLog)(nil)),
-		"ROLogBatch":  reflect.ValueOf((*types.ROLogBatch)(nil)),
 		"Sink":        reflect.ValueOf((*types.Sink)(nil)),
 		"Source":      reflect.ValueOf((*types.Source)(nil)),
 		"Transformer": reflect.ValueOf((*types.Transformer)(nil)),
 
 		// interface wrapper definitions
-		"_ROLog":       reflect.ValueOf((*_github_com_Azure_adx_mon_collector_logs_types_ROLog)(nil)),
-		"_ROLogBatch":  reflect.ValueOf((*_github_com_Azure_adx_mon_collector_logs_types_ROLogBatch)(nil)),
 		"_Sink":        reflect.ValueOf((*_github_com_Azure_adx_mon_collector_logs_types_Sink)(nil)),
 		"_Source":      reflect.ValueOf((*_github_com_Azure_adx_mon_collector_logs_types_Source)(nil)),
 		"_Transformer": reflect.ValueOf((*_github_com_Azure_adx_mon_collector_logs_types_Transformer)(nil)),
 	}
-}
-
-// _github_com_Azure_adx_mon_collector_logs_types_ROLog is an interface wrapper for ROLog type
-type _github_com_Azure_adx_mon_collector_logs_types_ROLog struct {
-	IValue                interface{}
-	WAttributeLen         func() int
-	WBodyLen              func() int
-	WCopy                 func() *types.Log
-	WForEachAttribute     func(a0 func(string, any) error) error
-	WForEachBody          func(a0 func(string, any) error) error
-	WForEachResource      func(a0 func(string, any) error) error
-	WGetAttributeValue    func(a0 string) (any, bool)
-	WGetAttributes        func() map[string]any
-	WGetBody              func() map[string]any
-	WGetBodyValue         func(a0 string) (any, bool)
-	WGetObservedTimestamp func() uint64
-	WGetResource          func() map[string]any
-	WGetResourceValue     func(a0 string) (any, bool)
-	WGetTimestamp         func() uint64
-	WResourceLen          func() int
-}
-
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) AttributeLen() int {
-	return W.WAttributeLen()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) BodyLen() int {
-	return W.WBodyLen()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) Copy() *types.Log {
-	return W.WCopy()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) ForEachAttribute(a0 func(string, any) error) error {
-	return W.WForEachAttribute(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) ForEachBody(a0 func(string, any) error) error {
-	return W.WForEachBody(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) ForEachResource(a0 func(string, any) error) error {
-	return W.WForEachResource(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetAttributeValue(a0 string) (any, bool) {
-	return W.WGetAttributeValue(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetAttributes() map[string]any {
-	return W.WGetAttributes()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetBody() map[string]any {
-	return W.WGetBody()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetBodyValue(a0 string) (any, bool) {
-	return W.WGetBodyValue(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetObservedTimestamp() uint64 {
-	return W.WGetObservedTimestamp()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetResource() map[string]any {
-	return W.WGetResource()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetResourceValue(a0 string) (any, bool) {
-	return W.WGetResourceValue(a0)
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) GetTimestamp() uint64 {
-	return W.WGetTimestamp()
-}
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLog) ResourceLen() int {
-	return W.WResourceLen()
-}
-
-// _github_com_Azure_adx_mon_collector_logs_types_ROLogBatch is an interface wrapper for ROLogBatch type
-type _github_com_Azure_adx_mon_collector_logs_types_ROLogBatch struct {
-	IValue   interface{}
-	WForEach func(a0 func(types.ROLog))
-}
-
-func (W _github_com_Azure_adx_mon_collector_logs_types_ROLogBatch) ForEach(a0 func(types.ROLog)) {
-	W.WForEach(a0)
 }
 
 // _github_com_Azure_adx_mon_collector_logs_types_Sink is an interface wrapper for Sink type

--- a/collector/logs/types/logs.go
+++ b/collector/logs/types/logs.go
@@ -241,26 +241,6 @@ func (l *Log) GetResource() map[string]any {
 	return result
 }
 
-// ROLog is a read-only view of a log
-// Do not modify any values stored within attributes, body, or resource unless copied
-type ROLog interface {
-	GetTimestamp() uint64
-	GetObservedTimestamp() uint64
-	GetAttributeValue(string) (any, bool)
-	GetBodyValue(string) (any, bool)
-	GetResourceValue(string) (any, bool)
-	ForEachAttribute(func(string, any) error) error
-	ForEachBody(func(string, any) error) error
-	ForEachResource(func(string, any) error) error
-	AttributeLen() int
-	BodyLen() int
-	ResourceLen() int
-	Copy() *Log
-	GetAttributes() map[string]any
-	GetBody() map[string]any
-	GetResource() map[string]any
-}
-
 // LogBatch represents a batch of logs
 type LogBatch struct {
 	Logs []*Log
@@ -280,16 +260,6 @@ func (l *LogBatch) Reset() {
 	}
 	l.Logs = l.Logs[:0]
 	l.Ack = noop
-}
-
-func (l *LogBatch) ForEach(f func(ROLog)) {
-	for _, log := range l.Logs {
-		f(log)
-	}
-}
-
-type ROLogBatch interface {
-	ForEach(func(ROLog))
 }
 
 func noop() {}

--- a/collector/logs/types/logs_test.go
+++ b/collector/logs/types/logs_test.go
@@ -153,13 +153,6 @@ func TestLogBatch(t *testing.T) {
 
 	require.Equal(t, 2, len(batch.Logs))
 
-	// Test ForEach
-	var timestamps []uint64
-	batch.ForEach(func(l ROLog) {
-		timestamps = append(timestamps, l.GetTimestamp())
-	})
-	require.Equal(t, []uint64{100, 200}, timestamps)
-
 	batch.Ack()
 	require.True(t, ackCalled)
 


### PR DESCRIPTION
This removes the `ROLog` type and replaces it with a pointer to `types.Log` in the `fluentEncoder` struct. This eliminates the need for allocations in this path and speeds up the encoding process significantly.

This exporter works end to end with local tests against a fluentbit instance listening for fluentforward protocol. Next steps are local benchmarking for our workloads, then integration into the config to allow using it.