### PR TITLE
Fix race in worker waitgroup management

### DIFF
--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -229,7 +229,7 @@ func (e *Executor) syncWorkers(ctx context.Context) {
 		if !ok {
 			logger.Infof("Starting new worker for %s", id)
 			worker := e.newWorker(r)
-			go worker.Run(ctx)
+			worker.Run(ctx)
 			e.workers[id] = worker
 			continue
 		}
@@ -244,7 +244,7 @@ func (e *Executor) syncWorkers(ctx context.Context) {
 		delete(e.workers, id)
 		w = e.newWorker(r)
 		e.workers[id] = w
-		go w.Run(ctx)
+		w.Run(ctx)
 	}
 
 	// Shutdown any workers that no longer exist


### PR DESCRIPTION
Workers in alerter were previously executed by running `go worker.Run()` where the body of the method added to the embedded waitgroup. The Close() method then waits on the waitgroup. This is racy because the Run method may not have actually executed yet, so it may leave a dangling goroutine hanging around.

We now execute Run() synchonously to add to the waitgroup and to assign the context and cancel methods for Close() to use later. We then execute the worker goroutine loop within a separate goroutine after the setup.

Found by the race detector
```
WARNING: DATA RACE
Write at 0x00c00023eb98 by goroutine 67:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/Azure/adx-mon/alerter/engine.(*worker).Close()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/worker.go:173 +0x66
  github.com/Azure/adx-mon/alerter/engine.(*Executor).syncWorkers()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/executor.go:243 +0x3d4
  github.com/Azure/adx-mon/alerter/engine.TestExecutor_syncWorkers_Changed()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/executor_test.go:350 +0x5d8
  testing.tRunner()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1851 +0x44

Previous read at 0x00c00023eb98 by goroutine 68:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/Azure/adx-mon/alerter/engine.(*worker).Run()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/worker.go:41 +0x64
  github.com/Azure/adx-mon/alerter/engine.(*Executor).syncWorkers.gowrap1()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/executor.go:232 +0x4f

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1851 +0x8f2
  testing.runTests.func1()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:2279 +0x85
  testing.tRunner()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.runTests()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:2277 +0x96c
  testing.(*M).Run()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:2[142](https://github.com/Azure/adx-mon/actions/runs/14269752329/job/40000027523?pr=655#step:7:143) +0xeea
  main.main()
      _testmain.go:85 +0x164

Goroutine 68 (running) created at:
  github.com/Azure/adx-mon/alerter/engine.(*Executor).syncWorkers()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/executor.go:232 +0x6b1
  github.com/Azure/adx-mon/alerter/engine.TestExecutor_syncWorkers_Changed()
      /home/runner/work/adx-mon/adx-mon/alerter/engine/executor_test.go:342 +0x3cd
  testing.tRunner()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/testing/testing.go:1851 +0x44
```