### PR TITLE
Fix lifecycle for logs services

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -593,8 +593,9 @@ func realMain(ctx *cli.Context) error {
 			}
 
 			return &logs.Service{
-				Source: source,
-				Sink:   sink,
+				Source:     source,
+				Transforms: transformers,
+				Sink:       sink,
 			}, nil
 		}
 
@@ -639,8 +640,9 @@ func realMain(ctx *cli.Context) error {
 				}
 
 				return &logs.Service{
-					Source: source,
-					Sink:   sink,
+					Source:     source,
+					Transforms: transforms,
+					Sink:       sink,
 				}, nil
 			}
 			opts.LogCollectionHandlers = append(opts.LogCollectionHandlers, collector.LogCollectorOpts{
@@ -696,8 +698,9 @@ func realMain(ctx *cli.Context) error {
 				source := journal.New(journalConfig)
 
 				return &logs.Service{
-					Source: source,
-					Sink:   sink,
+					Source:     source,
+					Transforms: transformers,
+					Sink:       sink,
 				}, nil
 			}
 

--- a/collector/logs/service.go
+++ b/collector/logs/service.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/Azure/adx-mon/pkg/logger"
+	"github.com/Azure/adx-mon/pkg/service"
 )
 
 type Service struct {
-	Source     types.Source
+	Source     service.Component
 	Transforms []types.Transformer
 	Sink       types.Sink
 
@@ -22,13 +23,11 @@ func (s *Service) Open(ctx context.Context) error {
 	if err := s.Sink.Open(ctx); err != nil {
 		return err
 	}
-	defer s.Sink.Close()
 
 	for i := len(s.Transforms) - 1; i >= 0; i-- {
 		if err := s.Transforms[i].Open(ctx); err != nil {
 			return err
 		}
-		defer s.Transforms[i].Close()
 	}
 
 	if err := s.Source.Open(ctx); err != nil {

--- a/collector/logs/service_test.go
+++ b/collector/logs/service_test.go
@@ -2,6 +2,7 @@ package logs_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,7 +10,14 @@ import (
 	"github.com/Azure/adx-mon/collector/logs/engine"
 	"github.com/Azure/adx-mon/collector/logs/sinks"
 	"github.com/Azure/adx-mon/collector/logs/sources"
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/Azure/adx-mon/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
 )
+
+const sourceName = "ConstSource"
 
 func BenchmarkPipeline(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -30,7 +38,8 @@ func BenchmarkPipeline(b *testing.B) {
 
 func TestPipeline(t *testing.T) {
 	// Ensure we can send 10k logs through the pipeline.
-	sink := sinks.NewCountingSink(10000)
+	numLogs := int64(10000)
+	sink := sinks.NewCountingSink(numLogs)
 	source := sources.NewConstSource("test-val", 1*time.Second, 1000, engine.WorkerCreator(nil, sink))
 
 	service := &logs.Service{
@@ -42,4 +51,155 @@ func TestPipeline(t *testing.T) {
 	service.Open(context)
 	<-sink.DoneChan()
 	service.Close()
+
+	countOfDropped := getCounterValue(t, metrics.LogsCollectorLogsDropped.WithLabelValues(sourceName, sink.Name()))
+	require.Equal(t, countOfDropped, float64(0))
+	countOfSent := getCounterValue(t, metrics.LogsCollectorLogsSent.WithLabelValues(sourceName, sink.Name()))
+	require.GreaterOrEqual(t, countOfSent, float64(numLogs)) // batching sends more logs which is ok
+}
+
+func TestLifecycle(t *testing.T) {
+	// Ensure we can open and close the service cleanly
+	// source only sends the log when it is closed, simulating a flush on close.
+	// transformer panics if told to transform when it is closed.
+	// sink panics if it receives a log after it is closed.
+	sink := sinks.NewCountingSink(1)
+	transform := &transformerpanicifclosed{}
+	transforms := []types.Transformer{transform}
+	source := newSourceSendOnClose(engine.WorkerCreator(transforms, sink))
+
+	service := &logs.Service{
+		Source:     source,
+		Transforms: transforms,
+		Sink:       sink,
+	}
+	context := context.Background()
+
+	err := service.Open(context)
+	if err != nil {
+		t.Fatalf("Failed to open service: %v", err)
+	}
+	service.Close()
+	<-sink.DoneChan()
+
+	countOfDropped := getCounterValue(t, metrics.LogsCollectorLogsDropped.WithLabelValues(sourceName, sink.Name()))
+	require.Equal(t, countOfDropped, float64(0))
+	countOfSent := getCounterValue(t, metrics.LogsCollectorLogsSent.WithLabelValues(sourceName, sink.Name()))
+	require.GreaterOrEqual(t, countOfSent, float64(1)) // batching sends more than 1
+}
+
+func getCounterValue(t *testing.T, metric prometheus.Metric) float64 {
+	t.Helper()
+
+	metricDTO := &dto.Metric{}
+	err := metric.Write(metricDTO)
+	require.NoError(t, err)
+	return metricDTO.Counter.GetValue()
+}
+
+type sourceSendOnClose struct {
+	workerGenerator engine.WorkerCreatorFunc
+	outputQueue     chan *types.LogBatch
+	wg              sync.WaitGroup
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newSourceSendOnClose(workerGenerator engine.WorkerCreatorFunc) *sourceSendOnClose {
+	return &sourceSendOnClose{
+		workerGenerator: workerGenerator,
+		outputQueue:     make(chan *types.LogBatch, 1),
+	}
+}
+
+func (s *sourceSendOnClose) Open(ctx context.Context) error {
+	if s.ctx != nil {
+		panic("context already set")
+	}
+	if s.cancel != nil {
+		panic("cancel function already set")
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
+	worker := s.workerGenerator(sourceName, s.outputQueue)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		worker.Run()
+	}()
+	return nil
+}
+
+func (s *sourceSendOnClose) Close() error {
+	// Panic if the context is already cancelled
+	select {
+	case <-s.ctx.Done():
+		panic("context already cancelled")
+	default:
+		// Context is still active, proceed with cancellation
+	}
+
+	s.cancel()
+	batch := &types.LogBatch{}
+	batch.Ack = func() {}
+	batch.AddLiterals([]*types.LogLiteral{
+		{
+			Body: map[string]interface{}{
+				"message": "test message",
+			},
+		},
+	})
+	s.outputQueue <- batch
+	close(s.outputQueue)
+
+	s.wg.Wait()
+	return nil
+}
+
+type transformerpanicifclosed struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (t *transformerpanicifclosed) Open(ctx context.Context) error {
+	if t.ctx != nil {
+		panic("context already set")
+	}
+	if t.cancel != nil {
+		panic("cancel function already set")
+	}
+
+	t.ctx, t.cancel = context.WithCancel(context.Background())
+	return nil
+}
+
+func (t *transformerpanicifclosed) Close() error {
+	// Panic if the context is already cancelled
+	select {
+	case <-t.ctx.Done():
+		panic("context already cancelled")
+	default:
+		// Context is still active, proceed with cancellation
+	}
+
+	t.cancel()
+	return nil
+}
+
+func (t *transformerpanicifclosed) Transform(ctx context.Context, batch *types.LogBatch) (*types.LogBatch, error) {
+	// Panic if the context is already cancelled
+	select {
+	case <-t.ctx.Done():
+		panic("context already cancelled")
+	default:
+		// Context is still active, proceed with cancellation
+	}
+
+	// This is a no-op transformer
+	return batch, nil
+}
+
+func (t *transformerpanicifclosed) Name() string {
+	return "transformerpanicifclosed"
 }


### PR DESCRIPTION
This fixes a few issues with the lifecycle management of logs services.

1. We were not assigning transforms to the service correctly, preventing them from being started and stopped.
2. We were incorrectly closing the source and transforms at the end of the `Open` method with defers, instead of closing them in the `Close` method.
3. The Otel logs service now uses the same workflow as other logs services, ensuring it gets started and stopped correctly.