### PR TITLE
feat(collector): add a generic space parser to parse logs by whitespace characters such as spaces and tabs

### DIFF
--- a/collector/logs/transforms/parser/parser.go
+++ b/collector/logs/transforms/parser/parser.go
@@ -26,6 +26,8 @@ func newParser(parserType ParserType) (Parser, error) {
 		return NewJsonParser(JsonParserConfig{})
 	case ParserTypeKeyValue:
 		return NewKeyValueParser(KeyValueParserConfig{})
+	case ParserTypeSpace:
+		return NewSpaceParser(SpaceParserConfig{})
 	default:
 		return nil, fmt.Errorf("unknown parser type: %s", parserType)
 	}
@@ -51,6 +53,8 @@ func IsValidParser(parserType string) bool {
 	case string(ParserTypeJson):
 		return true
 	case string(ParserTypeKeyValue):
+		return true
+	case string(ParserTypeSpace):
 		return true
 	default:
 		return false

--- a/collector/logs/transforms/parser/space.go
+++ b/collector/logs/transforms/parser/space.go
@@ -1,0 +1,35 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+const ParserTypeSpace ParserType = "space"
+
+type SpaceParserConfig struct{}
+
+type SpaceParser struct{}
+
+func NewSpaceParser(config SpaceParserConfig) (*SpaceParser, error) {
+	return &SpaceParser{}, nil
+}
+
+// Parse splits the message by whitespace and adds each field to the log body with a numeric index.
+// For example, "hello world" becomes {"field0": "hello", "field1": "world"}
+// This is useful for parsing generic log lines where fields are separated by one or more spaces.
+// This parser uses strings.Fields, which splits on any whitespace, including tabs and newlines.
+func (p *SpaceParser) Parse(log *types.Log, msg string) error {
+	if len(msg) == 0 {
+		return nil
+	}
+
+	fields := strings.Fields(msg)
+	for i, field := range fields {
+		log.SetBodyValue(fmt.Sprintf("field%d", i), field)
+	}
+
+	return nil
+}

--- a/collector/logs/transforms/parser/space_test.go
+++ b/collector/logs/transforms/parser/space_test.go
@@ -1,0 +1,115 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+func TestSpaceParse(t *testing.T) {
+	type testcase struct {
+		name         string
+		input        string
+		expectedBody map[string]interface{}
+	}
+
+	tests := []testcase{
+		{
+			name:         "empty",
+			input:        "",
+			expectedBody: map[string]interface{}{},
+		},
+		{
+			name:  "single word",
+			input: "hello",
+			expectedBody: map[string]interface{}{
+				"field0": "hello",
+			},
+		},
+		{
+			name:  "multiple words",
+			input: "hello world how are you",
+			expectedBody: map[string]interface{}{
+				"field0": "hello",
+				"field1": "world",
+				"field2": "how",
+				"field3": "are",
+				"field4": "you",
+			},
+		},
+		{
+			name:  "extra spaces",
+			input: "  hello   world  ",
+			expectedBody: map[string]interface{}{
+				"field0": "hello",
+				"field1": "world",
+			},
+		},
+		{
+			name:  "tabs",
+			input: "hello\tworld",
+			expectedBody: map[string]interface{}{
+				"field0": "hello",
+				"field1": "world",
+			},
+		},
+		{
+			name:  "multiple tabs and spaces",
+			input: "hello\t\tworld  foo  bar",
+			expectedBody: map[string]interface{}{
+				"field0": "hello",
+				"field1": "world",
+				"field2": "foo",
+				"field3": "bar",
+			},
+		},
+		{
+			name:  "ints",
+			input: "123 456 789",
+			expectedBody: map[string]interface{}{
+				"field0": "123",
+				"field1": "456",
+				"field2": "789",
+			},
+		},
+		{
+			name:  "floats",
+			input: "123.456 789.123",
+			expectedBody: map[string]interface{}{
+				"field0": "123.456",
+				"field1": "789.123",
+			},
+		},
+		{
+			name:  "scientific notation",
+			input: "3.590e-06 1.23e+10",
+			expectedBody: map[string]interface{}{
+				"field0": "3.590e-06",
+				"field1": "1.23e+10",
+			},
+		},
+	}
+
+	parser, _ := NewSpaceParser(SpaceParserConfig{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := types.NewLog()
+			err := parser.Parse(log, tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedBody, log.GetBody())
+		})
+	}
+}
+
+func BenchmarkSpaceParse(b *testing.B) {
+	parser, _ := NewSpaceParser(SpaceParserConfig{})
+	msg := "hello world how are you today"
+	log := types.NewLog()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		parser.Parse(log, msg)
+	}
+}


### PR DESCRIPTION
Adds a new generic "space" parser which can be useful for quickly parsing some generic log lines which are separated by one or more whitespace characters.