### PR TITLE
ManagementCommands - Capture errors in script

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -217,9 +217,9 @@ func (t *ManagementCommandTask) Run(ctx context.Context) error {
 
 		var stmt *kql.Builder
 		if command.Spec.Database == "" {
-			stmt = kql.New(".execute cluster script <|").AddUnsafe(command.Spec.Body)
+			stmt = kql.New(".execute cluster script with (ThrowOnErrors = true) <|").AddUnsafe(command.Spec.Body)
 		} else {
-			stmt = kql.New(".execute database script <|").AddUnsafe(command.Spec.Body)
+			stmt = kql.New(".execute database script with (ThrowOnErrors = true) <|").AddUnsafe(command.Spec.Body)
 		}
 		if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
 			logger.Errorf("Failed to execute management command %s.%s: %v", command.Spec.Database, command.Name, err)


### PR DESCRIPTION
If an error occurs in a ManagementCommand, which is a Kusto script, we want to ThrowOnErrors, which "If set to true - the script throws an error (fail) on the first error. Doesn't work together with ContinueOnErrors, only one is allowed. Default: false."

This pull request includes changes to the `ingestor/adx/tasks.go` file to improve error handling in the `Run` method of the `ManagementCommandTask` struct.

Improvements to error handling:

* Modified the `Run` method to include the `ThrowOnErrors = true` option in the Kusto query execution statements to ensure errors are thrown and handled properly.