### PR TITLE
fix flaky test - ensure we always write at least 1 byte

### DIFF
--- a/pkg/wal/segment_test.go
+++ b/pkg/wal/segment_test.go
@@ -340,7 +340,8 @@ func TestSegment_Size(t *testing.T) {
 			require.NoError(t, err)
 
 			for i := 0; i < 100; i++ {
-				n, err := s.Write(context.Background(), []byte(strings.Repeat("a", rand.Intn(8*1024))))
+				// Write random data to the segment, between 1 and 8k+1
+				n, err := s.Write(context.Background(), []byte(strings.Repeat("a", rand.Intn(8*1024)+1)))
 				require.NoError(t, err)
 				require.True(t, n > 0)
 			}


### PR DESCRIPTION
We check in a validation that we have written >0 bytes. rand.Intn could return 0, so always add 1 to ensure we get at least 1 byte.