### PR TITLE
Add support for gzipping segment transfers

### DIFF
--- a/cmd/collector/config/config.go
+++ b/cmd/collector/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	LiftLabels                []*LiftLabel      `toml:"lift-labels,omitempty" comment:"Global labels to lift from the metric to top level columns"`
 
 	DisableMetricsForwarding bool `toml:"disable-metrics-forwarding,omitempty" comment:"Disable metrics forwarding to endpoints."`
+	DisableGzip              bool `toml:"disable-gzip,omitempty" comment:"Disable gzip compression for transferring segments."`
 
 	// These are global config options that apply to all endpoints.
 	AddAttributes  map[string]string `toml:"add-attributes,omitempty" comment:"Key/value pairs of attributes to add to all logs."`

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -312,6 +312,7 @@ func realMain(ctx *cli.Context) error {
 		ListenAddr:             cfg.ListenAddr,
 		NodeName:               hostname,
 		Endpoint:               endpoint,
+		DisableGzip:            cfg.DisableGzip,
 		LiftLabels:             sortedLiftedLabels,
 		AddAttributes:          addAttributes,
 		LiftAttributes:         liftAttributes,

--- a/collector/service.go
+++ b/collector/service.go
@@ -131,6 +131,9 @@ type ServiceOpts struct {
 	// size of segments on the receiving size.  A lower number creates more batches and high remote transfer calls.  If
 	// not specified, the default is 25.
 	MaxBatchSegments int
+
+	// DisableGzip disables gzip compression for the transfer endpoint.
+	DisableGzip bool
 }
 
 type OtlpMetricsHandlerOpts struct {
@@ -289,6 +292,7 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 			SegmentRemover:         store,
 			InsecureSkipVerify:     opts.InsecureSkipVerify,
 			MaxTransferConcurrency: opts.MaxTransferConcurrency,
+			DisableGzip:            opts.DisableGzip,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create replicator: %w", err)

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -26,6 +26,7 @@ func TestService_Open(t *testing.T) {
 			PodInformer:    informer,
 			ScrapeInterval: 10 * time.Second,
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -51,6 +52,7 @@ func TestService_Open_Static(t *testing.T) {
 				{Addr: "http://localhost:8080/metrics"},
 			},
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -77,6 +79,7 @@ func TestService_Open_NoMatchingHost(t *testing.T) {
 				{Addr: "http://localhost:8080/metrics"},
 			},
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -103,6 +106,7 @@ func TestService_Open_NoMetricsAnnotations(t *testing.T) {
 				{Addr: "http://localhost:8080/metrics"},
 			},
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -149,6 +153,7 @@ func TestService_Open_Matching(t *testing.T) {
 				},
 			},
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -205,6 +210,7 @@ func TestService_Open_HostPort(t *testing.T) {
 			NodeName:       "ks8-master-123",
 			ScrapeInterval: 10 * time.Second,
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))
@@ -252,6 +258,7 @@ func TestService_Open_MatchingPort(t *testing.T) {
 				{Addr: "http://localhost:8080/metrics"},
 			},
 		},
+		DisableGzip: true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, s.Open(context.Background()))

--- a/ingestor/cluster/client_test.go
+++ b/ingestor/cluster/client_test.go
@@ -1,8 +1,11 @@
 package cluster
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,6 +29,7 @@ func TestClient_Write_Success(t *testing.T) {
 	client, err := NewClient(ClientOpts{
 		Timeout:            time.Second,
 		InsecureSkipVerify: true,
+		DisableGzip:        true,
 	})
 	require.NoError(t, err)
 
@@ -43,6 +47,7 @@ func TestClient_Write_BadRequest(t *testing.T) {
 	client, err := NewClient(ClientOpts{
 		Timeout:            time.Second,
 		InsecureSkipVerify: true,
+		DisableGzip:        true,
 	})
 	require.NoError(t, err)
 
@@ -62,6 +67,7 @@ func TestClient_Write_TooManyRequests(t *testing.T) {
 	client, err := NewClient(ClientOpts{
 		Timeout:            time.Second,
 		InsecureSkipVerify: true,
+		DisableGzip:        true,
 	})
 	require.NoError(t, err)
 
@@ -80,6 +86,7 @@ func TestClient_Write_SegmentExists(t *testing.T) {
 	client, err := NewClient(ClientOpts{
 		Timeout:            time.Second,
 		InsecureSkipVerify: true,
+		DisableGzip:        true,
 	})
 	require.NoError(t, err)
 
@@ -99,10 +106,41 @@ func TestClient_Write_HTTPError(t *testing.T) {
 	client, err := NewClient(ClientOpts{
 		Timeout:            time.Second,
 		InsecureSkipVerify: true,
+		DisableGzip:        true,
 	})
 	require.NoError(t, err)
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "internal server error")
+}
+
+func TestClient_Write_DisableGzip_False(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "/transfer", r.URL.Path)
+		require.Equal(t, "filename=testfile", r.URL.RawQuery)
+		require.Equal(t, "gzip", r.Header.Get("Content-Encoding")) // Ensure gzip encoding is set
+
+		// Decompress gzip data
+		gzipReader, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		defer gzipReader.Close()
+
+		var decompressed bytes.Buffer
+		_, err = io.Copy(&decompressed, gzipReader)
+		require.NoError(t, err)
+		require.Equal(t, "testdata", decompressed.String()) // Ensure data is compressed and matches
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientOpts{
+		Timeout:     time.Second,
+		DisableGzip: false,
+	})
+	require.NoError(t, err)
+
+	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
+	require.NoError(t, err)
 }

--- a/ingestor/cluster/replicator.go
+++ b/ingestor/cluster/replicator.go
@@ -33,6 +33,9 @@ type ReplicatorOpts struct {
 	// MaxTransferConcurrency is the maximum number of concurrent transfer requests to in flight at a time.
 	// Default is 5.
 	MaxTransferConcurrency int
+
+	// DisableGzip controls whether the client uses gzip compression for transfer requests.
+	DisableGzip bool
 }
 
 type SegmentRemover interface {
@@ -77,6 +80,7 @@ func NewReplicator(opts ReplicatorOpts) (Replicator, error) {
 		ResponseHeaderTimeout: 20 * time.Second,
 		DisableHTTP2:          true,
 		DisableKeepAlives:     false,
+		DisableGzip:           opts.DisableGzip,
 	})
 	if err != nil {
 		return nil, err

--- a/ingestor/cluster/replicator_test.go
+++ b/ingestor/cluster/replicator_test.go
@@ -25,6 +25,7 @@ func TestReplicator_SuccessfulTransfer(t *testing.T) {
 		SegmentRemover:     &fakeSegmentRemover{},
 		InsecureSkipVerify: true,
 		Hostname:           "node1",
+		DisableGzip:        true,
 	}
 
 	rep, err := NewReplicator(opts)
@@ -68,6 +69,7 @@ func TestReplicator_BadRequestError(t *testing.T) {
 		SegmentRemover:     &fakeSegmentRemover{},
 		InsecureSkipVerify: true,
 		Hostname:           "node1",
+		DisableGzip:        true,
 	}
 
 	rep, err := NewReplicator(opts)
@@ -110,6 +112,7 @@ func TestReplicator_SegmentExistsError(t *testing.T) {
 		SegmentRemover:     &fakeSegmentRemover{},
 		InsecureSkipVerify: true,
 		Hostname:           "node1",
+		DisableGzip:        true,
 	}
 
 	rep, err := NewReplicator(opts)
@@ -152,6 +155,7 @@ func TestReplicator_PeerOverloadedError(t *testing.T) {
 		SegmentRemover:     &fakeSegmentRemover{},
 		InsecureSkipVerify: true,
 		Hostname:           "node1",
+		DisableGzip:        true,
 	}
 
 	rep, err := NewReplicator(opts)
@@ -196,6 +200,7 @@ func TestReplicator_UnknownError(t *testing.T) {
 		SegmentRemover:     &fakeSegmentRemover{},
 		InsecureSkipVerify: true,
 		Hostname:           "node1",
+		DisableGzip:        true,
 	}
 
 	rep, err := NewReplicator(opts)

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/scheduler"
 	"github.com/Azure/adx-mon/pkg/wal"
 	"github.com/Azure/adx-mon/storage"
-	gzip "github.com/klauspost/pgzip"
+	"github.com/klauspost/compress/gzip"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -175,6 +175,7 @@ func NewService(opts ServiceOpts) (*Service, error) {
 		Health:                 health,
 		SegmentRemover:         store,
 		MaxTransferConcurrency: opts.MaxTransferConcurrency,
+		DisableGzip:            true,
 	})
 	if err != nil {
 		return nil, err

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -416,7 +416,7 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 	if f == "" {
 		logger.Errorf("Transfer requested with an invalid filename %q", filename)
 		m.WithLabelValues(strconv.Itoa(http.StatusBadRequest)).Inc()
-		http.Error(w, "filename is invalid", http.StatusBadRequest)
+		http.Error(w, "Filename is invalid", http.StatusBadRequest)
 		return
 	}
 
@@ -425,6 +425,7 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 		gzipReader, err := gzip.NewReader(body)
 		if err != nil {
 			logger.Errorf("Failed to create gzip reader: %s", err.Error())
+			m.WithLabelValues(strconv.Itoa(http.StatusBadRequest)).Inc()
 			http.Error(w, "Invalid gzip encoding", http.StatusBadRequest)
 			return
 		}
@@ -443,7 +444,7 @@ func (s *Service) HandleTransfer(w http.ResponseWriter, r *http.Request) {
 	} else if err != nil && strings.Contains(err.Error(), "block checksum verification failed") {
 		logger.Errorf("Transfer requested with checksum error %q from=%s", filename, originalIP)
 		m.WithLabelValues(strconv.Itoa(http.StatusBadRequest)).Inc()
-		http.Error(w, "block checksum verification failed", http.StatusBadRequest)
+		http.Error(w, "Block checksum verification failed", http.StatusBadRequest)
 		return
 	} else if err != nil {
 		logger.Errorf("Failed to import %s: %s from=%s", filename, err.Error(), originalIP)


### PR DESCRIPTION
This adds an option to gzip segments during transfer.  The intent is that this would be enabled by default for collector to ingestor but probably off for ingestor toingestor as they are on the same vnet.