### PR TITLE
Configure sinks on otel-log input, configure metrics for fluent exporter

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -551,6 +551,14 @@ func realMain(ctx *cli.Context) error {
 			}
 
 			sinks := []types.Sink{sink}
+			for _, exporterName := range v.Exporters {
+				sink, err := config.GetLogsExporter(exporterName, cfg.Exporters)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to get exporter %s: %w", exporterName, err)
+				}
+				sinks = append(sinks, sink)
+			}
+
 			logsSvc := otlp.NewLogsService(otlp.LogsServiceOpts{
 				WorkerCreator: engine.WorkerCreator(transformers, sinks),
 				HealthChecker: health,

--- a/collector/export/metric_otlp.go
+++ b/collector/export/metric_otlp.go
@@ -291,10 +291,10 @@ func (c *PromToOtlpExporter) sendRequest(body []byte, count int64) error {
 
 		if exportMetricsServiceResponse.HasPartialSuccess() {
 			rejected := exportMetricsServiceResponse.PartialSuccess.RejectedDataPoints
-			metrics.CollectorExporterMetricsFailed.WithLabelValues("PromToOtlp", c.destination).Add(float64(rejected))
-			metrics.CollectorExporterMetricsSent.WithLabelValues("PromToOtlp", c.destination).Add(float64(count - rejected))
+			metrics.CollectorExporterFailed.WithLabelValues("PromToOtlp", c.destination).Add(float64(rejected))
+			metrics.CollectorExporterSent.WithLabelValues("PromToOtlp", c.destination).Add(float64(count - rejected))
 		} else {
-			metrics.CollectorExporterMetricsSent.WithLabelValues("PromToOtlp", c.destination).Add(float64(count))
+			metrics.CollectorExporterSent.WithLabelValues("PromToOtlp", c.destination).Add(float64(count))
 		}
 	} else {
 		io.Copy(io.Discard, resp.Body)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -214,17 +214,17 @@ var (
 		Help:      "Counter of the number of metrics requests received",
 	}, []string{"protocol", "code", "endpoint"})
 
-	CollectorExporterMetricsSent = promauto.NewCounterVec(prometheus.CounterOpts{
+	CollectorExporterSent = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "collector",
-		Name:      "exporter_sent_metrics",
+		Name:      "exporter_sent_total",
 		Help:      "Counter of the number of telemetry points successfully sent by an exporter",
 	}, []string{"exporter", "endpoint"})
 
-	CollectorExporterMetricsFailed = promauto.NewCounterVec(prometheus.CounterOpts{
+	CollectorExporterFailed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: "collector",
-		Name:      "exporter_failed_metrics",
+		Name:      "exporter_failed_total",
 		Help:      "Counter of the number of telemetry points that failed to be sent by an exporter",
 	}, []string{"exporter", "endpoint"})
 )


### PR DESCRIPTION
This pull request introduces enhancements to the logging and metrics collection system in the telemetry collector. The key changes include support for multiple log exporters, improved error handling and reporting in exporters, and the unification of metrics counters for sent and failed telemetry points.

### Enhancements to logging and exporter functionality:
* Added support for configuring and using multiple log exporters in the `realMain` function. This allows logs to be sent to multiple destinations as defined in the configuration. (`cmd/collector/main.go`)

### Improvements to error handling and metrics reporting:
* Updated the `LogToFluentExporter` to track and report metrics for both successful and failed log batches. This includes incrementing counters for sent and failed logs using the unified metrics system. (`collector/export/log_fluent.go`)
* Refactored the `PromToOtlpExporter` to use the unified metrics counters (`CollectorExporterSent` and `CollectorExporterFailed`) for tracking sent and failed metrics, replacing the old `CollectorExporterMetricsSent` and `CollectorExporterMetricsFailed` counters. (`collector/export/metric_otlp.go`)

### Refactoring and unification of metrics counters:
* Renamed and unified metrics counters in `metrics.go`:
  * `CollectorExporterMetricsSent` → `CollectorExporterSent`
  * `CollectorExporterMetricsFailed` → `CollectorExporterFailed`
  This standardizes the naming and usage of counters for telemetry points sent and failed across all exporters. (`metrics/metrics.go`)

### Additional changes:
* Added a new import for the `metrics` package in `log_fluent.go` to support the updated metrics tracking functionality. (`collector/export/log_fluent.go`)