### PR TITLE
Alerter resets NotificationUnhealthy metric correctly

### DIFF
--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -141,18 +141,22 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 		}
 
 		endpointBaseName, _ := strings.CutPrefix(e.kustoClient.Endpoint(e.rule.Database), "https://")
-		if err := e.AlertCli.Create(ctx, e.AlertAddr, alert.Alert{
+		err = e.AlertCli.Create(ctx, e.AlertAddr, alert.Alert{
 			Destination:   e.rule.Destination,
 			Title:         fmt.Sprintf("Alert %s/%s has query errors on %s", e.rule.Namespace, e.rule.Name, e.kustoClient.Endpoint(e.rule.Database)),
 			Summary:       summary,
 			Severity:      3,
 			Source:        fmt.Sprintf("%s/%s", e.rule.Namespace, e.rule.Name),
 			CorrelationID: fmt.Sprintf("alert-failure/%s/%s/%s", endpointBaseName, e.rule.Namespace, e.rule.Name),
-		}); err != nil {
+		})
+
+		if err != nil {
 			logger.Errorf("Failed to send failure alert for %s/%s/%s: %s", endpointBaseName, e.rule.Namespace, e.rule.Name, err)
 			// Only set the notification as failed if we are not able to send a failure alert directly.
 			metrics.NotificationUnhealthy.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(1)
 			return
+		} else {
+			metrics.NotificationUnhealthy.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(0)
 		}
 		// Query failed due to user error, so return the query to healthy.
 		metrics.QueryHealth.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(1)


### PR DESCRIPTION
In situations where a query has repeated query failures, we need to ensure we reset the NotificationUnhealthy metric back to healthy once we have successfully sent a failure alert.

If we ever had a failure to send this notification, we would get stuck in a state when this would never resolve itself unless the query itself started to succeed.