### PR TITLE
Create a parser for the klog format

### DIFF
--- a/collector/logs/transforms/parser/klog.go
+++ b/collector/logs/transforms/parser/klog.go
@@ -1,0 +1,80 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+)
+
+const ParserTypeKlog ParserType = "klog"
+
+type KlogParserConfig struct{}
+
+type KlogParser struct{}
+
+// NewKlogParser creates a parser for the klog format.
+// https://kubernetes.io/docs/concepts/cluster-administration/system-logs
+func NewKlogParser(config KlogParserConfig) (*KlogParser, error) {
+	return &KlogParser{}, nil
+}
+
+func (p *KlogParser) Parse(log *types.Log, msg string) error {
+	// Trim leading/trailing whitespace
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return nil
+	}
+
+	// Split the log into header, message, and key-value pairs
+	headerEnd := strings.Index(msg, "]")
+	if headerEnd == -1 {
+		log.SetBodyValue("message", msg)
+		return nil // Gracefully handle unstructured logs
+	}
+
+	header := strings.TrimSpace(msg[:headerEnd])
+	messageAndPairs := strings.TrimSpace(msg[headerEnd+1:])
+
+	// Extract metadata from the header
+	fields := strings.Fields(header)
+	if len(fields) >= 4 {
+		log.SetBodyValue("timestamp", fields[1])
+		filenameAndLine := strings.Split(fields[3], ":")
+		if len(filenameAndLine) == 2 {
+			log.SetBodyValue("filename", filenameAndLine[0])
+			log.SetBodyValue("line_number", filenameAndLine[1])
+		}
+	}
+
+	// Extract the message and key-value pairs
+	messageParts := strings.SplitN(messageAndPairs, "\"", 3)
+	if len(messageParts) < 3 {
+		log.SetBodyValue("message", messageAndPairs)
+		return nil // Gracefully handle unstructured logs
+	}
+
+	log.SetBodyValue("message", messageParts[1])
+
+	// Parse key-value pairs
+	pairs := strings.Fields(messageParts[2])
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 {
+			key := kv[0]
+			value := unquoteKlog(kv[1])
+			log.SetBodyValue(key, value)
+		}
+	}
+
+	return nil
+}
+
+// unquoteKlog removes surrounding quotes from a string, if present
+func unquoteKlog(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/collector/logs/transforms/parser/klog_test.go
+++ b/collector/logs/transforms/parser/klog_test.go
@@ -1,0 +1,82 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKlogParser_Parse(t *testing.T) {
+	parser, err := NewKlogParser(KlogParserConfig{})
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]any
+	}{
+		{
+			name:  "Valid klog with message and key-value pairs",
+			input: "I1025 00:15:15.525108       1 controller_utils.go:116] \"Pod status updated\" pod=\"kube-system/kubedns\" status=\"ready\"",
+			expected: map[string]any{
+				"timestamp":   "00:15:15.525108",
+				"filename":    "controller_utils.go",
+				"line_number": "116",
+				"message":     "Pod status updated",
+				"pod":         "kube-system/kubedns",
+				"status":      "ready",
+			},
+		},
+		{
+			name:  "Valid klog with message and many key-value pairs",
+			input: `I0506 15:38:33.629140       1 proxier.go:1508] "Reloading service iptables data" numServices=0 numEndpoints=0 numFilterChains=5 numFilterRules=3 numNATChains=4 numNATRules=5`,
+			expected: map[string]any{
+				"timestamp":       "15:38:33.629140",
+				"filename":        "proxier.go",
+				"line_number":     "1508",
+				"message":         "Reloading service iptables data",
+				"numServices":     "0",
+				"numEndpoints":    "0",
+				"numFilterChains": "5",
+				"numFilterRules":  "3",
+				"numNATChains":    "4",
+				"numNATRules":     "5",
+			},
+		},
+		{
+			name:  "Valid klog with only message",
+			input: "I1025 00:15:15.525108       1 example.go:79] \"This is a message\"",
+			expected: map[string]any{
+				"timestamp":   "00:15:15.525108",
+				"filename":    "example.go",
+				"line_number": "79",
+				"message":     "This is a message",
+			},
+		},
+		{
+			name:  "Unstructured log message",
+			input: "I0506 15:40:33.494743       1 bounded_frequency_runner.go:296] sync-runner: ran, next possible in 1s, periodic in 1h0m0s",
+			expected: map[string]any{
+				"timestamp":   "15:40:33.494743",
+				"filename":    "bounded_frequency_runner.go",
+				"line_number": "296",
+				"message":     "sync-runner: ran, next possible in 1s, periodic in 1h0m0s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := types.NewLog()
+			err := parser.Parse(log, tt.input)
+			assert.NoError(t, err)
+
+			for key, expectedValue := range tt.expected {
+				actualValue, exists := log.GetBodyValue(key)
+				assert.True(t, exists, "Key %s should exist", key)
+				assert.Equal(t, expectedValue, actualValue, "Value for key %s should match", key)
+			}
+		})
+	}
+}

--- a/collector/logs/transforms/parser/parser.go
+++ b/collector/logs/transforms/parser/parser.go
@@ -28,6 +28,8 @@ func newParser(parserType ParserType) (Parser, error) {
 		return NewKeyValueParser(KeyValueParserConfig{})
 	case ParserTypeSpace:
 		return NewSpaceParser(SpaceParserConfig{})
+	case ParserTypeKlog:
+		return NewKlogParser(KlogParserConfig{})
 	default:
 		return nil, fmt.Errorf("unknown parser type: %s", parserType)
 	}
@@ -55,6 +57,8 @@ func IsValidParser(parserType string) bool {
 	case string(ParserTypeKeyValue):
 		return true
 	case string(ParserTypeSpace):
+		return true
+	case string(ParserTypeKlog):
 		return true
 	default:
 		return false


### PR DESCRIPTION
This commit introduces a new parser for the klog format, which is used in Kubernetes and other Go projects for structured logging. The parser