### PR TITLE
feat(operator): implement optimistic concurrency control 

### DIFF
--- a/operator/adx.go
+++ b/operator/adx.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto"
 	armresources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -522,7 +523,7 @@ func (r *AdxReconciler) CheckStatus(ctx context.Context, cluster *adxmonv1.ADXCl
 			return ctrl.Result{}, fmt.Errorf("failed to store applied provisioning state: %w", err)
 		}
 		cluster.Spec.Endpoint = *resp.Properties.URI
-		if err := r.Update(ctx, cluster); err != nil {
+		if err := r.updateClusterWithRetry(ctx, cluster); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update cluster endpoint: %w", err)
 		}
 
@@ -884,9 +885,6 @@ func applyDefaults(ctx context.Context, r *AdxReconciler, cluster *adxmonv1.ADXC
 	}
 
 	updated := false
-	if cluster.Spec.Endpoint != "" {
-		return nil // Skip clusters that already have endpoints
-	}
 
 	// Initialize provision and status if needed
 	if cluster.Spec.Provision == nil {
@@ -914,8 +912,8 @@ func applyDefaults(ctx context.Context, r *AdxReconciler, cluster *adxmonv1.ADXC
 		updated = true
 	}
 
-	// Get best available SKU if not specified
-	if cluster.Spec.Provision.SkuName == "" {
+	// Get best available SKU if not specified and Endpoint isn't already set, which means the cluster is already provisioned
+	if cluster.Spec.Provision.SkuName == "" && cluster.Spec.Endpoint == "" {
 		sku, tier, err := getBestAvailableSKU(ctx, cluster.Spec.Provision.SubscriptionId, cluster.Spec.Provision.Location, cred)
 		if err != nil {
 			return fmt.Errorf("failed to determine SKU: %w", err)
@@ -942,7 +940,7 @@ func applyDefaults(ctx context.Context, r *AdxReconciler, cluster *adxmonv1.ADXC
 
 	// Persist any changes back to the API server
 	if updated {
-		if err := r.Update(ctx, cluster); err != nil {
+		if err := r.updateClusterWithRetry(ctx, cluster); err != nil {
 			logger.Errorf("Failed to update cluster information: %v", err)
 			return fmt.Errorf("failed to update cluster spec: %w", err)
 		}
@@ -1186,4 +1184,39 @@ func executeKustoScripts(ctx context.Context, client *kusto.Client, database str
 		}
 	}
 	return nil
+}
+
+// updateClusterWithRetry implements optimistic concurrency control for cluster updates
+func (r *AdxReconciler) updateClusterWithRetry(ctx context.Context, cluster *adxmonv1.ADXCluster) error {
+	const maxRetries = 5
+	for i := 0; i < maxRetries; i++ {
+		if err := r.Update(ctx, cluster); err != nil {
+			if !apierrors.IsConflict(err) {
+				// Not a conflict error, return immediately
+				return err
+			}
+
+			// Conflict error, fetch the latest version and retry
+			logger.Infof("Conflict updating cluster %s, retrying (attempt %d/%d)", cluster.Name, i+1, maxRetries)
+
+			var latestCluster adxmonv1.ADXCluster
+			if err := r.Get(ctx, client.ObjectKeyFromObject(cluster), &latestCluster); err != nil {
+				return fmt.Errorf("failed to fetch latest cluster for retry: %w", err)
+			}
+
+			// Preserve the spec changes we want to apply
+			preservedSpec := cluster.Spec
+
+			// Update with the latest cluster object
+			*cluster = latestCluster
+
+			// Reapply our spec changes
+			cluster.Spec = preservedSpec
+
+			continue
+		}
+		// Update succeeded
+		return nil
+	}
+	return fmt.Errorf("failed to update cluster after %d retries due to conflicts", maxRetries)
 }

--- a/operator/alerter.go
+++ b/operator/alerter.go
@@ -182,7 +182,7 @@ func (r *AlerterReconciler) updateImageIfNeeded(deployment *appsv1.Deployment, a
 func (r *AlerterReconciler) IsReady(ctx context.Context, alerter *adxmonv1.Alerter) (ctrl.Result, error) {
 	var deploy appsv1.Deployment
 	if err := r.Get(ctx, client.ObjectKey{Namespace: alerter.GetNamespace(), Name: "alerter"}, &deploy); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		return ctrl.Result{}, err
@@ -251,7 +251,7 @@ func (r *AlerterReconciler) CreateAlerter(ctx context.Context, alerter *adxmonv1
 				}
 			}
 		}
-		if err := r.Create(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+		if err := r.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to create %s %s: %w", obj.GetKind(), obj.GetName(), err)
 		}
 	}
@@ -275,7 +275,7 @@ func (r *AlerterReconciler) installAlertRuleCRD(ctx context.Context) error {
 	existing.SetGroupVersionKind(obj.GroupVersionKind())
 	err = r.Client.Get(ctx, client.ObjectKey{Name: obj.GetName()}, existing)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			if err := r.Client.Create(ctx, obj); err != nil {
 				return fmt.Errorf("failed to create AlertRule CRD %s: %w", obj.GetName(), err)
 			}

--- a/operator/alerter.go
+++ b/operator/alerter.go
@@ -14,7 +14,6 @@ import (
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/pkg/logger"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/operator/ingestor.go
+++ b/operator/ingestor.go
@@ -75,7 +75,7 @@ func (r *IngestorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *IngestorReconciler) IsReady(ctx context.Context, ingestor *adxmonv1.Ingestor) (ctrl.Result, error) {
 	var sts appsv1.StatefulSet
 	if err := r.Get(ctx, client.ObjectKey{Namespace: ingestor.GetNamespace(), Name: ingestor.GetName()}, &sts); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		return ctrl.Result{}, err
@@ -383,7 +383,7 @@ func (r *IngestorReconciler) CreateIngestor(ctx context.Context, ingestor *adxmo
 			logger.Infof("Skipping owner reference for cluster-scoped resource %s/%s", obj.GetKind(), obj.GetName())
 		}
 
-		if err := r.Create(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+		if err := r.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to create %s %s: %w", obj.GetKind(), obj.GetName(), err)
 		}
 	}
@@ -502,7 +502,7 @@ func (r *IngestorReconciler) installCrds(ctx context.Context) error {
 		existing.SetGroupVersionKind(obj.GroupVersionKind())
 		err = r.Client.Get(ctx, client.ObjectKey{Name: obj.GetName()}, existing)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// CRD doesn't exist, create it
 				if err := r.Client.Create(ctx, obj); err != nil {
 					return fmt.Errorf("failed to create CRD %s: %w", obj.GetName(), err)

--- a/operator/ingestor.go
+++ b/operator/ingestor.go
@@ -14,7 +14,6 @@ import (
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/pkg/logger"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -527,6 +526,7 @@ func (r *IngestorReconciler) installCrds(ctx context.Context) error {
 // retryWithConflictResolution retries an update operation on a Kubernetes object, resolving conflicts by fetching the latest version and reapplying changes.
 func retryWithConflictResolution(ctx context.Context, c client.Client, obj client.Object, reapplyChanges func(latest client.Object) error) error {
 	const maxRetries = 5
+	const baseBackoff = 100 * time.Millisecond
 	for i := 0; i < maxRetries; i++ {
 		if err := c.Update(ctx, obj); err != nil {
 			if !apierrors.IsConflict(err) {

--- a/pkg/k8s/retry.go
+++ b/pkg/k8s/retry.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UpdateWithRetry implements optimistic concurrency control for Kubernetes object updates.
+// It retries update operations when conflicts occur by fetching the latest version and
+// reapplying the desired changes using the provided callback function.
+func UpdateWithRetry(ctx context.Context, c client.Client, obj client.Object, reapplyChanges func(latest client.Object) error) error {
+	const maxRetries = 5
+
+	// Create a working copy to avoid modifying the original until we're sure of success
+	workingCopy := obj.DeepCopyObject().(client.Object)
+
+	// Apply changes to the working copy for the first update attempt
+	if err := reapplyChanges(workingCopy); err != nil {
+		return fmt.Errorf("failed to apply initial changes: %w", err)
+	}
+
+	for i := 0; i < maxRetries; i++ {
+		if err := c.Update(ctx, workingCopy); err != nil {
+			if !apierrors.IsConflict(err) {
+				// Not a conflict error, return immediately
+				return err
+			}
+
+			// Conflict error, fetch the latest version and retry
+			logger.Infof("Conflict updating %s, retrying (attempt %d/%d)", obj.GetName(), i+1, maxRetries)
+
+			latest := obj.DeepCopyObject().(client.Object)
+			if err := c.Get(ctx, client.ObjectKeyFromObject(obj), latest); err != nil {
+				return fmt.Errorf("failed to fetch latest object for retry: %w", err)
+			}
+
+			// Reapply the desired changes to the latest version
+			if err := reapplyChanges(latest); err != nil {
+				return fmt.Errorf("failed to reapply changes: %w", err)
+			}
+
+			// Use the updated latest version for the next update attempt
+			workingCopy = latest
+			continue
+		}
+
+		// Update succeeded - copy the successful result back to the original object
+		objValue := reflect.ValueOf(obj).Elem()
+		workingValue := reflect.ValueOf(workingCopy).Elem()
+		objValue.Set(workingValue)
+		return nil
+	}
+	return fmt.Errorf("failed to update object after %d retries due to conflicts", maxRetries)
+}
+
+// UpdateWithRetryPreserveSpec is a convenience wrapper for UpdateWithRetry that preserves
+// the entire Spec field from the current object and applies it to the latest version.
+// This covers the common case where you want to preserve all spec changes.
+func UpdateWithRetryPreserveSpec[T client.Object, S any](ctx context.Context, c client.Client, obj T, getSpec func(T) S, setSpec func(T, S)) error {
+	// Capture the desired spec before any retries
+	preservedSpec := getSpec(obj)
+
+	return UpdateWithRetry(ctx, c, obj, func(latest client.Object) error {
+		latestTyped, ok := latest.(T)
+		if !ok {
+			return fmt.Errorf("unexpected latest object type: %T", latest)
+		}
+
+		// Apply the preserved spec to the latest version
+		setSpec(latestTyped, preservedSpec)
+		return nil
+	})
+}

--- a/pkg/k8s/retry_test.go
+++ b/pkg/k8s/retry_test.go
@@ -1,0 +1,495 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MockObject implements client.Object for testing
+type MockObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   MockSpec   `json:"spec,omitempty"`
+	Status MockStatus `json:"status,omitempty"`
+}
+
+type MockSpec struct {
+	Field1 string `json:"field1,omitempty"`
+	Field2 int    `json:"field2,omitempty"`
+}
+
+type MockStatus struct {
+	Phase string `json:"phase,omitempty"`
+}
+
+func (m *MockObject) DeepCopyObject() runtime.Object {
+	return &MockObject{
+		TypeMeta:   m.TypeMeta,
+		ObjectMeta: *m.ObjectMeta.DeepCopy(),
+		Spec:       m.Spec,
+		Status:     m.Status,
+	}
+}
+
+// MockClient implements client.Client for testing
+type MockClient struct {
+	updateCallCount int
+	getCallCount    int
+	shouldConflict  []bool // Controls which update calls should return conflicts
+	updateError     error  // Non-conflict error to return
+	getError        error  // Error to return from Get calls
+	getFunc         func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+
+	// Object state simulation
+	currentObject *MockObject
+}
+
+func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	m.getCallCount++
+
+	if m.getFunc != nil {
+		return m.getFunc(ctx, key, obj, opts...)
+	}
+
+	if m.getError != nil {
+		return m.getError
+	}
+
+	// Simulate fetching the latest version
+	mockObj, ok := obj.(*MockObject)
+	if !ok {
+		return fmt.Errorf("expected MockObject, got %T", obj)
+	}
+
+	if m.currentObject != nil {
+		*mockObj = *m.currentObject
+		// Simulate resource version increment
+		mockObj.SetResourceVersion(fmt.Sprintf("v%d", m.getCallCount))
+	}
+
+	return nil
+}
+
+func (m *MockClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	m.updateCallCount++
+
+	if m.updateError != nil {
+		return m.updateError
+	}
+
+	// Check if this call should return a conflict
+	if m.updateCallCount <= len(m.shouldConflict) && m.shouldConflict[m.updateCallCount-1] {
+		return apierrors.NewConflict(
+			schema.GroupResource{Group: "", Resource: "mockobjects"},
+			obj.GetName(),
+			fmt.Errorf("conflict on attempt %d", m.updateCallCount),
+		)
+	}
+
+	// Successful update - store the object
+	if mockObj, ok := obj.(*MockObject); ok {
+		m.currentObject = &MockObject{
+			TypeMeta:   mockObj.TypeMeta,
+			ObjectMeta: *mockObj.ObjectMeta.DeepCopy(),
+			Spec:       mockObj.Spec,
+			Status:     mockObj.Status,
+		}
+	}
+
+	return nil
+}
+
+// Implement the rest of client.Client interface (not used in tests)
+func (m *MockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return nil
+}
+func (m *MockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+func (m *MockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+func (m *MockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+func (m *MockClient) Status() client.StatusWriter { return nil }
+func (m *MockClient) Scheme() *runtime.Scheme     { return nil }
+func (m *MockClient) RESTMapper() meta.RESTMapper { return nil }
+func (m *MockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+func (m *MockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return true, nil
+}
+func (m *MockClient) SubResource(subResource string) client.SubResourceClient {
+	return nil
+}
+
+func TestUpdateWithRetry_SuccessfulUpdate(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+		Spec: MockSpec{
+			Field1: "original",
+			Field2: 42,
+		},
+	}
+
+	// Test successful update on first try
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		latestMock := latest.(*MockObject)
+		latestMock.Spec.Field1 = "updated"
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if mockClient.updateCallCount != 1 {
+		t.Errorf("Expected 1 update call, got: %d", mockClient.updateCallCount)
+	}
+
+	if mockClient.getCallCount != 0 {
+		t.Errorf("Expected 0 get calls for successful update, got: %d", mockClient.getCallCount)
+	}
+
+	if obj.Spec.Field1 != "updated" {
+		t.Errorf("Expected Field1 to be 'updated', got: %s", obj.Spec.Field1)
+	}
+}
+
+func TestUpdateWithRetry_ConflictRetry(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true, true, false}, // Conflict on first 2 attempts, succeed on 3rd
+		currentObject: &MockObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-object",
+				Namespace: "default",
+			},
+			Spec: MockSpec{
+				Field1: "server-version",
+				Field2: 99,
+			},
+		},
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+		Spec: MockSpec{
+			Field1: "client-version",
+			Field2: 42,
+		},
+	}
+
+	callCount := 0
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		callCount++
+		latestMock := latest.(*MockObject)
+
+		if callCount == 1 {
+			// First call should have original client values
+			if latestMock.Spec.Field1 != "client-version" {
+				t.Errorf("Expected first call Field1 to be 'client-version', got: %s", latestMock.Spec.Field1)
+			}
+			if latestMock.Spec.Field2 != 42 {
+				t.Errorf("Expected first call Field2 to be 42, got: %d", latestMock.Spec.Field2)
+			}
+		} else {
+			// Retry calls should have server values
+			if latestMock.Spec.Field1 != "server-version" {
+				t.Errorf("Expected retry call Field1 to be 'server-version', got: %s", latestMock.Spec.Field1)
+			}
+			if latestMock.Spec.Field2 != 99 {
+				t.Errorf("Expected retry call Field2 to be 99, got: %d", latestMock.Spec.Field2)
+			}
+		}
+
+		// Apply our change to the latest version
+		latestMock.Spec.Field1 = "updated-by-client"
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if callCount != 3 {
+		t.Errorf("Expected callback to be called 3 times, got: %d", callCount)
+	}
+
+	if mockClient.updateCallCount != 3 {
+		t.Errorf("Expected 3 update calls, got: %d", mockClient.updateCallCount)
+	}
+
+	if mockClient.getCallCount != 2 {
+		t.Errorf("Expected 2 get calls (for 2 retries), got: %d", mockClient.getCallCount)
+	}
+
+	// Verify the object was updated with the latest server state + our changes
+	if obj.Spec.Field1 != "updated-by-client" {
+		t.Errorf("Expected Field1 to be 'updated-by-client', got: %s", obj.Spec.Field1)
+	}
+	if obj.Spec.Field2 != 99 {
+		t.Errorf("Expected Field2 to be 99 (from server), got: %d", obj.Spec.Field2)
+	}
+}
+
+func TestUpdateWithRetry_MaxRetriesExceeded(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true, true, true, true, true, true}, // Always conflict
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("Expected error due to max retries exceeded")
+	}
+
+	expectedError := "failed to update object after 5 retries due to conflicts"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error message '%s', got: %s", expectedError, err.Error())
+	}
+
+	if mockClient.updateCallCount != 5 {
+		t.Errorf("Expected 5 update calls, got: %d", mockClient.updateCallCount)
+	}
+
+	if mockClient.getCallCount != 5 {
+		t.Errorf("Expected 5 get calls, got: %d", mockClient.getCallCount)
+	}
+}
+
+func TestUpdateWithRetry_NonConflictError(t *testing.T) {
+	ctx := context.Background()
+	expectedError := errors.New("some other error")
+	mockClient := &MockClient{
+		updateError: expectedError,
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		return nil
+	})
+
+	if err != expectedError {
+		t.Errorf("Expected error to be %v, got: %v", expectedError, err)
+	}
+
+	if mockClient.updateCallCount != 1 {
+		t.Errorf("Expected 1 update call, got: %d", mockClient.updateCallCount)
+	}
+
+	if mockClient.getCallCount != 0 {
+		t.Errorf("Expected 0 get calls for non-conflict error, got: %d", mockClient.getCallCount)
+	}
+}
+
+func TestUpdateWithRetry_GetError(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true}, // Trigger conflict to cause Get call
+		getError:       errors.New("get failed"),
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("Expected error due to Get failure")
+	}
+
+	expectedError := "failed to fetch latest object for retry: get failed"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error message '%s', got: %s", expectedError, err.Error())
+	}
+}
+
+func TestUpdateWithRetry_ReapplyChangesError(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	reapplyError := errors.New("reapply failed")
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		return reapplyError
+	})
+
+	if err == nil {
+		t.Fatal("Expected error due to reapply failure")
+	}
+
+	expectedError := "failed to apply initial changes: reapply failed"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error message '%s', got: %s", expectedError, err.Error())
+	}
+}
+
+func TestUpdateWithRetry_ReapplyChangesErrorDuringRetry(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true}, // Trigger conflict to cause reapply
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	callCount := 0
+	reapplyError := errors.New("reapply failed")
+	err := UpdateWithRetry(ctx, mockClient, obj, func(latest client.Object) error {
+		callCount++
+		if callCount == 2 { // Fail on the second call (retry attempt)
+			return reapplyError
+		}
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("Expected error due to reapply failure")
+	}
+
+	expectedError := "failed to reapply changes: reapply failed"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error message '%s', got: %s", expectedError, err.Error())
+	}
+}
+
+func TestUpdateWithRetryPreserveSpec_Success(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true, false}, // Conflict once, then succeed
+		currentObject: &MockObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test-object",
+				Namespace:       "default",
+				ResourceVersion: "v1",
+			},
+			Spec: MockSpec{
+				Field1: "server-field1",
+				Field2: 999,
+			},
+			Status: MockStatus{
+				Phase: "server-phase",
+			},
+		},
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+		Spec: MockSpec{
+			Field1: "client-field1",
+			Field2: 42,
+		},
+		Status: MockStatus{
+			Phase: "client-phase",
+		},
+	}
+
+	err := UpdateWithRetryPreserveSpec(ctx, mockClient, obj,
+		func(o *MockObject) MockSpec { return o.Spec },
+		func(o *MockObject, spec MockSpec) { o.Spec = spec },
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify that our spec was preserved but other fields came from server
+	if obj.Spec.Field1 != "client-field1" {
+		t.Errorf("Expected Field1 to be preserved as 'client-field1', got: %s", obj.Spec.Field1)
+	}
+	if obj.Spec.Field2 != 42 {
+		t.Errorf("Expected Field2 to be preserved as 42, got: %d", obj.Spec.Field2)
+	}
+	if obj.Status.Phase != "server-phase" {
+		t.Errorf("Expected Status.Phase to be from server 'server-phase', got: %s", obj.Status.Phase)
+	}
+	if obj.GetResourceVersion() != "v1" {
+		t.Errorf("Expected ResourceVersion to be from server 'v1', got: %s", obj.GetResourceVersion())
+	}
+}
+
+func TestUpdateWithRetryPreserveSpec_TypeMismatch(t *testing.T) {
+	ctx := context.Background()
+	mockClient := &MockClient{
+		shouldConflict: []bool{true}, // Trigger conflict
+		getFunc: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			// Return an error to simulate Get failure
+			return fmt.Errorf("type assertion would fail")
+		},
+	}
+
+	obj := &MockObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-object",
+			Namespace: "default",
+		},
+	}
+
+	err := UpdateWithRetryPreserveSpec(ctx, mockClient, obj,
+		func(o *MockObject) MockSpec { return o.Spec },
+		func(o *MockObject, spec MockSpec) { o.Spec = spec },
+	)
+
+	if err == nil {
+		t.Fatal("Expected error due to Get failure")
+	}
+}


### PR DESCRIPTION
This pull request introduces optimistic concurrency control for updating Kubernetes resources in the `adx`, `alerter`, and `ingestor` operators. It replaces direct update calls with retryable update methods to handle conflicts gracefully. Additionally, it includes logic improvements for setting default values in the `adx` operator.

### Optimistic Concurrency Control

* Added `updateClusterWithRetry` in `adx.go` to handle conflicts when updating `ADXCluster` resources. The method retries up to 5 times, fetching the latest version and reapplying changes on conflict. (`[operator/adx.goR1188-R1222](diffhunk://#diff-f0a3069b79272986864a2002b3163b5701e3fb2c5e97588c803e3b272e6bb522R1188-R1222)`)
* Added `updateDeploymentWithRetry` in `alerter.go` to handle conflicts when updating `Deployment` resources. Similar retry logic is applied. (`[operator/alerter.goR422-R456](diffhunk://#diff-5e6bc85176464f9ed5e9a7191b548faf484bd19867b49d4efb4def65b76fa189R422-R456)`)
* Added `updateStatefulSetWithRetry` in `ingestor.go` to handle conflicts when updating `StatefulSet` resources. The method follows the same retry pattern. (`[operator/ingestor.goR526-R560](diffhunk://#diff-b3cf67f46a7960e8f642c1226eca8ba64e7a253e35f0bf23b6bd1d55b53b0fb0R526-R560)`)

### Logic Improvements in `adx` Operator

* Modified `applyDefaults` to skip fetching the best available SKU if the `Endpoint` is already set, indicating the cluster is provisioned. (`[operator/adx.goL917-R916](diffhunk://#diff-f0a3069b79272986864a2002b3163b5701e3fb2c5e97588c803e3b272e6bb522L917-R916)`)
* Removed redundant checks for `Endpoint` in `applyDefaults`, simplifying the logic for clusters with existing endpoints. (`[operator/adx.goL887-L889](diffhunk://#diff-f0a3069b79272986864a2002b3163b5701e3fb2c5e97588c803e3b272e6bb522L887-L889)`)

### Miscellaneous

* Updated import statements in `adx.go`, `alerter.go`, and `ingestor.go` to include `k8s.io/apimachinery/pkg/api/errors` as `apierrors` for improved readability. (`[[1]](diffhunk://#diff-f0a3069b79272986864a2002b3163b5701e3fb2c5e97588c803e3b272e6bb522R23)`, `[[2]](diffhunk://#diff-5e6bc85176464f9ed5e9a7191b548faf484bd19867b49d4efb4def65b76fa189R18)`, `[[3]](diffhunk://#diff-b3cf67f46a7960e8f642c1226eca8ba64e7a253e35f0bf23b6bd1d55b53b0fb0R18)`)