### PR TITLE
Fix batch upload leak

### DIFF
--- a/ingestor/adx/dispatcher.go
+++ b/ingestor/adx/dispatcher.go
@@ -81,6 +81,7 @@ func (d *dispatcher) upload(ctx context.Context) {
 			select {
 			case u.UploadQueue() <- batch:
 			default:
+				batch.Release()
 				logger.Errorf("Failed to queue batch for %s. Queue is full: %d/%d", batch.Database, len(u.UploadQueue()), cap(u.UploadQueue()))
 			}
 		}

--- a/pkg/wal/repository.go
+++ b/pkg/wal/repository.go
@@ -64,6 +64,7 @@ func (s *Repository) Open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer dir.Close()
 
 	for {
 		entries, err := dir.ReadDir(100)


### PR DESCRIPTION
This pull request introduces two changes aimed at improving resource management and error handling in different parts of the codebase.

### Resource Management Improvements:

* [`ingestor/adx/dispatcher.go`](diffhunk://#diff-c2f50876da2d07dfa37681d09bb5fb3b146af1425688a3b7f81c99f9efa41dd0R84): Added a call to `batch.Release()` in the default case of the `select` statement to ensure that resources are properly released when the upload queue is full.
* [`pkg/wal/repository.go`](diffhunk://#diff-6da285d4a21d7e052a10a3076558ce32a0d72c6084a3dc8325baa14a15efdf99R67): Added a `defer dir.Close()` statement in the `Open` method to ensure the directory resource is closed properly after use.