### PR TITLE
(fix): Change summary rules scheduling interval from 10 minutes to 1 minute

### DIFF
--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -291,7 +291,7 @@ func (s *Service) Open(ctx context.Context) error {
 		})
 
 		sr := adx.NewSummaryRuleTask(crdStore, v)
-		s.scheduler.ScheduleEvery(10*time.Minute, "summary-rules", func(ctx context.Context) error {
+		s.scheduler.ScheduleEvery(time.Minute, "summary-rules", func(ctx context.Context) error {
 			return sr.Run(ctx)
 		})
 	}
@@ -308,7 +308,7 @@ func (s *Service) Open(ctx context.Context) error {
 		})
 
 		sr := adx.NewSummaryRuleTask(crdStore, v)
-		s.scheduler.ScheduleEvery(10*time.Minute, "summary-rules", func(ctx context.Context) error {
+		s.scheduler.ScheduleEvery(time.Minute, "summary-rules", func(ctx context.Context) error {
 			return sr.Run(ctx)
 		})
 	}


### PR DESCRIPTION
Internal business requirements require a change in the scheduling interval for summary rules.