### PR TITLE
Failed operation accumulation fix

### DIFF
--- a/api/v1/summaryrule_types.go
+++ b/api/v1/summaryrule_types.go
@@ -161,7 +161,21 @@ func (s *SummaryRule) SetAsyncOperation(operation AsyncOperation) {
 	// Check if the operation already exists
 	found := false
 	for i, op := range asyncOperations {
-		if op.OperationId == operation.OperationId {
+		// If we're unable to submit an AsyncOperation, we add it to our backlog for
+		// future submission. Once we're able to submit the operation, we set the
+		// operation-id, which means we need to detect this case and match operations
+		// based on their time windows.
+		if op.OperationId == "" {
+			if op.StartTime == operation.StartTime &&
+				op.EndTime == operation.EndTime &&
+				op.StartTime != "" && op.EndTime != "" {
+				// If the operation is in the backlog, we need to update it with the new
+				// operation-id and the start and end times.
+				asyncOperations[i] = operation
+				found = true
+				break
+			}
+		} else if op.OperationId == operation.OperationId {
 			// Update the existing operation
 			asyncOperations[i] = operation
 			found = true

--- a/api/v1/summaryrule_types_test.go
+++ b/api/v1/summaryrule_types_test.go
@@ -93,3 +93,31 @@ func TestAsyncOperations(t *testing.T) {
 	ops = sr.GetAsyncOperations()
 	require.Equal(t, 200, len(ops))
 }
+
+func TestBacklog(t *testing.T) {
+	var sr SummaryRule
+
+	// We expect the initial AsyncOperation to be empty
+	ops := sr.GetAsyncOperations()
+	require.Equal(t, 0, len(ops))
+
+	// Create a backlog AsyncOperation, which means it has no operation-id
+	sr.SetAsyncOperation(AsyncOperation{StartTime: "2025-05-22T19:20:00Z", EndTime: "2025-05-22T19:30:00Z"})
+	ops = sr.GetAsyncOperations()
+	require.Equal(t, 1, len(ops))
+
+	// Add another backlog
+	sr.SetAsyncOperation(AsyncOperation{StartTime: "2025-05-22T19:40:00Z", EndTime: "2025-05-22T19:50:00Z"})
+	ops = sr.GetAsyncOperations()
+	require.Equal(t, 2, len(ops))
+
+	// Now simulate the operation was able to be submitted, so the operation-id is now set
+	sr.SetAsyncOperation(AsyncOperation{OperationId: "1", StartTime: "2025-05-22T19:20:00Z", EndTime: "2025-05-22T19:30:00Z"})
+	ops = sr.GetAsyncOperations()
+	require.Equal(t, 2, len(ops)) // should just update the existing operation
+	for _, op := range ops {
+		if op.StartTime == "2025-05-22T19:20:00Z" && op.EndTime == "2025-05-22T19:30:00Z" {
+			require.Equal(t, "1", op.OperationId) // should have the operation-id set now
+		}
+	}
+}

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -632,7 +632,7 @@ func TestSummaryRuleSubmissionFailure(t *testing.T) {
 
 	// Should have no async operations since submission failed
 	asyncOps := updatedRule.GetAsyncOperations()
-	require.Len(t, asyncOps, 0, "Should have no async operations when submission fails")
+	require.Len(t, asyncOps, 1, "Should have an async operations when submission fails")
 }
 
 func TestSummaryRuleSubmissionSuccess(t *testing.T) {


### PR DESCRIPTION
This change address the issue where failed submission operations weren't being accumulated for later retry when Kusto is offline. The fix ensures that operation windows are always stored in the CRD, even when initial submission fails.