### PR TITLE
Fix disk usage exceeding max disk usage limit

### DIFF
--- a/ingestor/adx/fake.go
+++ b/ingestor/adx/fake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/Azure/adx-mon/ingestor/cluster"
@@ -76,9 +75,9 @@ func (f *fakeUploader) upload(ctx context.Context) {
 
 			for _, si := range segments {
 				logger.Warnf("Uploading segment %s", si.Path)
-				if err := os.RemoveAll(si.Path); err != nil {
-					logger.Errorf("Failed to remove segment: %s", err.Error())
-				}
+			}
+			if err := batch.Remove(); err != nil {
+				logger.Errorf("Failed to remove batch: %s", err.Error())
 			}
 			batch.Release()
 		}

--- a/ingestor/adx/uploader.go
+++ b/ingestor/adx/uploader.go
@@ -217,6 +217,7 @@ func (n *uploader) upload(ctx context.Context) error {
 
 			if batch.Database != n.database {
 				logger.Errorf("Database mismatch: %s != %s. Skipping batch", batch.Database, n.database)
+				batch.Release()
 				continue
 			}
 

--- a/ingestor/cluster/batcher_test.go
+++ b/ingestor/cluster/batcher_test.go
@@ -461,8 +461,8 @@ func TestBatcher_Stats(t *testing.T) {
 	require.NoError(t, err)
 
 	// No batches should be returned because existing segments are already assigned to batched and not released
-	require.Equal(t, int64(0), a.SegmentsTotal())
-	require.Equal(t, int64(0), a.SegmentsSize())
+	require.Equal(t, int64(4), a.SegmentsTotal())
+	require.Equal(t, int64(103524), a.SegmentsSize())
 
 	// Release all the segments so they can re-assigned to new batches
 	for _, b := range owned {


### PR DESCRIPTION
There was a bug in the health status reporting where the disk usage reported was not correct because it used the values reported from the last batcher run.  This does not include all segments on disks and would under report the actual usage and lead to incorrect health status and allowing for more data to be accepted.

The fix is to use the repository stats which account for all segments on disk.  This should prevent disk usage exceeding the limits for both collector and ingestor.