### PR TITLE
feat(summary-rules): truncate start and end times to interval to ensure nice buckets

### DIFF
--- a/api/v1/summaryrule_types.go
+++ b/api/v1/summaryrule_types.go
@@ -292,12 +292,13 @@ func (s *SummaryRule) NextExecutionWindow(clk clock.Clock) (windowStartTime time
 		// First execution: start from current time aligned to interval boundary, going back one interval
 		now := clk.Now().UTC()
 		// Align to minute boundary for consistency
-		alignedNow := now.Truncate(time.Minute)
+		alignedNow := now.Truncate(s.Spec.Interval.Duration)
 		windowEndTime = alignedNow
 		windowStartTime = windowEndTime.Add(-s.Spec.Interval.Duration)
 	} else {
 		// Subsequent executions: start from where the last successful execution ended
 		windowStartTime = *lastSuccessfulEndTime
+		windowStartTime = windowStartTime.Truncate(s.Spec.Interval.Duration)
 		windowEndTime = windowStartTime.Add(s.Spec.Interval.Duration)
 
 		// Ensure we don't execute future windows


### PR DESCRIPTION
Previously, we were only rounding the start and end time of summary rules to the nearest minute. This meant that for longer interval summary rules, like say an hour, your startTime could be something like 08:07 and your endTime 09:07 forcing you to round yourself in your query if you desired nice even buckets. This is not ideal as it ends up producing a lot of duplicate lines throughout summary rules just to give you nice round buckets.

As discussed, this could be made into an optional feature at a later date, but for simplicity and to get any current summary rules corrected and running on the correct intervals, this makes sense to me to start with. We will take the hit with some initial oddness with data that could occur as this rolls out given limited uses of summary rules today.