### PR TITLE
fix(operator): update heartbeat parsing to handle multiple schemas per endpoint

### DIFF
--- a/operator/adx.go
+++ b/operator/adx.go
@@ -1106,7 +1106,10 @@ func parseHeartbeatRows(rows []HeartbeatRow) (map[string][]ADXClusterSchema, map
 	partitionMetaByEndpoint := make(map[string]map[string]string)
 	for _, row := range rows {
 		var schema []ADXClusterSchema
-		_ = json.Unmarshal(row.Schema, &schema)
+		if err := json.Unmarshal(row.Schema, &schema); err != nil {
+			logger.Errorf("failed to parse schema for endpoint %s: %v", row.ClusterEndpoint, err)
+			continue
+		}
 		schemaByEndpoint[row.ClusterEndpoint] = schema
 		partitionMetaByEndpoint[row.ClusterEndpoint] = row.PartitionMetadata
 	}

--- a/operator/adx_test.go
+++ b/operator/adx_test.go
@@ -576,7 +576,7 @@ func TestHeartbeatFederatedClusters(t *testing.T) {
 }
 
 func TestParseHeartbeatRows(t *testing.T) {
-	rawSchema := `{"database":"db1","tables":["t1","t2"]}`
+	rawSchema := `[{"database":"db1","tables":["t1","t2"]}]`
 	rawMeta := map[string]string{"geo": "us"}
 	rows := []HeartbeatRow{
 		{
@@ -588,14 +588,14 @@ func TestParseHeartbeatRows(t *testing.T) {
 	}
 	schemaByEndpoint, metaByEndpoint := parseHeartbeatRows(rows)
 	require.Contains(t, schemaByEndpoint, "ep1")
-	require.Equal(t, "db1", schemaByEndpoint["ep1"].Database)
+	require.Equal(t, "db1", schemaByEndpoint["ep1"][0].Database)
 	require.Equal(t, rawMeta, metaByEndpoint["ep1"])
 }
 
 func TestExtractDatabasesFromSchemas(t *testing.T) {
-	schemas := map[string]ADXClusterSchema{
-		"ep1": {Database: "db1"},
-		"ep2": {Database: "db2"},
+	schemas := map[string][]ADXClusterSchema{
+		"ep1": {{Database: "db1"}},
+		"ep2": {{Database: "db2"}},
 	}
 	dbs := extractDatabasesFromSchemas(schemas)
 	require.Contains(t, dbs, "db1")
@@ -603,9 +603,9 @@ func TestExtractDatabasesFromSchemas(t *testing.T) {
 }
 
 func TestMapTablesToEndpoints(t *testing.T) {
-	schemas := map[string]ADXClusterSchema{
-		"ep1": {Database: "db1", Tables: []string{"t1", "t2"}},
-		"ep2": {Database: "db1", Tables: []string{"t2"}},
+	schemas := map[string][]ADXClusterSchema{
+		"ep1": {{Database: "db1", Tables: []string{"t1", "t2"}}},
+		"ep2": {{Database: "db1", Tables: []string{"t2"}}},
 	}
 	m := mapTablesToEndpoints(schemas)
 	require.ElementsMatch(t, m["db1"]["t1"], []string{"ep1"})


### PR DESCRIPTION
When Partition clusters heartbeat to a Federated cluster, they send their schema, which is an array of database/table combinations. The parsing of these results were incorrectly expecting the schemas to be a flat database/table. This change fixes the parsing to account for the correct schema topology.