### PR TITLE
feat(summaryrules): add an ingestion delay field to summary rules which gets subtracted from the execution window, ensuring data consistency

### DIFF
--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1038,6 +1038,11 @@ func (in *SummaryRuleList) DeepCopyObject() runtime.Object {
 func (in *SummaryRuleSpec) DeepCopyInto(out *SummaryRuleSpec) {
 	*out = *in
 	out.Interval = in.Interval
+	if in.IngestionDelay != nil {
+		in, out := &in.IngestionDelay, &out.IngestionDelay
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.Criteria != nil {
 		in, out := &in.Criteria, &out.Criteria
 		*out = make(map[string][]string, len(*in))

--- a/kustomize/bases/summaryrules_crd.yaml
+++ b/kustomize/bases/summaryrules_crd.yaml
@@ -57,6 +57,12 @@ spec:
                 description: Database is the name of the database in which the function
                   will be created
                 type: string
+              ingestionDelay:
+                description: |-
+                  IngestionDelay is the delay to subtract from the execution window start and end times
+                  to account for data ingestion latency. This ensures the query processes data that has
+                  been fully ingested. If not specified, no delay is applied.
+                type: string
               interval:
                 description: Interval is the cadence at which the rule will be executed
                 type: string

--- a/operator/manifests/crds/summaryrules_crd.yaml
+++ b/operator/manifests/crds/summaryrules_crd.yaml
@@ -57,6 +57,12 @@ spec:
                 description: Database is the name of the database in which the function
                   will be created
                 type: string
+              ingestionDelay:
+                description: |-
+                  IngestionDelay is the delay to subtract from the execution window start and end times
+                  to account for data ingestion latency. This ensures the query processes data that has
+                  been fully ingested. If not specified, no delay is applied.
+                type: string
               interval:
                 description: Interval is the cadence at which the rule will be executed
                 type: string


### PR DESCRIPTION
Adds an ingestion delay field to summary rules.

This delay is subtracted from the start/end time window before rounding to the interval. This ensures perfect windows of querying while accounting for ingestion delay.