### PR TITLE
Ensure lifted labels are sorted case insensitive

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -152,7 +153,7 @@ func realMain(ctx *cli.Context) error {
 		logger.Infof("Using storage dir: %s", cfg.StorageDir)
 	}
 	sort.Slice(cfg.LiftLabels, func(i, j int) bool {
-		return cfg.LiftLabels[i].Name < cfg.LiftLabels[j].Name
+		return strings.ToLower(cfg.LiftLabels[i].Name) < strings.ToLower(cfg.LiftLabels[j].Name)
 	})
 
 	defaultMapping := schema.DefaultMetricsMapping


### PR DESCRIPTION
There was a bug where they were not sorted correctly with the data which causes values to be inserted into the wrong columns.