### PR TITLE
fix(summaryrules): remove 1tick from _endTime to allow inclusive between syntax

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -399,9 +399,9 @@ func (t *SummaryRuleTask) handleRuleExecution(ctx context.Context, rule *v1.Summ
 	if rule.ShouldSubmitRule(nil) {
 		// Subtract 1 tick (100 nanoseconds, the smallest time unit supported by Kusto datetime)
 		// from endTime for the query to avoid boundary issues while keeping the original
-		// windowEndTime for status tracking. This allows users to use `between(_startTime .. _endTIme)`
+		// windowEndTime for status tracking. This allows users to use `between(_startTime .. _endTime)`
 		// in their query without worrying about the boundary issue.
-		queryEndTime := windowEndTime.Add(-100 * time.Nanosecond)
+		queryEndTime := windowEndTime.Add(-kustoutil.OneTick)
 
 		// Prepare a new async operation with calculated time range
 		asyncOp := v1.AsyncOperation{

--- a/ingestor/adx/time_window_test.go
+++ b/ingestor/adx/time_window_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/Azure/adx-mon/api/v1"
+	"github.com/Azure/adx-mon/pkg/kustoutil"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,7 +76,7 @@ func TestTimeWindowCalculation(t *testing.T) {
 
 		// Verify the window duration is exactly the interval minus 1 tick (100 nanoseconds)
 		windowDuration := endTime.Sub(startTime)
-		expectedDuration := rule.Spec.Interval.Duration - 100*time.Nanosecond
+		expectedDuration := rule.Spec.Interval.Duration - kustoutil.OneTick
 		require.Equal(t, expectedDuration, windowDuration,
 			"Window duration should match the configured interval minus 1 tick")
 
@@ -163,7 +164,7 @@ func TestTimeWindowCalculation(t *testing.T) {
 
 		// Verify the window duration is exactly the interval minus 1 tick (100 nanoseconds)
 		windowDuration := endTime.Sub(startTime)
-		expectedDuration := rule.Spec.Interval.Duration - 100*time.Nanosecond
+		expectedDuration := rule.Spec.Interval.Duration - kustoutil.OneTick
 		require.Equal(t, expectedDuration, windowDuration,
 			"Window duration should match the configured interval minus 1 tick")
 	})
@@ -241,7 +242,7 @@ func TestTimeWindowCalculation(t *testing.T) {
 		submittedEndTime, err := time.Parse(time.RFC3339Nano, submittedWindowEndTime)
 		require.NoError(t, err)
 		// The last execution time should be 1 tick (100 nanoseconds) more than the submitted end time
-		expectedLastExecution := submittedEndTime.Add(100 * time.Nanosecond)
+		expectedLastExecution := submittedEndTime.Add(kustoutil.OneTick)
 		require.True(t, lastExecution.Equal(expectedLastExecution),
 			"Last execution time should be 1 tick more than the submitted window end time")
 
@@ -331,7 +332,7 @@ func TestTimeWindowCalculation(t *testing.T) {
 
 		// Verify correct duration (minus 1 tick)
 		duration := end.Sub(start)
-		expectedDuration := 30*time.Minute - 100*time.Nanosecond
+		expectedDuration := 30*time.Minute - kustoutil.OneTick
 		require.Equal(t, expectedDuration, duration,
 			"Window duration should match the configured interval minus 1 tick")
 

--- a/pkg/kustoutil/kql.go
+++ b/pkg/kustoutil/kql.go
@@ -5,7 +5,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// OneTick represents 1 tick in Kusto datetime, which is 100 nanoseconds.
+// This is the smallest time unit supported by Kusto datetime.
+const OneTick = 100 * time.Nanosecond
 
 // ApplySubstitutions applies time and cluster label substitutions to a KQL query body
 func ApplySubstitutions(body, startTime, endTime string, clusterLabels map[string]string) string {


### PR DESCRIPTION
This PR enables SummaryRules to use the more intuitive `between (_startTime .. _endTime)` syntax instead of requiring the error-prone `>= _startTime and < _endTime` pattern.

## Problem

Previously, users had to write SummaryRules with careful attention to inclusive/exclusive boundaries:

```kql
SomeTable
| where PreciseTimeStamp >= _startTime and PreciseTimeStamp < _endTime
| summarize avg(Value) by bin(PreciseTimeStamp, 1h)
```

The preferred `between` syntax didn't work because it's inclusive on both ends, which would cause overlapping time windows:

```kql
-- This would cause overlaps without this fix
| where PreciseTimeStamp between (_startTime .. _endTime)
```

To allow users to use the more intuitive `between` syntax, we automatically remove the smallest unit of time kusto supports, 1tick or 100 nanoseconds, from the `_endTime`. This ensures no overlapping time boundaries when using `between`, while preserving all other time window execution logic.

Fixes #845