### PR TITLE
fix(alerter): alert scheduling should be smarter on startup

### DIFF
--- a/alerter/rules/store.go
+++ b/alerter/rules/store.go
@@ -86,6 +86,7 @@ func toRule(r alertrulev1.AlertRule, region string) (*Rule, error) {
 		AutoMitigateAfter: r.Spec.AutoMitigateAfter.Duration,
 		Criteria:          r.Spec.Criteria,
 		IsMgmtQuery:       false,
+		LastQueryTime:     r.Status.LastQueryTime.Time,
 	}
 
 	// If a query starts with a dot then it is acting against that Kusto cluster and not looking through
@@ -168,4 +169,7 @@ type Rule struct {
 
 	// Stmt specifies the underlayEtcdPeersQuery to execute.
 	Stmt kusto.Stmt
+
+	// LastQueryTime from the AlertRule status, used for smart scheduling
+	LastQueryTime time.Time
 }


### PR DESCRIPTION
## What was wrong
When the alerter started up, it would immediately run all alert rules regardless of when they were last executed. This meant if you restarted the alerter and a rule had just run 1 minute ago, it would run again immediately instead of waiting for the proper interval.

## What this fixes
Now the alerter looks at the LastQueryTime from the AlertRule status and calculates when the next execution should actually happen. If a rule was executed recently, it waits until the proper time. If it's overdue, it runs immediately.

## How it works
- On startup, calculate nextQueryTime = LastQueryTime + Interval
- If nextQueryTime is in the past → execute immediately
- If nextQueryTime is in the future → wait until that time, then start the regular ticker
- After the initial scheduling, use a simple ticker for ongoing execution