### PR TITLE
Test cursor seeks with journal, seek to head if not found

### DIFF
--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -26,6 +26,7 @@ type journalReader interface {
 	NextSkip(skip uint64) (uint64, error)
 	SeekHead() error
 	SeekCursor(cursor string) error
+	TestCursor(cursor string) error
 	Wait(timeout time.Duration) int
 	Close() error
 }

--- a/collector/logs/sources/journal/journal_linux_test.go
+++ b/collector/logs/sources/journal/journal_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/Azure/adx-mon/collector/logs"
@@ -191,4 +192,71 @@ func TestJournalMulipleSources(t *testing.T) {
 	<-sink.DoneChan()
 	service.Close()
 	require.Equal(t, fmt.Sprintf("%d", numLogs-1), types.StringOrEmpty(sink.Latest().GetBodyValue(types.BodyKeyMessage)))
+}
+
+func TestJournalInvalidCursor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	if !journal.Enabled() {
+		t.Skip("journal is not available - skipping")
+	}
+
+	logger.SetLevel(slog.LevelDebug)
+
+	cursorDir := t.TempDir()
+	testtag := "COLLECTORE2E_INVALID_CURSOR"
+	randNum := rand.Int()
+	testValue := fmt.Sprintf("testValue-%d", randNum)
+	journalFields := map[string]string{testtag: testValue}
+	t.Logf("Sending logs - view in journalctl with journalctl %s=%s", testtag, testValue)
+	matchTag := fmt.Sprintf("%s=%s", testtag, testValue)
+
+	numLogs := 500
+	// Send logs first
+	for i := 0; i < numLogs; i++ {
+		err := journal.Send(fmt.Sprintf("%d", i), journal.PriInfo, journalFields)
+		require.NoError(t, err)
+	}
+	// Create an invalid cursor file manually
+	// This simulates having a cursor from a previous run that is no longer valid
+	targetConfig := JournalTargetConfig{
+		Matches:  []string{matchTag},
+		Database: "testdb",
+		Table:    "testtable",
+	}
+	cursorFilePath := cursorPath(cursorDir, targetConfig.Matches, targetConfig.Database, targetConfig.Table)
+
+	// Write an invalid cursor with the correct format, but not from this system
+	invalidCursor := "s=65a1fbde9961443ab61e48f57b1e1cfb;i=32904c2;b=93046e4a5c424d96ad6e02659ce7dde9;m=7b29e77112;t=639d5fa6bb246;x=1cacd317ebe1eb33"
+	err := os.WriteFile(cursorFilePath, []byte(fmt.Sprintf(`{"cursor":"%s"}`, invalidCursor)), 0644)
+	require.NoError(t, err)
+
+	// Create the journal source with the invalid cursor
+	sink := sinks.NewCountingSink(int64(numLogs))
+	allSinks := []types.Sink{sink}
+	source := New(SourceConfig{
+		Targets:         []JournalTargetConfig{targetConfig},
+		CursorDirectory: cursorDir,
+		WorkerCreator:   engine.WorkerCreator(nil, allSinks),
+	})
+
+	service := &logs.Service{
+		Source: source,
+		Sinks:  allSinks,
+	}
+	ctx := context.Background()
+	err = service.Open(ctx)
+	require.NoError(t, err)
+	defer service.Close()
+
+	// Wait for all logs to be processed
+	count := <-sink.DoneChan()
+
+	// Since we had an invalid cursor, the journal should have fallen back to reading from head
+	// and should have read all logs we sent
+	require.Equal(t, fmt.Sprintf("%d", numLogs-1), types.StringOrEmpty(sink.Latest().GetBodyValue(types.BodyKeyMessage)))
+
+	// Verify we got all the logs we expected
+	require.Equal(t, int64(numLogs), count)
 }


### PR DESCRIPTION
Journald can provide us with cursors that will be invalid after different system boots. This can manifest not as an error, but instead by silently never providing us new journal entries after the seek.

We now use sd_journal_test_cursor to tell us if the seek went to the expected place. If not, the cursor isn't valid and we'll seek to head instead.