### PR TITLE
fix(summaryrule): advance LastSuccessfulExecution timestamp for backlog operations

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -505,14 +505,19 @@ func (t *SummaryRuleTask) processBacklogOperation(ctx context.Context, rule *v1.
 
 			// Only advance timestamp if this window represents forward progress
 			currentTimestamp := rule.GetLastExecutionTime()
-			if currentTimestamp == nil || originalWindowEndTime.After(*currentTimestamp) {
+			if currentTimestamp == nil {
+				currentTimestamp = &time.Time{}
+			}
+			if originalWindowEndTime.After(*currentTimestamp) {
 				rule.SetLastExecutionTime(originalWindowEndTime)
 			}
 		} else {
 			logger.Warnf("Failed to parse operation EndTime '%s' for backlog recovery: %v", operation.EndTime, parseErr)
 		}
 
-		// Track the operation after timestamp advancement to maintain consistency
+		// Track the operation after timestamp advancement to maintain consistency.
+		// This order ensures that if timestamp advancement succeeds, the operation is tracked;
+		// if timestamp parsing fails, we still track the operation but without advancing the timestamp.
 		rule.SetAsyncOperation(operation)
 	}
 }

--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -495,20 +495,25 @@ func (t *SummaryRuleTask) processBacklogOperation(ctx context.Context, rule *v1.
 	if operationId, err := t.SubmitRule(ctx, *rule, operation.StartTime, operation.EndTime); err == nil {
 		// Great, we were able to recover the failed submission window.
 		operation.OperationId = operationId
-		rule.SetAsyncOperation(operation)
 
-		// Update timestamp to reflect successful backlog recovery
-		// Parse the operation EndTime and add OneTick back since it was subtracted for Kusto boundary
+		// Parse the operation EndTime and calculate the original window end time.
+		// The operation.EndTime has kustoutil.OneTick (100ns) subtracted in handleRuleExecution
+		// to avoid Kusto boundary issues, so we need to add it back for timestamp tracking.
 		if operationEndTime, parseErr := time.Parse(time.RFC3339Nano, operation.EndTime); parseErr == nil {
-			// Add OneTick back to get the original window end time
-			windowEndTime := operationEndTime.Add(kustoutil.OneTick)
-			
-			// Only advance timestamp if this window is newer than current timestamp (forward progress)
+			// Restore the original window end time by adding back the subtracted OneTick
+			originalWindowEndTime := operationEndTime.Add(kustoutil.OneTick)
+
+			// Only advance timestamp if this window represents forward progress
 			currentTimestamp := rule.GetLastExecutionTime()
-			if windowEndTime.After(*currentTimestamp) {
-				rule.SetLastExecutionTime(windowEndTime)
+			if currentTimestamp == nil || originalWindowEndTime.After(*currentTimestamp) {
+				rule.SetLastExecutionTime(originalWindowEndTime)
 			}
+		} else {
+			logger.Warnf("Failed to parse operation EndTime '%s' for backlog recovery: %v", operation.EndTime, parseErr)
 		}
+
+		// Track the operation after timestamp advancement to maintain consistency
+		rule.SetAsyncOperation(operation)
 	}
 }
 

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -2175,8 +2175,6 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 	require.Len(t, ops, 1, "Should have one operation after backlog recovery")
 	require.Equal(t, operationID, ops[0].OperationId, "Backlog operation should have received operation ID")
 
-	// THE BUG: processBacklogOperation does not update LastSuccessfulExecution timestamp
-	// This assertion will FAIL with the current implementation, demonstrating the bug
 	currentTimestamp := rule.GetLastExecutionTime()
 
 	require.True(t, currentTimestamp.After(oldTimestamp),

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -2185,11 +2185,8 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 		oldTimestamp.Format(time.RFC3339),
 		currentTimestamp.Format(time.RFC3339))
 
-	require.True(t, currentTimestamp.Equal(backlogWindowEndTime) || currentTimestamp.After(backlogWindowEndTime.Add(-time.Second)),
-		"processBacklogOperation should set LastSuccessfulExecution to the recovered window EndTime. "+
-			"Expected: %s, Got: %s",
-		backlogWindowEndTime.Format(time.RFC3339),
-		currentTimestamp.Format(time.RFC3339))
+	require.WithinDuration(t, backlogWindowEndTime, *currentTimestamp, time.Millisecond,
+		"processBacklogOperation should set LastSuccessfulExecution to the recovered window EndTime")
 }
 
 // TestSummaryRuleBacklogTimestampForwardProgressOnly tests that backlog operations

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -2122,13 +2122,13 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 	}
 	operationIDRows, err := kusto.NewMockRows(operationIDColumns)
 	require.NoError(t, err)
-	
+
 	operationID := "backlog-op-success-12345"
 	err = operationIDRows.Row(value.Values{
 		value.String{Value: operationID, Valid: true},
 	})
 	require.NoError(t, err)
-	
+
 	mockExecutor.mockRows = operationIDRows
 
 	// Create storage interface
@@ -2161,7 +2161,7 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 	failedOperation := adxmonv1.AsyncOperation{
 		StartTime:   time.Date(2024, 8, 6, 13, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
 		EndTime:     backlogWindowEndTime.Add(-kustoutil.OneTick).Format(time.RFC3339Nano), // Adjusted for Kusto boundary
-		OperationId: "", // Empty indicates it needs backlog recovery
+		OperationId: "",                                                                    // Empty indicates it needs backlog recovery
 	}
 	rule.SetAsyncOperation(failedOperation)
 
@@ -2178,17 +2178,17 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 	// THE BUG: processBacklogOperation does not update LastSuccessfulExecution timestamp
 	// This assertion will FAIL with the current implementation, demonstrating the bug
 	currentTimestamp := rule.GetLastExecutionTime()
-	
-	require.True(t, currentTimestamp.After(oldTimestamp), 
+
+	require.True(t, currentTimestamp.After(oldTimestamp),
 		"processBacklogOperation should advance LastSuccessfulExecution when recovering newer windows. "+
-		"Expected timestamp > %s, Got: %s", 
-		oldTimestamp.Format(time.RFC3339), 
+			"Expected timestamp > %s, Got: %s",
+		oldTimestamp.Format(time.RFC3339),
 		currentTimestamp.Format(time.RFC3339))
 
 	require.True(t, currentTimestamp.Equal(backlogWindowEndTime) || currentTimestamp.After(backlogWindowEndTime.Add(-time.Second)),
 		"processBacklogOperation should set LastSuccessfulExecution to the recovered window EndTime. "+
-		"Expected: %s, Got: %s", 
-		backlogWindowEndTime.Format(time.RFC3339), 
+			"Expected: %s, Got: %s",
+		backlogWindowEndTime.Format(time.RFC3339),
 		currentTimestamp.Format(time.RFC3339))
 }
 
@@ -2197,24 +2197,24 @@ func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
 func TestSummaryRuleBacklogTimestampForwardProgressOnly(t *testing.T) {
 	// Create mock executor
 	mockExecutor := &TestStatementExecutor{
-		database: "testdb", 
+		database: "testdb",
 		endpoint: "http://test-endpoint",
 	}
 	mockExecutor.Reset()
 
-	// Create mock rows for operation ID response  
+	// Create mock rows for operation ID response
 	operationIDColumns := table.Columns{
 		{Name: "OperationId", Type: kustotypes.String},
 	}
 	operationIDRows, err := kusto.NewMockRows(operationIDColumns)
 	require.NoError(t, err)
-	
+
 	operationID := "old-backlog-op-67890"
 	err = operationIDRows.Row(value.Values{
 		value.String{Value: operationID, Valid: true},
 	})
 	require.NoError(t, err)
-	
+
 	mockExecutor.mockRows = operationIDRows
 
 	store := &mockCRDHandler{}
@@ -2229,7 +2229,7 @@ func TestSummaryRuleBacklogTimestampForwardProgressOnly(t *testing.T) {
 		},
 		Spec: adxmonv1.SummaryRuleSpec{
 			Database: "testdb",
-			Table:    "TestDestination", 
+			Table:    "TestDestination",
 			Interval: metav1.Duration{Duration: time.Hour},
 			Body:     "TestSource | summarize count() by bin(Timestamp, 1h)",
 		},
@@ -2259,7 +2259,7 @@ func TestSummaryRuleBacklogTimestampForwardProgressOnly(t *testing.T) {
 	finalTimestamp := rule.GetLastExecutionTime()
 	require.True(t, finalTimestamp.Equal(currentTimestamp),
 		"processBacklogOperation should NOT advance LastSuccessfulExecution for older windows. "+
-		"Expected: %s, Got: %s", 
+			"Expected: %s, Got: %s",
 		currentTimestamp.Format(time.RFC3339),
 		finalTimestamp.Format(time.RFC3339))
 }

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -2104,3 +2104,162 @@ func TestSummaryRuleTaskGetOperation(t *testing.T) {
 		require.Nil(t, result)
 	})
 }
+
+// TestSummaryRuleBacklogTimestampUpdate tests that processBacklogOperation
+// updates LastSuccessfulExecution timestamp when backlog operations succeed.
+// This test should initially FAIL, demonstrating the bug in production.
+func TestSummaryRuleBacklogTimestampUpdate(t *testing.T) {
+	// Create a mock statement executor
+	mockExecutor := &TestStatementExecutor{
+		database: "testdb",
+		endpoint: "http://test-endpoint",
+	}
+	mockExecutor.Reset()
+
+	// Create a mock response for the submission operation ID
+	operationIDColumns := table.Columns{
+		{Name: "OperationId", Type: kustotypes.String},
+	}
+	operationIDRows, err := kusto.NewMockRows(operationIDColumns)
+	require.NoError(t, err)
+	
+	operationID := "backlog-op-success-12345"
+	err = operationIDRows.Row(value.Values{
+		value.String{Value: operationID, Valid: true},
+	})
+	require.NoError(t, err)
+	
+	mockExecutor.mockRows = operationIDRows
+
+	// Create storage interface
+	store := &mockCRDHandler{}
+
+	// Create the SummaryRuleTask
+	task := NewSummaryRuleTask(store, mockExecutor, nil)
+
+	// Create a test SummaryRule with an old timestamp (simulating production case)
+	oldTimestamp := time.Date(2024, 8, 1, 18, 0, 0, 0, time.UTC) // Stuck timestamp
+	rule := &adxmonv1.SummaryRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-stuck-rule",
+			Namespace: "default",
+		},
+		Spec: adxmonv1.SummaryRuleSpec{
+			Database: "testdb",
+			Table:    "TestDestination",
+			Interval: metav1.Duration{Duration: time.Hour},
+			Body:     "TestSource | summarize count() by bin(Timestamp, 1h)",
+		},
+	}
+
+	// Set the old timestamp to simulate the stuck state
+	rule.SetLastExecutionTime(oldTimestamp)
+
+	// Simulate a failed operation that needs backlog recovery
+	// This represents a window that failed initial submission but should have succeeded
+	backlogWindowEndTime := time.Date(2024, 8, 6, 14, 0, 0, 0, time.UTC)
+	failedOperation := adxmonv1.AsyncOperation{
+		StartTime:   time.Date(2024, 8, 6, 13, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		EndTime:     backlogWindowEndTime.Add(-kustoutil.OneTick).Format(time.RFC3339Nano), // Adjusted for Kusto boundary
+		OperationId: "", // Empty indicates it needs backlog recovery
+	}
+	rule.SetAsyncOperation(failedOperation)
+
+	ctx := context.Background()
+
+	// Execute processBacklogOperation - this should recover the operation AND update timestamp
+	task.processBacklogOperation(ctx, rule, failedOperation)
+
+	// Verify the operation got an ID (backlog recovery succeeded)
+	ops := rule.GetAsyncOperations()
+	require.Len(t, ops, 1, "Should have one operation after backlog recovery")
+	require.Equal(t, operationID, ops[0].OperationId, "Backlog operation should have received operation ID")
+
+	// THE BUG: processBacklogOperation does not update LastSuccessfulExecution timestamp
+	// This assertion will FAIL with the current implementation, demonstrating the bug
+	currentTimestamp := rule.GetLastExecutionTime()
+	
+	require.True(t, currentTimestamp.After(oldTimestamp), 
+		"processBacklogOperation should advance LastSuccessfulExecution when recovering newer windows. "+
+		"Expected timestamp > %s, Got: %s", 
+		oldTimestamp.Format(time.RFC3339), 
+		currentTimestamp.Format(time.RFC3339))
+
+	require.True(t, currentTimestamp.Equal(backlogWindowEndTime) || currentTimestamp.After(backlogWindowEndTime.Add(-time.Second)),
+		"processBacklogOperation should set LastSuccessfulExecution to the recovered window EndTime. "+
+		"Expected: %s, Got: %s", 
+		backlogWindowEndTime.Format(time.RFC3339), 
+		currentTimestamp.Format(time.RFC3339))
+}
+
+// TestSummaryRuleBacklogTimestampForwardProgressOnly tests that backlog operations
+// only advance the timestamp when the recovered window is newer than current timestamp.
+func TestSummaryRuleBacklogTimestampForwardProgressOnly(t *testing.T) {
+	// Create mock executor
+	mockExecutor := &TestStatementExecutor{
+		database: "testdb", 
+		endpoint: "http://test-endpoint",
+	}
+	mockExecutor.Reset()
+
+	// Create mock rows for operation ID response  
+	operationIDColumns := table.Columns{
+		{Name: "OperationId", Type: kustotypes.String},
+	}
+	operationIDRows, err := kusto.NewMockRows(operationIDColumns)
+	require.NoError(t, err)
+	
+	operationID := "old-backlog-op-67890"
+	err = operationIDRows.Row(value.Values{
+		value.String{Value: operationID, Valid: true},
+	})
+	require.NoError(t, err)
+	
+	mockExecutor.mockRows = operationIDRows
+
+	store := &mockCRDHandler{}
+	task := NewSummaryRuleTask(store, mockExecutor, nil)
+
+	// Create rule with current timestamp NEWER than the backlog operation
+	currentTimestamp := time.Date(2024, 8, 1, 18, 0, 0, 0, time.UTC)
+	rule := &adxmonv1.SummaryRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-forward-progress-rule",
+			Namespace: "default",
+		},
+		Spec: adxmonv1.SummaryRuleSpec{
+			Database: "testdb",
+			Table:    "TestDestination", 
+			Interval: metav1.Duration{Duration: time.Hour},
+			Body:     "TestSource | summarize count() by bin(Timestamp, 1h)",
+		},
+	}
+	rule.SetLastExecutionTime(currentTimestamp)
+
+	// Create a backlog operation for an OLDER window (should NOT advance timestamp)
+	olderWindowEndTime := time.Date(2024, 7, 25, 10, 0, 0, 0, time.UTC)
+	olderOperation := adxmonv1.AsyncOperation{
+		StartTime:   time.Date(2024, 7, 25, 9, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		EndTime:     olderWindowEndTime.Add(-kustoutil.OneTick).Format(time.RFC3339Nano),
+		OperationId: "",
+	}
+	rule.SetAsyncOperation(olderOperation)
+
+	ctx := context.Background()
+
+	// Process the backlog operation
+	task.processBacklogOperation(ctx, rule, olderOperation)
+
+	// Verify the operation got recovered
+	ops := rule.GetAsyncOperations()
+	require.Len(t, ops, 1, "Should have one operation after backlog recovery")
+	require.Equal(t, operationID, ops[0].OperationId)
+
+	// Verify timestamp was NOT advanced (forward progress protection)
+	finalTimestamp := rule.GetLastExecutionTime()
+	require.True(t, finalTimestamp.Equal(currentTimestamp),
+		"processBacklogOperation should NOT advance LastSuccessfulExecution for older windows. "+
+		"Expected: %s, Got: %s", 
+		currentTimestamp.Format(time.RFC3339),
+		finalTimestamp.Format(time.RFC3339))
+}


### PR DESCRIPTION
## Overview

Fixes a critical timing bug where `LastSuccessfulExecution` timestamp becomes stuck and doesn't advance when backlog operations are successfully recovered, preventing forward progress in time window processing.

## Problem

The SummaryRule execution flow has two submission paths:
1. **Normal submission** (`handleRuleExecution`): Calls `SetLastExecutionTime(windowEndTime)` ✅
2. **Backlog recovery** (`processBacklogOperation`): Successfully submits operations but does NOT call `SetLastExecutionTime()` ❌

### Production Impact
Real SummaryRule in production shows:
- **LastSuccessfulExecution message**: `"2025-08-01T18:00:00Z"` (stuck since 2025-08-01T18:35:13Z)
- **Latest successful operation**: `6d035fd6-6459-4fb6-8931-64d63a1f0c8c` with window ending `"2025-08-06T08:00:00Z"`
- **Gap**: 5+ days of successful operations not reflected in timestamp advancement

## Solution

Enhanced `processBacklogOperation` to:
1. Parse the operation's `EndTime` and restore the original window end time (adding back the subtracted `OneTick`)
2. Only advance timestamp if it represents forward progress (`new_timestamp > current_timestamp`)
3. Handle time parsing errors gracefully with appropriate logging
4. Track operations after timestamp advancement to maintain consistency

## Implementation Details

### Key Changes
- **`ingestor/adx/tasks.go`**: Added timestamp advancement logic to `processBacklogOperation`
- **`ingestor/adx/tasks_test.go`**: Added comprehensive test coverage demonstrating the bug and validating the fix

### Safety Features
- **Forward Progress Guard**: Only advances timestamp when `new_timestamp > current_timestamp`
- **Time Boundary Correction**: Properly handles Kusto boundary adjustments by adding back `OneTick`
- **Error Handling**: Graceful handling of time parsing failures with descriptive logging
- **Consistency**: Updates timestamp before tracking operations to maintain state consistency

### Test Coverage
1. **`TestSummaryRuleBacklogTimestampUpdate`**: Demonstrates that backlog operations advance timestamps when recovering newer windows
2. **`TestSummaryRuleBacklogTimestampForwardProgressOnly`**: Ensures older backlog operations don't regress timestamps

## Validation

- ✅ Backlog operations with newer timestamps advance `LastSuccessfulExecution`
- ✅ Backlog operations with older timestamps do NOT advance `LastSuccessfulExecution` (forward progress protection)
- ✅ Normal submission path continues working unchanged
- ✅ Time parsing errors handled gracefully
- ✅ Production scenario (stuck at 2025-08-01 → 2025-08-06) would be resolved

## Risk Assessment

**Overall Risk: LOW**
- Adding missing timestamp update to existing successful code path
- Forward-progress guard prevents regression
- Comprehensive test coverage validates behavior
- No changes to external interfaces or configuration

## Related Issues

Addresses the SummaryRule timing bug identified in production where successful backlog recovery operations don't advance the `LastSuccessfulExecution` timestamp, causing processing windows to remain stuck.

## Testing

```bash
go test ./ingestor/adx -run TestSummaryRuleBacklog -v
```

The tests demonstrate the bug (would fail without the fix) and validate the solution works correctly.