### PR TITLE
fix: apply OneTick subtraction to BackfillAsyncOperations for boundary consistency

### DIFF
--- a/api/v1/summaryrule_types.go
+++ b/api/v1/summaryrule_types.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/Azure/adx-mon/pkg/kustoutil"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
@@ -376,10 +377,12 @@ func (s *SummaryRule) BackfillAsyncOperations(clk clock.Clock) {
 		windowKey := windowStart.Format(time.RFC3339Nano) + ":" + windowEnd.Format(time.RFC3339Nano)
 		if !existingWindows[windowKey] {
 			// Create new async operation (without OperationId - backlog operation)
+			// Subtract OneTick (100 nanoseconds) from windowEnd to match the boundary handling
+			// used in handleRuleExecution, ensuring consistency between regular and backfilled operations
 			newOp := AsyncOperation{
 				OperationId: "", // Empty for backlog operations
 				StartTime:   windowStart.Format(time.RFC3339Nano),
-				EndTime:     windowEnd.Format(time.RFC3339Nano),
+				EndTime:     windowEnd.Add(-kustoutil.OneTick).Format(time.RFC3339Nano),
 			}
 			newOperations = append(newOperations, newOp)
 			existingWindows[windowKey] = true

--- a/api/v1/summaryrule_types_test.go
+++ b/api/v1/summaryrule_types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/adx-mon/pkg/kustoutil"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1447,8 +1448,7 @@ func TestOneTick_Inconsistency_Between_Regular_And_Backfill_Operations(t *testin
 
 		// 1. Simulate what regular operations do (from handleRuleExecution)
 		// They subtract OneTick from windowEnd before formatting
-		const OneTick = 100 * time.Nanosecond // Same as kustoutil.OneTick
-		regularOpEndTime := windowEnd.Add(-OneTick).Format(time.RFC3339Nano)
+		regularOpEndTime := windowEnd.Add(-kustoutil.OneTick).Format(time.RFC3339Nano)
 
 		// 2. Create a backfilled operation using current BackfillAsyncOperations logic
 		rule := &SummaryRule{
@@ -1474,6 +1474,6 @@ func TestOneTick_Inconsistency_Between_Regular_And_Backfill_Operations(t *testin
 		// This will show the actual difference:
 		t.Logf("Regular operation EndTime: %s", regularOpEndTime)
 		t.Logf("Backfill operation EndTime: %s", backfillOpEndTime)
-		t.Logf("Difference: %v", windowEnd.Sub(windowEnd.Add(-OneTick)))
+		t.Logf("Difference: %v", windowEnd.Sub(windowEnd.Add(-kustoutil.OneTick)))
 	})
 }

--- a/api/v1/summaryrule_types_test.go
+++ b/api/v1/summaryrule_types_test.go
@@ -1154,7 +1154,7 @@ func TestBackfillAsyncOperations(t *testing.T) {
 		require.Equal(t, 1, len(ops))
 		require.Equal(t, "", ops[0].OperationId) // Should be backlog operation
 		require.Equal(t, "2025-06-23T10:00:00Z", ops[0].StartTime)
-		require.Equal(t, "2025-06-23T11:00:00Z", ops[0].EndTime)
+		require.Equal(t, "2025-06-23T10:59:59.9999999Z", ops[0].EndTime) // EndTime now has OneTick subtracted
 	})
 
 	t.Run("generates multiple backfill operations", func(t *testing.T) {
@@ -1180,13 +1180,13 @@ func TestBackfillAsyncOperations(t *testing.T) {
 			require.Equal(t, "", op.OperationId)
 		}
 
-		// Check time windows
+		// Check time windows (EndTime now has OneTick subtracted)
 		require.Equal(t, "2025-06-23T08:00:00Z", ops[0].StartTime)
-		require.Equal(t, "2025-06-23T09:00:00Z", ops[0].EndTime)
+		require.Equal(t, "2025-06-23T08:59:59.9999999Z", ops[0].EndTime)
 		require.Equal(t, "2025-06-23T09:00:00Z", ops[1].StartTime)
-		require.Equal(t, "2025-06-23T10:00:00Z", ops[1].EndTime)
+		require.Equal(t, "2025-06-23T09:59:59.9999999Z", ops[1].EndTime)
 		require.Equal(t, "2025-06-23T10:00:00Z", ops[2].StartTime)
-		require.Equal(t, "2025-06-23T11:00:00Z", ops[2].EndTime)
+		require.Equal(t, "2025-06-23T10:59:59.9999999Z", ops[2].EndTime)
 	})
 
 	t.Run("respects ingestion delay", func(t *testing.T) {
@@ -1209,7 +1209,7 @@ func TestBackfillAsyncOperations(t *testing.T) {
 		ops := rule.GetAsyncOperations()
 		require.Equal(t, 1, len(ops))
 		require.Equal(t, "2025-06-23T10:00:00Z", ops[0].StartTime)
-		require.Equal(t, "2025-06-23T11:00:00Z", ops[0].EndTime)
+		require.Equal(t, "2025-06-23T10:59:59.9999999Z", ops[0].EndTime) // EndTime now has OneTick subtracted
 	})
 
 	t.Run("does not create duplicate operations", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes OneTick subtraction inconsistency between regular and backfilled operations in SummaryRule processing.

## Problem

The `BackfillAsyncOperations` method was missing the OneTick (100 nanosecond) subtraction from `windowEnd` that is properly applied in `handleRuleExecution`. This inconsistency could cause overlapping time windows between backfilled operations and regular operations, potentially leading to:

- Data duplication in overlapping windows
- Boundary issues with KQL queries using `between(_startTime .. _endTime)`
- Inconsistent behavior between operation creation paths

## Solution

Applied the same OneTick subtraction pattern used in `handleRuleExecution` to the `BackfillAsyncOperations` method:

```go
// Before:
EndTime: windowEnd.Format(time.RFC3339Nano),

// After:  
EndTime: windowEnd.Add(-kustoutil.OneTick).Format(time.RFC3339Nano),
```

## Changes

### 🔧 **Core Fix**
- **api/v1/summaryrule_types.go**: Applied OneTick subtraction to backfilled operations' EndTime
- **api/v1/summaryrule_types.go**: Added kustoutil import and comprehensive documentation

### 🧪 **Testing**
- **api/v1/summaryrule_types_test.go**: Added test demonstrating the original inconsistency
- **api/v1/summaryrule_types_test.go**: Updated existing tests for OneTick-adjusted expectations

## Verification

- ✅ **Bug Fix Verified**: OneTick consistency test passes - both operation types now use identical EndTime calculations
- ✅ **Regression Testing**: All existing BackfillAsyncOperations tests pass with updated expectations  
- ✅ **Code Quality**: Enhanced documentation explains the rationale for future maintainers
- ✅ **Consistency Achieved**: Both operation creation paths now use identical boundary logic

## Risk Assessment

- **Low Risk**: Brings consistency with existing proven pattern from handleRuleExecution
- **Data Safety**: Prevents potential overlapping windows that could cause data issues
- **Boundary Correctness**: Ensures proper boundary handling in KQL queries
- **Backward Compatibility**: Only affects new backfilled operations; existing operations unchanged

## Testing

```bash
# Verify the fix
go test -v ./api/v1 -run "TestOneTick_Inconsistency"

# All BackfillAsyncOperations tests pass
go test -v ./api/v1 -run "TestBackfillAsyncOperations"
```

Closes: N/A (proactive bug fix)