### PR TITLE
Correctly handle criteria casing

### DIFF
--- a/alerter/rules/store.go
+++ b/alerter/rules/store.go
@@ -214,7 +214,8 @@ func (r *Rule) Matches(tags map[string]string) (bool, error) {
 	if r.CriteriaExpression == "" {
 		expressionMatched = true
 	} else {
-		matched, err := celutil.EvaluateCriteriaExpression(lowered, r.CriteriaExpression)
+		// do not pass lowered - for expressions, match on the actual cases.
+		matched, err := celutil.EvaluateCriteriaExpression(tags, r.CriteriaExpression)
 		if err != nil {
 			return false, fmt.Errorf("failed to evaluate criteriaExpression: %w", err)
 		}

--- a/ingestor/adx/tasks_criteriaexpression_test.go
+++ b/ingestor/adx/tasks_criteriaexpression_test.go
@@ -22,12 +22,12 @@ func (f fakeStatementExecutor) Mgmt(ctx context.Context, stmt kusto.Statement, o
 }
 
 func TestSummaryRuleTask_shouldProcessRule_CriteriaExpression(t *testing.T) {
-	clusterLabels := map[string]string{"region": "eastus", "environment": "prod"}
-	Task := &SummaryRuleTask{ClusterLabels: clusterLabels, kustoCli: fakeStatementExecutor{db: "db"}}
+	defaultLabels := map[string]string{"region": "eastus", "environment": "prod"}
 
 	cases := []struct {
 		name   string
 		rule   v1.SummaryRule
+		labels map[string]string // optional override of cluster labels
 		expect bool
 	}{
 		{
@@ -60,11 +60,76 @@ func TestSummaryRuleTask_shouldProcessRule_CriteriaExpression(t *testing.T) {
 			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Body: "", Interval: metav1.Duration{Duration: time.Minute}, Criteria: map[string][]string{"region": {"westus"}}, CriteriaExpression: "environment == 'prod'"}},
 			expect: false,
 		},
+		// Casing behavior tests
+		{
+			name:   "criteria map insensitive - upper label lower criteria key",
+			labels: map[string]string{"REGION": "EASTUS", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, Criteria: map[string][]string{"region": {"eastus"}}}},
+			expect: true,
+		},
+		{
+			name:   "criteria map insensitive - mixed case label & criteria key",
+			labels: map[string]string{"Region": "EastUS", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, Criteria: map[string][]string{"REGION": {"EASTUS"}}}},
+			expect: true, // map matching ignores case for both key & value
+		},
+		{
+			name:   "criteriaExpression sensitive - mismatched case identifiers",
+			labels: map[string]string{"region": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "REGION == 'eastus'"}},
+			expect: false, // REGION undefined
+		},
+		{
+			name:   "criteriaExpression sensitive - matching TitleCase identifier",
+			labels: map[string]string{"Region": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "Region == 'eastus'"}},
+			expect: true,
+		},
+		{
+			name:   "criteriaExpression value mismatch case",
+			labels: map[string]string{"region": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "region == 'EASTUS'"}},
+			expect: false,
+		},
+		{
+			name:   "criteriaExpression uppercase identifier matches",
+			labels: map[string]string{"REGION": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "REGION == 'eastus'"}},
+			expect: true,
+		},
+		{
+			name:   "criteriaExpression uppercase value matches",
+			labels: map[string]string{"region": "EASTUS", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "region == 'EASTUS'"}},
+			expect: true,
+		},
+		{
+			name:   "combined - criteria insensitive expression identifier mismatch",
+			labels: map[string]string{"region": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, Criteria: map[string][]string{"region": {"eastus"}}, CriteriaExpression: "REGION == 'eastus'"}},
+			expect: false,
+		},
+		{
+			name:   "combined - criteria insensitive mixed key cases expression true",
+			labels: map[string]string{"region": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, Criteria: map[string][]string{"Region": {"EASTUS"}}, CriteriaExpression: "environment == 'prod' && region == 'eastus'"}},
+			expect: true,
+		},
+		{
+			name:   "expression unknown variable due to different label key case",
+			labels: map[string]string{"REGION": "eastus", "environment": "prod"},
+			rule:   v1.SummaryRule{Spec: v1.SummaryRuleSpec{Database: "db", Table: "t", Interval: metav1.Duration{Duration: time.Minute}, CriteriaExpression: "region == 'eastus'"}},
+			expect: false,
+		},
 	}
 
 	for _, c := range cases {
 		c := c
-		// ensure required fields non-empty; already set above
+		labels := defaultLabels
+		if c.labels != nil {
+			labels = c.labels
+		}
+		Task := &SummaryRuleTask{ClusterLabels: labels, kustoCli: fakeStatementExecutor{db: "db"}}
 		ok := Task.shouldProcessRule(c.rule)
 		require.Equal(t, c.expect, ok, c.name)
 	}

--- a/pkg/celutil/criteria.go
+++ b/pkg/celutil/criteria.go
@@ -2,7 +2,6 @@ package celutil
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/google/cel-go/cel"
 )
@@ -20,9 +19,8 @@ func EvaluateCriteriaExpression(clusterLabels map[string]string, expression stri
 	decls := make([]cel.EnvOption, 0, len(clusterLabels))
 	activation := make(map[string]interface{}, len(clusterLabels))
 	for k, v := range clusterLabels {
-		lk := strings.ToLower(k)
-		decls = append(decls, cel.Variable(lk, cel.StringType))
-		activation[lk] = strings.ToLower(v)
+		decls = append(decls, cel.Variable(k, cel.StringType))
+		activation[k] = v
 	}
 	env, err := cel.NewEnv(decls...)
 	if err != nil {


### PR DESCRIPTION
`criteriaExpression` expressions are intended to be evaluated as-is, including casing unlike `criteria` maps. As a result, we should not normalize the names of the tags, or the tag values themselves to lowercase prior to evaluation. Instead, evaluate them directly.

An example that did not work previously that now does is `region == 'AzureCloud'`.