### PR TITLE
Enable building images on non-AMD64 platforms

### DIFF
--- a/build/images/Dockerfile.alerter
+++ b/build/images/Dockerfile.alerter
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.collector
+++ b/build/images/Dockerfile.collector
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang systemd-devel gcc glibc-devel binutils kernel-headers ca-certificates
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.ingestor
+++ b/build/images/Dockerfile.ingestor
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.operator
+++ b/build/images/Dockerfile.operator
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \


### PR DESCRIPTION
Use the standard args for building Go programs on target architectures and OSes:

https://docs.docker.com/build/building/multi-platform/