### PR TITLE
Publish images on multiple architectures

### DIFF
--- a/.github/workflows/publish-container-images.yaml
+++ b/.github/workflows/publish-container-images.yaml
@@ -33,6 +33,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Enable multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/aarch64
+
       # Set up BuildKit Docker container builder to be able to build images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/build/images/Dockerfile.alerter
+++ b/build/images/Dockerfile.alerter
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.collector
+++ b/build/images/Dockerfile.collector
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang systemd-devel gcc glibc-devel binutils kernel-headers ca-certificates
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.ingestor
+++ b/build/images/Dockerfile.ingestor
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \

--- a/build/images/Dockerfile.operator
+++ b/build/images/Dockerfile.operator
@@ -1,13 +1,12 @@
 FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
 
 RUN tdnf install -y golang ca-certificates gcc make glibc-devel binutils kernel-headers
 
 ADD . /code
 WORKDIR /code
 
-ARG VERSION GIT_COMMIT BUILD_TIME
-
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 -ldflags=" \
 -X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
 -X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \


### PR DESCRIPTION
This PR is blocked by #942. Although they are related, I believe it's better to stage the CI/CD changes separately.

Use QEMU to build image manifests that include ARM64 and AMD64 compatible images. On a modern MacOS machine (ARM64), the AMD64 build completes in ~4x the time:

```
=> [linux/arm64 builder 5/5] RUN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -ldflags=" -X 'github.com/Azure/adx-mon/pkg/versi  15.8s
=> [linux/amd64 builder 5/5] RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags=" -X 'github.com/Azure/adx-mon/pkg/versi  55.3s
```
