### PR TITLE
Refresh the service token every 1m instead of 30m

### DIFF
--- a/collector/client.go
+++ b/collector/client.go
@@ -274,7 +274,7 @@ func (c *MetricsClient) readToken() (string, error) {
 }
 
 func (c *MetricsClient) refreshToken() {
-	t := time.NewTicker(30 * time.Minute)
+	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
 
 	for {


### PR DESCRIPTION
Service tokens default expire every 1h. However, they refresh relatively close to the time they expire. These tokens are projected into pods, at least on Linux. With testing, there does not appear to be a good way to detect changes to this token file with mechanisms like stat - the mtimes and inodes appear to not change even after being refreshed.

client-go and other standardized Kubernetes libraries appear to either refresh every 1s or essentially every minute (see
client-go/transport/token-source.go). This is the strategy we are also adopting. This should not really add that much i/o impact to this process because it is such a small file.

Kubernetes does not appear to document a canonical way to observe rotations.