### PR TITLE
Return the interface types instead of the concrete type

### DIFF
--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -1,10 +1,11 @@
-package main_test
+package main
 
 import (
 	"os/exec"
 	"testing"
 
 	"github.com/Azure/adx-mon/cmd/collector/config"
+	"github.com/Azure/adx-mon/collector/metadata"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -18,4 +19,18 @@ func TestMainFunction_Config(t *testing.T) {
 
 	var fileConfig config.Config
 	require.NoError(t, toml.Unmarshal(output, &fileConfig))
+}
+
+// Ensure that the value returned from newLogLabeler is nil when assigned to the interface type metadata.LogLabeler.
+// Needed to avoid segfaults.
+func TestNewLogLabelerNilKubeNode(t *testing.T) {
+	var labeler metadata.LogLabeler = newLogLabeler(nil)
+	require.Nil(t, labeler)
+}
+
+// Ensure that the value returned from newLogLabeler is nil when assigned to the interface type metadata.LogLabeler.
+// Needed to avoid segfaults.
+func TestNewMetricLabelerNilKubeNode(t *testing.T) {
+	var labeler metadata.MetricLabeler = newMetricLabeler(nil)
+	require.Nil(t, labeler)
 }


### PR DESCRIPTION
We always assign these values to the interface values. This is problemtic because the interface will not be nil, even if the contained value is nil. This prevents the nil checks within transformer and add_attributes from working correctly. We now create from the interface types directly now which avoids the problem.