### PR TITLE
Detect stalled collector informers

### DIFF
--- a/pkg/k8s/informer.go
+++ b/pkg/k8s/informer.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +13,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// PodInformer wraps a shared pod informer for a single node and adds self-monitoring
+// so the collector can detect when cache updates stop flowing. Once the watchdog
+// declares the informer stale the caller will crash (allowing kubelet to restart
+// the pod) rather than continuing to run in a silently unhealthy state.
 type PodInformer struct {
 	K8sClient kubernetes.Interface
 	NodeName  string
@@ -19,7 +25,23 @@ type PodInformer struct {
 	informerFactory   informers.SharedInformerFactory
 	informer          cache.SharedIndexInformer
 	eventHandlerCount int
+	lastActivity      atomic.Int64
+	watchdogCancel    context.CancelFunc
 }
+
+var (
+	// PodInformerStaleThreshold controls how long we allow the informer to sit idle
+	// after the most recent pod Add/Update/Delete callback before we assume it is
+	// wedged and crash. Exported so tests (or future config) can tune the value.
+	PodInformerStaleThreshold = 5 * time.Minute
+	// podInformerWatchdogInterval is intentionally shorter than the stale threshold
+	// so we check multiple times before crossing the threshold. Tests override this
+	// to speed up execution.
+	podInformerWatchdogInterval = time.Minute
+	// podInformerPanic allows tests to intercept the watchdog panic path without
+	// bringing down the entire test process. Production code leaves this as panic.
+	podInformerPanic = func(msg string) { panic(msg) }
+)
 
 func NewPodInformer(k8sClient kubernetes.Interface, nodeName string) *PodInformer {
 	return &PodInformer{
@@ -40,12 +62,34 @@ func (p *PodInformer) Add(ctx context.Context, handler cache.ResourceEventHandle
 		tweakOptions := informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
 			lo.FieldSelector = "spec.nodeName=" + p.NodeName
 		})
-
 		p.informerFactory = informers.NewSharedInformerFactoryWithOptions(p.K8sClient, time.Minute, tweakOptions)
 		p.informer = p.informerFactory.Core().V1().Pods().Informer()
 
-		p.informerFactory.Start(ctx.Done())
+		p.markActivity()
+
+		activityHandler := cache.ResourceEventHandlerFuncs{
+			AddFunc: func(object any) {
+				p.markActivity()
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				p.markActivity()
+			},
+			DeleteFunc: func(object any) {
+				p.markActivity()
+			},
+		}
+
+		if _, err := p.informer.AddEventHandler(activityHandler); err != nil {
+			p.informerFactory = nil
+			p.informer = nil
+			return nil, fmt.Errorf("k8s: failed to add activity handler: %w", err)
+		}
+
+		p.startWatchdogLocked(ctx)
+
+		p.informerFactory.Start(ctx.Done()) // start informer goroutines
 		p.informerFactory.WaitForCacheSync(ctx.Done())
+		p.markActivity()
 	}
 
 	ret, err := p.informer.AddEventHandler(handler)
@@ -69,8 +113,89 @@ func (p *PodInformer) Remove(reg cache.ResourceEventHandlerRegistration) error {
 			p.informerFactory.Shutdown()
 			p.informerFactory = nil
 			p.informer = nil
+			p.stopWatchdogLocked()
 		}
 	}
 
 	return err
+}
+
+func (p *PodInformer) markActivity() {
+	// Called from informer's event handlers and when the informer is first
+	// constructed. Writing the timestamp here lets the watchdog measure how
+	// long it has been since the informer observed any pod events.
+	p.lastActivity.Store(time.Now().UnixNano())
+}
+
+func (p *PodInformer) startWatchdogLocked(ctx context.Context) {
+	// Avoid spawning duplicate watchdogs if multiple handlers race to create the informer.
+	if p.watchdogCancel != nil {
+		return
+	}
+
+	if PodInformerStaleThreshold <= 0 {
+		// Disabled via tuning: never panic in this mode.
+		return
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	p.watchdogCancel = cancel
+
+	go func() {
+		// Ticker that periodically evaluates the informer activity time. We defer
+		// cleanup so a stopped informer does not leak goroutines.
+		ticker := time.NewTicker(podInformerWatchdogInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case <-ticker.C:
+				last := p.lastActivity.Load()
+				if last == 0 {
+					continue
+				}
+
+				lastEvent := time.Unix(0, last)
+				idle := time.Since(lastEvent)
+				if idle > PodInformerStaleThreshold {
+					if p.storeEmpty() {
+						continue
+					}
+					podInformerPanic(fmt.Sprintf("k8s.PodInformer for node %s stale for %s (threshold %s)", p.NodeName, idle, PodInformerStaleThreshold))
+				}
+			}
+		}
+	}()
+}
+
+func (p *PodInformer) stopWatchdogLocked() {
+	if p.watchdogCancel == nil {
+		return
+	}
+
+	p.watchdogCancel()
+	p.watchdogCancel = nil
+}
+
+func (p *PodInformer) storeEmpty() bool {
+	p.mu.Lock()
+	informer := p.informer
+	p.mu.Unlock()
+
+	if informer == nil {
+		return true
+	}
+
+	store := informer.GetStore()
+	if store == nil {
+		return true
+	}
+
+	if len(store.ListKeys()) == 0 {
+		return true
+	}
+
+	return false
 }

--- a/pkg/k8s/informer_test.go
+++ b/pkg/k8s/informer_test.go
@@ -1,0 +1,94 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodInformerWatchdog(t *testing.T) {
+	originalThreshold := PodInformerStaleThreshold
+	originalInterval := podInformerWatchdogInterval
+	originalPanic := podInformerPanic
+	defer func() {
+		PodInformerStaleThreshold = originalThreshold
+		podInformerWatchdogInterval = originalInterval
+		podInformerPanic = originalPanic
+	}()
+
+	PodInformerStaleThreshold = 30 * time.Millisecond
+	podInformerWatchdogInterval = 10 * time.Millisecond
+
+	t.Run("emptyStoreDoesNotPanic", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		panicCh := make(chan string, 1)
+		podInformerPanic = func(msg string) { panicCh <- msg }
+		defer func() { podInformerPanic = originalPanic }()
+
+		informer := NewPodInformer(client, "node1")
+		reg, err := informer.Add(ctx, cache.ResourceEventHandlerFuncs{})
+		require.NoError(t, err)
+		defer func() {
+			cancel()
+			informer.Remove(reg)
+		}()
+
+		informer.lastActivity.Store(time.Now().Add(-2 * PodInformerStaleThreshold).UnixNano())
+
+		select {
+		case msg := <-panicCh:
+			t.Fatalf("unexpected watchdog panic: %s", msg)
+		case <-time.After(3 * PodInformerStaleThreshold):
+			// Expected: watchdog should see empty store and skip panic.
+		}
+	})
+
+	t.Run("nonEmptyStorePanics", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		panicCh := make(chan string, 1)
+		podInformerPanic = func(msg string) { panicCh <- msg }
+		defer func() { podInformerPanic = originalPanic }()
+
+		informer := NewPodInformer(client, "node1")
+		reg, err := informer.Add(ctx, cache.ResourceEventHandlerFuncs{})
+		require.NoError(t, err)
+		defer func() {
+			cancel()
+			informer.Remove(reg)
+		}()
+
+		store := informer.informer.GetStore()
+		require.NotNil(t, store)
+		err = store.Add(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				UID:       "uid-1",
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node1",
+			},
+		})
+		require.NoError(t, err)
+
+		informer.lastActivity.Store(time.Now().Add(-2 * PodInformerStaleThreshold).UnixNano())
+
+		select {
+		case msg := <-panicCh:
+			require.Contains(t, msg, "stale")
+		case <-time.After(3 * PodInformerStaleThreshold):
+			t.Fatal("expected watchdog panic when store is non-empty")
+		}
+	})
+}


### PR DESCRIPTION
* Context
  * Rarely the collector pod informer stops receiving events and the async cache hydration loop stalls as well, leaving the process busy but blind.
  * Restarting the pod fixes the condition, so the safest mitigation is to crash when we detect the informer is wedged.

* Summary
  * Wrap the node-scoped pod informer with a watchdog that records the timestamp of the most recent pod event and panics when activity stops for longer than `PodInformerStaleThreshold`.
  * Skip the panic when the informer cache is empty so newly provisioned or drained nodes do not flap.
  * Surface the panic path via an injectable function so tests can assert the watchdog fired without terminating the process.
  * Add unit tests covering both the empty-cache and populated-cache scenarios to prove we only crash when the informer is actually stale.

* Testing
  * go test ./...
