### PR TITLE
fix(function): silently skip database mismatches

### DIFF
--- a/api/v1/function_types_test.go
+++ b/api/v1/function_types_test.go
@@ -78,29 +78,6 @@ func TestFunctionSetReconcileCondition(t *testing.T) {
 	require.True(t, !cond.LastTransitionTime.Time.Before(previousTransition.Time))
 }
 
-func TestFunctionSetDatabaseMatchCondition(t *testing.T) {
-	fn := &Function{}
-	fn.Generation = 9
-
-	fn.SetDatabaseMatchCondition(false, "ProdDB", "prod, staging")
-	cond := meta.FindStatusCondition(fn.Status.Conditions, FunctionDatabaseMatch)
-	require.NotNil(t, cond)
-	require.Equal(t, metav1.ConditionFalse, cond.Status)
-	require.Equal(t, "DatabaseMismatch", cond.Reason)
-	require.Contains(t, cond.Message, "ProdDB")
-
-	fn.SetDatabaseMatchCondition(true, "ProdDB", "prod")
-	cond = meta.FindStatusCondition(fn.Status.Conditions, FunctionDatabaseMatch)
-	require.NotNil(t, cond)
-	require.Equal(t, metav1.ConditionTrue, cond.Status)
-	require.Equal(t, "DatabaseMatched", cond.Reason)
-
-	fn.SetDatabaseMatchCondition(true, AllDatabases, "prod")
-	cond = meta.FindStatusCondition(fn.Status.Conditions, FunctionDatabaseMatch)
-	require.NotNil(t, cond)
-	require.Equal(t, "DatabaseWildcard", cond.Reason)
-}
-
 func TestFunctionSetCriteriaMatchCondition(t *testing.T) {
 	labels := map[string]string{"region": "eastus", "environment": "prod"}
 
@@ -132,18 +109,14 @@ func TestFunctionMultipleConditionsCoexist(t *testing.T) {
 	fn.Generation = 2
 	labels := map[string]string{"region": "westus"}
 
-	fn.SetDatabaseMatchCondition(true, "Prod", "prod")
 	fn.SetCriteriaMatchCondition(true, "region == 'westus'", nil, labels)
 	fn.SetReconcileCondition(metav1.ConditionTrue, "ReconcileSucceeded", "Created")
 
-	dbCond := meta.FindStatusCondition(fn.Status.Conditions, FunctionDatabaseMatch)
 	critCond := meta.FindStatusCondition(fn.Status.Conditions, FunctionCriteriaMatch)
 	recCond := meta.FindStatusCondition(fn.Status.Conditions, FunctionReconciled)
 
-	require.NotNil(t, dbCond)
 	require.NotNil(t, critCond)
 	require.NotNil(t, recCond)
-	require.Equal(t, metav1.ConditionTrue, dbCond.Status)
 	require.Equal(t, metav1.ConditionTrue, critCond.Status)
 	require.Equal(t, metav1.ConditionTrue, recCond.Status)
 }

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -302,31 +302,30 @@ spec:
 
 ### Status Conditions
 
-`Function` resources surface detailed reconciliation state via Kubernetes conditions. These appear in `kubectl describe function <name>` and provide actionable diagnostics without digging into ingestor logs.
+`Function` resources surface detailed reconciliation state via Kubernetes conditions. These appear in `kubectl describe function <name>` and provide actionable diagnostics without digging into ingestor logs. Functions whose `spec.database` does not match the ingestor's configured database are skipped silently; the controller leaves the existing conditions untouched to avoid flapping status between ingestors.
 
 | Condition Type | Meaning | Typical Status / Reasons |
 |----------------|---------|---------------------------|
-| `function.adx-mon.azure.com/DatabaseMatch` | Whether the spec `database` matches an ingestor endpoint (case-insensitive). | `True` with reason `DatabaseMatched` or `DatabaseWildcard`; `False` with reason `DatabaseMismatch` including available databases in the message. |
 | `function.adx-mon.azure.com/CriteriaMatch` | Result of evaluating `spec.criteriaExpression` against cluster labels. | `True` with reason `CriteriaMatched`; `False` with reason `CriteriaNotMatched` (expression evaluated to false) or `CriteriaExpressionError` (parse/evaluation failure). |
-| `function.adx-mon.azure.com/Reconciled` | Outcome of the most recent reconciliation attempt. | `True` with reason `KustoExecutionSucceeded` or `FunctionDeleted`; `False` for intermediate states such as `DatabaseMismatchSkipped`, `CriteriaNotMatched`, `CriteriaEvaluationFailed`, `KustoExecutionRetrying`, or `KustoExecutionFailed`. |
+| `function.adx-mon.azure.com/Reconciled` | Outcome of the most recent reconciliation attempt. | `True` with reason `KustoExecutionSucceeded` or `FunctionDeleted`; `False` for intermediate states such as `CriteriaNotMatched`, `CriteriaEvaluationFailed`, `KustoExecutionRetrying`, or `KustoExecutionFailed`. |
 
-Example describe output when a database mismatch occurs:
+Example describe output when a criteria mismatch occurs:
 
 ```yaml
 Status:
   Conditions:
   - lastTransitionTime: "2025-10-16T20:05:00Z"
-    message: Function database 'ContosoProd' does not match available ingestor databases: contosoprod, contosoinfra
+    message: Function skipped because criteria expression evaluated to false for cluster labels: environment=prod, location=westus2
     observedGeneration: 2
-    reason: DatabaseMismatch
-    status: "False"
-    type: function.adx-mon.azure.com/DatabaseMatch
-  - lastTransitionTime: "2025-10-16T20:05:00Z"
-    message: Function skipped due to database mismatch (configured "ContosoProd", available "contosoinfra")
-    observedGeneration: 2
-    reason: DatabaseMismatchSkipped
+    reason: CriteriaNotMatched
     status: "False"
     type: function.adx-mon.azure.com/Reconciled
+  - lastTransitionTime: "2025-10-16T20:05:00Z"
+    message: Criteria expression evaluated to false for cluster labels: environment=prod, location=westus2
+    observedGeneration: 2
+    reason: CriteriaNotMatched
+    status: "False"
+    type: function.adx-mon.azure.com/CriteriaMatch
 ```
 
 Controllers always set `observedGeneration` to the processed spec generation, making it easy to confirm whether the latest edit has been reconciled. Messages are capped at 256 characters (consistent with other CRDs) to avoid log spam while remaining human-readable.

--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/kql"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 )
@@ -138,22 +137,8 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 		availableDB := t.kustoCli.Database()
 		configuredDB := function.Spec.Database
 		if configuredDB != v1.AllDatabases && !strings.EqualFold(configuredDB, availableDB) {
-			if t.shouldSkipDatabaseMismatchUpdate(function, availableDB) {
-				continue
-			}
-			function.SetDatabaseMatchCondition(false, configuredDB, availableDB)
-			message := fmt.Sprintf("Function skipped due to database mismatch (configured %q, available %q)", configuredDB, availableDB)
-			function.SetReconcileCondition(metav1.ConditionFalse, "DatabaseMismatchSkipped", message)
-			function.Status.Status = v1.Failed
-			function.Status.Error = ""
-			function.Status.Reason = "DatabaseMismatch"
-			function.Status.Message = message
-			if err := t.store.UpdateStatus(ctx, function); err != nil {
-				logger.Errorf("Failed to update function status for %s.%s after database mismatch: %v", configuredDB, function.Name, err)
-			}
 			continue
 		}
-		function.SetDatabaseMatchCondition(true, configuredDB, availableDB)
 
 		expr := strings.TrimSpace(function.Spec.CriteriaExpression)
 		if expr == "" {
@@ -250,43 +235,6 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (t *SyncFunctionsTask) shouldSkipDatabaseMismatchUpdate(fn *v1.Function, availableDB string) bool {
-	if fn == nil {
-		return false
-	}
-	if fn.Status.Status != v1.Failed || fn.Status.Reason != "DatabaseMismatch" || fn.Status.Error != "" {
-		return false
-	}
-	dbCond := meta.FindStatusCondition(fn.Status.Conditions, v1.FunctionDatabaseMatch)
-	if dbCond == nil || dbCond.Status != metav1.ConditionFalse || dbCond.Reason != "DatabaseMismatch" || dbCond.ObservedGeneration != fn.GetGeneration() {
-		return false
-	}
-	configuredDB := fn.Spec.Database
-	expectedDBCondMessage := expectedDatabaseMismatchConditionMessage(configuredDB, availableDB)
-	if dbCond.Message != expectedDBCondMessage {
-		return false
-	}
-	recCond := fn.GetCondition()
-	if recCond == nil || recCond.Status != metav1.ConditionFalse || recCond.Reason != "DatabaseMismatchSkipped" || recCond.ObservedGeneration != fn.GetGeneration() {
-		return false
-	}
-	expectedStatusMessage := fmt.Sprintf("Function skipped due to database mismatch (configured %q, available %q)", configuredDB, availableDB)
-	if recCond.Message != expectedStatusMessage {
-		return false
-	}
-	if fn.Status.Message != expectedStatusMessage {
-		return false
-	}
-	return true
-}
-
-func expectedDatabaseMismatchConditionMessage(configuredDB, availableDB string) string {
-	if strings.TrimSpace(availableDB) == "" {
-		return fmt.Sprintf("Function database %q does not match any configured ingestor endpoints", configuredDB)
-	}
-	return fmt.Sprintf("Function database %q does not match available ingestor databases: %s", configuredDB, availableDB)
 }
 
 func (t *SyncFunctionsTask) updateKQLFunctionStatus(ctx context.Context, fn *v1.Function, status v1.FunctionStatusEnum, err error) error {

--- a/kustomize/bases/functions_crd.yaml
+++ b/kustomize/bases/functions_crd.yaml
@@ -81,21 +81,22 @@ spec:
               conditions:
                 description: |-
                   Conditions conveys detailed reconciliation state in a Kubernetes-native format.
-                  Controllers set FunctionDatabaseMatch and FunctionCriteriaMatch to surface gating
-                  decisions (skipped due to database mismatch or criteria mismatch) and
+                  Controllers set FunctionCriteriaMatch to surface criteria gating decisions and
                   FunctionReconciled to report the outcome of the most recent reconciliation attempt.
+                  Functions targeting databases that the ingestor does not manage are skipped silently;
+                  their existing conditions remain unchanged to avoid oscillating status between clusters.
 
                   Example:
                     status:
                       conditions:
-                      - type: function.adx-mon.azure.com/DatabaseMatch
+                      - type: function.adx-mon.azure.com/CriteriaMatch
                         status: "False"
-                        reason: DatabaseMismatch
-                        message: "Function database 'AKSProd' does not match available databases: aksprod, aksinfra"
+                        reason: CriteriaNotMatched
+                        message: "Criteria expression evaluated to false for cluster labels: environment=prod, location=westus2"
                       - type: function.adx-mon.azure.com/Reconciled
                         status: "False"
-                        reason: DatabaseMismatchSkipped
-                        message: "Function skipped due to database mismatch"
+                        reason: CriteriaNotMatched
+                        message: "Function skipped because criteria expression evaluated to false for cluster labels: environment=prod, location=westus2"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/operator/manifests/crds/functions_crd.yaml
+++ b/operator/manifests/crds/functions_crd.yaml
@@ -81,21 +81,22 @@ spec:
               conditions:
                 description: |-
                   Conditions conveys detailed reconciliation state in a Kubernetes-native format.
-                  Controllers set FunctionDatabaseMatch and FunctionCriteriaMatch to surface gating
-                  decisions (skipped due to database mismatch or criteria mismatch) and
+                  Controllers set FunctionCriteriaMatch to surface criteria gating decisions and
                   FunctionReconciled to report the outcome of the most recent reconciliation attempt.
+                  Functions targeting databases that the ingestor does not manage are skipped silently;
+                  their existing conditions remain unchanged to avoid oscillating status between clusters.
 
                   Example:
                     status:
                       conditions:
-                      - type: function.adx-mon.azure.com/DatabaseMatch
+                      - type: function.adx-mon.azure.com/CriteriaMatch
                         status: "False"
-                        reason: DatabaseMismatch
-                        message: "Function database 'AKSProd' does not match available databases: aksprod, aksinfra"
+                        reason: CriteriaNotMatched
+                        message: "Criteria expression evaluated to false for cluster labels: environment=prod, location=westus2"
                       - type: function.adx-mon.azure.com/Reconciled
                         status: "False"
-                        reason: DatabaseMismatchSkipped
-                        message: "Function skipped due to database mismatch"
+                        reason: CriteriaNotMatched
+                        message: "Function skipped because criteria expression evaluated to false for cluster labels: environment=prod, location=westus2"
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.


### PR DESCRIPTION
## Summary
Function reconciliation used to write a `DatabaseMatch` condition whenever the Function’s
`spec.database` didn’t match the ingestor’s database. In multi-cluster deployments that behavior
became a liability: a Function would appear “handled” by the wrong ingestor, leaving the matching
ingestor with no signal to reconcile it. This change treats database mismatches as benign skips and
stops mutating status for them.

## Bug Description
Functions targeting an ingestor without a matching database had their status rewritten with a
`DatabaseMatch` condition and a `Reconciled=False (DatabaseMismatchSkipped)` entry. Because status
is shared across ingestors, whichever ingestor got there first blocked the correct ingestor from
applying the Function. Operators were also misled into thinking reconciliation had completed when it
hadn’t.

## Fix
- Short-circuit the Function sync loop on database mismatches without touching status.
- Drop the `FunctionDatabaseMatch` helper and related tests.
- Refresh documentation and CRD comments to explain the new silent-skip behavior.

## Testing
- `go test ./api/v1 ./ingestor/adx`