### PR TITLE
Emit tail library logs into normal logger

### DIFF
--- a/collector/logs/sources/tail/logger.go
+++ b/collector/logs/sources/tail/logger.go
@@ -1,0 +1,51 @@
+package tail
+
+import (
+	"fmt"
+
+	"github.com/Azure/adx-mon/pkg/logger"
+)
+
+type tailLogger struct{}
+
+func (t *tailLogger) Fatal(v ...interface{}) {
+	logger.Fatal(fmt.Sprint(v...))
+}
+
+func (t *tailLogger) Fatalf(format string, v ...interface{}) {
+	logger.Fatalf(format, v...)
+}
+
+func (t *tailLogger) Fatalln(v ...interface{}) {
+	logger.Fatal(fmt.Sprintln(v...))
+}
+
+func (t *tailLogger) Panic(v ...interface{}) {
+	msg := fmt.Sprint(v...)
+	logger.Error(msg)
+	panic(msg)
+}
+
+func (t *tailLogger) Panicf(format string, v ...interface{}) {
+	msg := fmt.Sprintf(format, v...)
+	logger.Error(msg)
+	panic(msg)
+}
+
+func (t *tailLogger) Panicln(v ...interface{}) {
+	msg := fmt.Sprintln(v...)
+	logger.Error(msg)
+	panic(msg)
+}
+
+func (t *tailLogger) Print(v ...interface{}) {
+	logger.Info(fmt.Sprint(v...))
+}
+
+func (t *tailLogger) Printf(format string, v ...interface{}) {
+	logger.Infof(format, v...)
+}
+
+func (t *tailLogger) Println(v ...interface{}) {
+	logger.Info(fmt.Sprintln(v...))
+}

--- a/collector/logs/sources/tail/tailer.go
+++ b/collector/logs/sources/tail/tailer.go
@@ -41,7 +41,7 @@ func StartTailing(config TailerConfig) (*Tailer, error) {
 
 	batchQueue := make(chan *types.Log, 512)
 	outputQueue := make(chan *types.LogBatch, 1)
-	tailConfig := tail.Config{Follow: true, ReOpen: true, Poll: true}
+	tailConfig := tail.Config{Follow: true, ReOpen: true, Poll: true, Logger: &tailLogger{}}
 	existingCursorPath := cursorPath(config.CursorDirectory, config.Target.FilePath)
 	fileId, position, err := readCursor(existingCursorPath)
 	if err == nil {


### PR DESCRIPTION
Ensure we capture the logs that the tail library emits using its logging adapter.