### PR TITLE
Adding better error messages for undefined databases

### DIFF
--- a/alerter/engine/client.go
+++ b/alerter/engine/client.go
@@ -9,4 +9,6 @@ import (
 type Client interface {
 	Endpoint(db string) string
 	Query(ctx context.Context, qc *QueryContext, fn func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error) (error, int)
+	AvailableDatabases() []string
+	FindCaseInsensitiveMatch(db string) string
 }

--- a/alerter/engine/errors.go
+++ b/alerter/engine/errors.go
@@ -1,11 +1,40 @@
 package engine
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+const maxDisplayedDatabases = 10
 
 type UnknownDBError struct {
-	DB string
+	DB                   string
+	AvailableDatabases   []string
+	CaseInsensitiveMatch string
 }
 
 func (e *UnknownDBError) Error() string {
-	return fmt.Sprintf("no client for database %s", e.DB)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "no client for database %q", e.DB)
+
+	// Suggest case-insensitive match if found
+	if e.CaseInsensitiveMatch != "" {
+		fmt.Fprintf(&sb, "; did you mean %q? (database names are case-sensitive)", e.CaseInsensitiveMatch)
+	}
+
+	// List available databases
+	if len(e.AvailableDatabases) > 0 {
+		sb.WriteString("; configured databases via --kusto-endpoint: [")
+		if len(e.AvailableDatabases) <= maxDisplayedDatabases {
+			sb.WriteString(strings.Join(e.AvailableDatabases, ", "))
+		} else {
+			sb.WriteString(strings.Join(e.AvailableDatabases[:maxDisplayedDatabases], ", "))
+			fmt.Fprintf(&sb, ", ... and %d more", len(e.AvailableDatabases)-maxDisplayedDatabases)
+		}
+		sb.WriteString("]")
+	} else {
+		sb.WriteString("; no databases configured via --kusto-endpoint")
+	}
+
+	return sb.String()
 }

--- a/alerter/engine/errors_test.go
+++ b/alerter/engine/errors_test.go
@@ -1,0 +1,112 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnknownDBError_Basic(t *testing.T) {
+	err := &UnknownDBError{
+		DB:                 "cluster_state",
+		AvailableDatabases: []string{"db1", "db2"},
+	}
+
+	errMsg := err.Error()
+	require.Contains(t, errMsg, `no client for database "cluster_state"`)
+	require.Contains(t, errMsg, "--kusto-endpoint")
+	require.Contains(t, errMsg, "db1")
+	require.Contains(t, errMsg, "db2")
+}
+
+func TestUnknownDBError_CaseInsensitiveMatch(t *testing.T) {
+	err := &UnknownDBError{
+		DB:                   "cluster_state",
+		AvailableDatabases:   []string{"Cluster_State", "db2"},
+		CaseInsensitiveMatch: "Cluster_State",
+	}
+
+	errMsg := err.Error()
+	require.Contains(t, errMsg, `no client for database "cluster_state"`)
+	require.Contains(t, errMsg, `did you mean "Cluster_State"?`)
+	require.Contains(t, errMsg, "case-sensitive")
+	require.Contains(t, errMsg, "--kusto-endpoint")
+}
+
+func TestUnknownDBError_NoDatabases(t *testing.T) {
+	err := &UnknownDBError{
+		DB:                 "cluster_state",
+		AvailableDatabases: []string{},
+	}
+
+	errMsg := err.Error()
+	require.Contains(t, errMsg, `no client for database "cluster_state"`)
+	require.Contains(t, errMsg, "no databases configured via --kusto-endpoint")
+}
+
+func TestUnknownDBError_TruncateOver10(t *testing.T) {
+	dbs := make([]string, 15)
+	for i := 0; i < 15; i++ {
+		dbs[i] = "db" + string(rune('a'+i))
+	}
+
+	err := &UnknownDBError{
+		DB:                 "unknown",
+		AvailableDatabases: dbs,
+	}
+
+	errMsg := err.Error()
+	require.Contains(t, errMsg, `no client for database "unknown"`)
+	require.Contains(t, errMsg, "--kusto-endpoint")
+
+	// Should contain first 10 databases
+	for i := 0; i < 10; i++ {
+		require.Contains(t, errMsg, dbs[i])
+	}
+
+	// Should NOT contain databases 11-15
+	for i := 10; i < 15; i++ {
+		require.NotContains(t, errMsg, dbs[i])
+	}
+
+	// Should show "... and 5 more"
+	require.Contains(t, errMsg, "... and 5 more")
+}
+
+func TestUnknownDBError_Exactly10Databases(t *testing.T) {
+	dbs := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		dbs[i] = "db" + string(rune('a'+i))
+	}
+
+	err := &UnknownDBError{
+		DB:                 "unknown",
+		AvailableDatabases: dbs,
+	}
+
+	errMsg := err.Error()
+
+	// Should contain all 10 databases
+	for i := 0; i < 10; i++ {
+		require.Contains(t, errMsg, dbs[i])
+	}
+
+	// Should NOT have truncation message
+	require.NotContains(t, errMsg, "... and")
+	require.NotContains(t, errMsg, "more")
+}
+
+func TestUnknownDBError_FullMessage(t *testing.T) {
+	err := &UnknownDBError{
+		DB:                   "CLUSTER_STATE",
+		AvailableDatabases:   []string{"cluster_state", "logs", "metrics"}, // Already sorted
+		CaseInsensitiveMatch: "cluster_state",
+	}
+
+	errMsg := err.Error()
+	// The message should be well-structured
+	require.True(t, strings.HasPrefix(errMsg, `no client for database "CLUSTER_STATE"`))
+	require.Contains(t, errMsg, `did you mean "cluster_state"? (database names are case-sensitive)`)
+	require.Contains(t, errMsg, "configured databases via --kusto-endpoint: [cluster_state, logs, metrics]")
+}

--- a/alerter/engine/fake.go
+++ b/alerter/engine/fake.go
@@ -35,6 +35,14 @@ func (m *fakeKustoClient) Query(ctx context.Context, qc *QueryContext, fn func(c
 	return nil, 1
 }
 
+func (m *fakeKustoClient) AvailableDatabases() []string {
+	return []string{"fakedb"}
+}
+
+func (m *fakeKustoClient) FindCaseInsensitiveMatch(db string) string {
+	return ""
+}
+
 type fakeAlerter struct {
 	createFn func(ctx context.Context, endpoint string, alert alert.Alert) error
 }

--- a/alerter/engine/worker_test.go
+++ b/alerter/engine/worker_test.go
@@ -364,7 +364,7 @@ func TestWorker_RequestInvalid(t *testing.T) {
 
 func TestWorker_UnknownDB(t *testing.T) {
 	kcli := &fakeKustoClient{
-		queryErr: &UnknownDBError{"fakedb"},
+		queryErr: &UnknownDBError{DB: "fakedb", AvailableDatabases: []string{"db1", "db2"}},
 	}
 
 	var createCalled bool

--- a/alerter/multikustoclient/client.go
+++ b/alerter/multikustoclient/client.go
@@ -3,6 +3,7 @@ package multikustoclient
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Azure/adx-mon/alerter/alert"
@@ -13,8 +14,9 @@ import (
 )
 
 type multiKustoClient struct {
-	clients          map[string]QueryClient
-	maxNotifications int
+	clients            map[string]QueryClient
+	availableDatabases []string
+	maxNotifications   int
 }
 
 func New(endpoints map[string]string, configureAuth authConfiguror, max int) (multiKustoClient, error) {
@@ -33,13 +35,28 @@ func New(endpoints map[string]string, configureAuth authConfiguror, max int) (mu
 	if len(clients) == 0 {
 		return multiKustoClient{}, fmt.Errorf("no kusto endpoints provided")
 	}
-	return multiKustoClient{clients: clients, maxNotifications: max}, nil
+
+	availableDatabases := make([]string, 0, len(clients))
+	for name := range clients {
+		availableDatabases = append(availableDatabases, name)
+	}
+	sort.Strings(availableDatabases)
+
+	return multiKustoClient{
+		clients:            clients,
+		availableDatabases: availableDatabases,
+		maxNotifications:   max,
+	}, nil
 }
 
 func (c multiKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn func(context.Context, string, *engine.QueryContext, *table.Row) error) (error, int) {
 	client := c.clients[qc.Rule.Database]
 	if client == nil {
-		return &engine.UnknownDBError{DB: qc.Rule.Database}, 0
+		return &engine.UnknownDBError{
+			DB:                   qc.Rule.Database,
+			AvailableDatabases:   c.availableDatabases,
+			CaseInsensitiveMatch: c.FindCaseInsensitiveMatch(qc.Rule.Database),
+		}, 0
 	}
 
 	var iter *kusto.RowIterator
@@ -99,6 +116,23 @@ func (c multiKustoClient) Endpoint(db string) string {
 		return "unknown"
 	}
 	return cl.Endpoint()
+}
+
+// AvailableDatabases returns a sorted list of all configured database names.
+func (c multiKustoClient) AvailableDatabases() []string {
+	return c.availableDatabases
+}
+
+// FindCaseInsensitiveMatch returns a database name that matches the given db name
+// case-insensitively, or an empty string if no match is found.
+func (c multiKustoClient) FindCaseInsensitiveMatch(db string) string {
+	lowerDB := strings.ToLower(db)
+	for name := range c.clients {
+		if strings.ToLower(name) == lowerDB {
+			return name
+		}
+	}
+	return ""
 }
 
 type QueryClient interface {

--- a/alerter/multikustoclient/client_test.go
+++ b/alerter/multikustoclient/client_test.go
@@ -309,3 +309,64 @@ func newRowsWithError(t *testing.T, values []string, rowError error) *kusto.Mock
 	require.NoError(t, err)
 	return rows
 }
+
+func TestFindCaseInsensitiveMatch(t *testing.T) {
+	client := multiKustoClient{
+		clients: map[string]QueryClient{
+			"Cluster_State": &fakeQueryClient{endpoint: "endpoint"},
+			"Metrics":       &fakeQueryClient{endpoint: "endpoint"},
+		},
+	}
+
+	// Different casing
+	match := client.FindCaseInsensitiveMatch("cluster_state")
+	require.Equal(t, "Cluster_State", match)
+
+	// Different casing
+	match = client.FindCaseInsensitiveMatch("CLUSTER_STATE")
+	require.Equal(t, "Cluster_State", match)
+
+	// No match
+	match = client.FindCaseInsensitiveMatch("unknown")
+	require.Empty(t, match)
+
+	// Metrics with different case
+	match = client.FindCaseInsensitiveMatch("metrics")
+	require.Equal(t, "Metrics", match)
+}
+
+func TestQuery_UnknownDB_EnhancedError(t *testing.T) {
+	client := multiKustoClient{
+		clients: map[string]QueryClient{
+			"Cluster_State": &fakeQueryClient{endpoint: "endpoint"},
+			"Metrics":       &fakeQueryClient{endpoint: "endpoint"},
+		},
+		availableDatabases: []string{"Cluster_State", "Metrics"},
+		maxNotifications:   5,
+	}
+
+	ctx := context.Background()
+	queryContext := &engine.QueryContext{
+		Rule: &rules.Rule{
+			Database: "cluster_state", // Wrong case
+		},
+		Stmt: kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd("query"),
+	}
+
+	err, _ := client.Query(ctx, queryContext, func(context.Context, string, *engine.QueryContext, *table.Row) error {
+		return nil
+	})
+
+	require.Error(t, err)
+
+	var unknownDBErr *engine.UnknownDBError
+	require.ErrorAs(t, err, &unknownDBErr)
+	require.Equal(t, "cluster_state", unknownDBErr.DB)
+	require.Equal(t, "Cluster_State", unknownDBErr.CaseInsensitiveMatch)
+	require.Equal(t, []string{"Cluster_State", "Metrics"}, unknownDBErr.AvailableDatabases)
+
+	// Check error message contains helpful info
+	errMsg := err.Error()
+	require.Contains(t, errMsg, `did you mean "Cluster_State"?`)
+	require.Contains(t, errMsg, "--kusto-endpoint")
+}


### PR DESCRIPTION
Make it more clear in Alerter when we cannot find a destination database because one is not configured.

Example error messages are:

`Failed to execute query=adx-mon/etcd-leader on unknown/logs: no client for database "logs"; did you mean "Logs"? (database names are case-sensitive); configured databases via --kusto-endpoint: [Logs, Metrics]`

`Failed to execute query=adx-mon/etcd-leader on unknown/logs: no client for database "logs"; configured databases via --kusto-endpoint: [Metrics]`