### PR TITLE
Update plugin transformer to accept a map configuration

### DIFF
--- a/cmd/collector/config/config.go
+++ b/cmd/collector/config/config.go
@@ -297,6 +297,9 @@ func (w *OtelLog) Validate() error {
 	}
 
 	for _, v := range w.Transforms {
+		if v == nil {
+			return errors.New("otel-log.transforms entry must not be nil")
+		}
 		if !transforms.IsValidTransformType(v.Name) {
 			return fmt.Errorf("otel-log.transforms %s is not a valid transform", v.Name)
 		}
@@ -435,6 +438,9 @@ func (w *HostLog) Validate() error {
 	}
 
 	for _, v := range w.Transforms {
+		if v == nil {
+			return errors.New("host-log.transforms entry must not be nil")
+		}
 		if !transforms.IsValidTransformType(v.Name) {
 			return fmt.Errorf("host-log.transforms %s is not a valid transform", v.Name)
 		}

--- a/cmd/collector/config/config_test.go
+++ b/cmd/collector/config/config_test.go
@@ -540,6 +540,13 @@ func TestConfig_ValidateOtelLog_Transforms(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Failure_nil_transform",
+			otelLog: &OtelLog{
+				Transforms: []*LogTransform{nil},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Failure_invalid_transform",
 			otelLog: &OtelLog{
 				Transforms: []*LogTransform{
@@ -1438,6 +1445,13 @@ func TestConfig_Validate_HostLog(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "Failure_nil_transform",
+			config: &HostLog{
+				Transforms: []*LogTransform{nil},
+			},
+			wantErr: true,
 		},
 		{
 			name: "Failure_invalid_transform",

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji.go
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji.go
@@ -8,10 +8,22 @@ import (
 )
 
 type AddEmoji struct {
+	suffix string
 }
 
-func New() types.Transformer {
-	return &AddEmoji{}
+func New(config map[string]any) types.Transformer {
+	if config == nil {
+		config = map[string]any{}
+	}
+
+	suffix := ""
+	if rawSuffix, ok := config["Suffix"]; ok {
+		if value, ok := rawSuffix.(string); ok {
+			suffix = value
+		}
+	}
+
+	return &AddEmoji{suffix: suffix}
 }
 
 func (t *AddEmoji) Open(ctx context.Context) error {
@@ -28,7 +40,11 @@ func (t *AddEmoji) Transform(ctx context.Context, batch *types.LogBatch) (*types
 		if !ok {
 			continue
 		}
-		log.SetBodyValue(types.BodyKeyMessage, mapping.Map(messageStr))
+		mapped := mapping.Map(messageStr)
+		if t.suffix != "" {
+			mapped += t.suffix
+		}
+		log.SetBodyValue(types.BodyKeyMessage, mapped)
 	}
 	return batch, nil
 }

--- a/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji_test.go
+++ b/collector/logs/transforms/plugin/test-plugin/src/github.com/Azure/testplugin/pkg/transforms/addemoji_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestAddEmoji(t *testing.T) {
-	transformer := New()
+	transformer := New(map[string]any{
+		"Suffix": " ✅",
+	})
 	if transformer.Name() != "AddEmoji" {
 		t.Errorf("Expected name to be AddEmoji, got %s", transformer.Name())
 	}
@@ -36,7 +38,7 @@ func TestAddEmoji(t *testing.T) {
 		t.Errorf("Expected 3 log, got %d", len(transformedBatch.Logs))
 	}
 	message := types.StringOrEmpty(transformedBatch.Logs[0].GetBodyValue("message"))
-	if message != "Hello World 😃" {
-		t.Errorf("Expected message to be Hello World 😃, got %s", message)
+	if message != "Hello World 😃 ✅" {
+		t.Errorf("Expected message to be Hello World 😃 ✅, got %s", message)
 	}
 }

--- a/collector/logs/transforms/plugin/yaegi.go
+++ b/collector/logs/transforms/plugin/yaegi.go
@@ -3,13 +3,14 @@ package plugin
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
 	"github.com/traefik/yaegi/interp"
 	"github.com/traefik/yaegi/stdlib"
 )
 
-/* Plugins are defined with a Go package that exports a New() function that returns a types.Transformer.
+/* Plugins are defined with a Go package that exports a New(config map[string]any) function that returns a types.Transformer.
    The structure of a plugin is like the following, simulating a full GoPath with a single project within.
 
    The plugin system does not support Go modules, so all dependencies must be vendored and the plugin path
@@ -37,7 +38,7 @@ import (
                                             └── logs.go
 */
 
-func FromConfigMap(config map[string]interface{}) (types.Transformer, error) {
+func FromConfigMap(config map[string]any) (types.Transformer, error) {
 	goPath, ok := config["GoPath"].(string)
 	if !ok {
 		return nil, fmt.Errorf("GoPath is required")
@@ -48,9 +49,19 @@ func FromConfigMap(config map[string]interface{}) (types.Transformer, error) {
 		return nil, fmt.Errorf("ImportName is required")
 	}
 
+	pluginConfig := map[string]any{}
+	if rawConfig, ok := config["Config"]; ok {
+		configMap, ok := rawConfig.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("Config must be a map[string]any")
+		}
+		pluginConfig = configMap
+	}
+
 	transformConfig := TransformConfig{
 		GoPath:     goPath,
 		ImportName: importName,
+		Config:     pluginConfig,
 	}
 
 	return NewTransform(transformConfig)
@@ -61,9 +72,12 @@ type TransformConfig struct {
 	// This expects a directory with a src directory at the base.
 	GoPath string
 
-	// Import package of the plugin that contains the New() function.
+	// Import package of the plugin that contains the New(config map[string]any) function.
 	// e.g. github.com/Azure/emojitransforms/pkg/transforms
 	ImportName string
+
+	// Config passed to the plugin New(config map[string]any) function.
+	Config map[string]any
 }
 
 func NewTransform(config TransformConfig) (types.Transformer, error) {
@@ -84,8 +98,14 @@ func NewTransform(config TransformConfig) (types.Transformer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get New function from %s: %w", baseName, err)
 	}
-	// Consider changing this interface to accept a configuration object that can contain metrics, etc.
-	results := newFuncInterface.Call(nil)
+	if config.Config == nil {
+		config.Config = map[string]any{}
+	}
+
+	results := newFuncInterface.Call([]reflect.Value{reflect.ValueOf(config.Config)})
+	if len(results) == 0 {
+		return nil, fmt.Errorf("%s.New() did not return a value; expected types.Transformer", baseName)
+	}
 
 	var ok bool
 	transformer, ok := results[0].Interface().(types.Transformer)

--- a/collector/logs/transforms/plugin/yaegi_test.go
+++ b/collector/logs/transforms/plugin/yaegi_test.go
@@ -12,6 +12,7 @@ func TestYaegi(t *testing.T) {
 	transform, err := NewTransform(TransformConfig{
 		GoPath:     "test-plugin",
 		ImportName: "github.com/Azure/testplugin/pkg/transforms",
+		Config:     map[string]any{},
 	})
 	require.NoError(t, err)
 

--- a/collector/logs/transforms/transform.go
+++ b/collector/logs/transforms/transform.go
@@ -26,6 +26,10 @@ func IsValidTransformType(transformType string) bool {
 }
 
 func NewTransform(transformType string, config map[string]any) (types.Transformer, error) {
+	if config == nil {
+		config = map[string]any{}
+	}
+
 	creator, ok := transformCreators[transformType]
 	if !ok {
 		return nil, fmt.Errorf("unknown transform type: %s", transformType)


### PR DESCRIPTION
Plugins often need configuration properties provided at startup via config. Allow passing in configuration as a map[string]any.