### PR TITLE
fix: call Stop() on kusto RowIterator results to prevent memory leak

### DIFF
--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -325,10 +325,11 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 	for _, fn := range functions {
 		logger.Infof("Creating function %s", fn.name)
 		stmt := kusto.NewStmt("", kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(fn.body)
-		_, err := s.KustoCli.Mgmt(ctx, s.database, stmt)
+		result, err := s.KustoCli.Mgmt(ctx, s.database, stmt)
 		if err != nil {
 			return err
 		}
+		result.Stop()
 	}
 	return nil
 }

--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -180,7 +180,8 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 			}
 
 			stmt := kql.New(".drop function ").AddUnsafe(function.Name).AddLiteral(" ifexists")
-			if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
+			result, err := t.kustoCli.Mgmt(ctx, stmt)
+			if err != nil {
 				parsed := kustoutil.ParseError(err)
 				logger.Errorf("Failed to delete function %s.%s: %v", function.Spec.Database, function.Name, err)
 				function.SetReconcileCondition(metav1.ConditionFalse, "FunctionDeletionFailed", parsed)
@@ -192,6 +193,7 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 				continue
 			}
 
+			result.Stop()
 			function.SetReconcileCondition(metav1.ConditionTrue, "FunctionDeleted", fmt.Sprintf("Function successfully deleted from %s", availableDB))
 			if err := t.updateKQLFunctionStatus(ctx, function, v1.Success, nil); err != nil {
 				logger.Errorf("Failed to update success status following deletion for %s.%s: %v", function.Spec.Database, function.Name, err)
@@ -201,7 +203,8 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 
 		if t.kustoCli.Endpoint() != function.Spec.AppliedEndpoint || function.Status.Status != v1.Success || function.GetGeneration() != function.Status.ObservedGeneration {
 			stmt := kql.New(".execute database script with (ThrowOnErrors=true) <| ").AddUnsafe(function.Spec.Body)
-			if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
+			result, err := t.kustoCli.Mgmt(ctx, stmt)
+			if err != nil {
 				parsed := kustoutil.ParseError(err)
 				if !errors.Retry(err) {
 					logger.Errorf("Permanent failure to create function %s.%s: %v", function.Spec.Database, function.Name, err)
@@ -219,6 +222,7 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 				continue
 			}
 
+			result.Stop()
 			logger.Infof("Successfully created function %s.%s", function.Spec.Database, function.Name)
 			if t.kustoCli.Endpoint() != function.Spec.AppliedEndpoint {
 				function.Spec.AppliedEndpoint = t.kustoCli.Endpoint()
@@ -300,12 +304,14 @@ func (t *ManagementCommandTask) Run(ctx context.Context) error {
 		} else {
 			stmt = kql.New(".execute database script with (ThrowOnErrors = true) <|").AddUnsafe(command.Spec.Body)
 		}
-		if _, err := t.kustoCli.Mgmt(ctx, stmt); err != nil {
+		result, err := t.kustoCli.Mgmt(ctx, stmt)
+		if err != nil {
 			logger.Errorf("Failed to execute management command %s.%s: %v", command.Spec.Database, command.Name, err)
 			if err = t.store.UpdateStatus(ctx, &command, err); err != nil {
 				logger.Errorf("Failed to update management command status: %v", err)
 			}
 		} else {
+			result.Stop()
 			logger.Infof("Successfully executed management command %s.%s", command.Spec.Database, command.Name)
 			if err := t.store.UpdateStatus(ctx, &command, nil); err != nil {
 				logger.Errorf("Failed to update success status: %v", err)

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -290,7 +290,15 @@ func (t *TestStatementExecutor) Mgmt(ctx context.Context, query kusto.Statement,
 		return iter, nil
 	}
 
-	return nil, nil
+	// Default: return an empty but properly initialized mock iterator
+	mockRows, err := kusto.NewMockRows(table.Columns{{Name: "Result", Type: kustotypes.String}})
+	if err != nil {
+		return nil, err
+	}
+	if err := iter.Mock(mockRows); err != nil {
+		return nil, fmt.Errorf("failed to mock iterator: %w", err)
+	}
+	return iter, nil
 }
 
 type TestFunctionStore struct {

--- a/operator/adx.go
+++ b/operator/adx.go
@@ -562,7 +562,10 @@ func ensureHeartbeatTable(ctx context.Context, cluster *adxmonv1.ADXCluster) (bo
 	}
 
 	stmt := kql.New(".create table ").AddTable(*cluster.Spec.Federation.HeartbeatTable).AddLiteral("(Timestamp: datetime, ClusterEndpoint: string, Schema: dynamic, PartitionMetadata: dynamic)")
-	_, err = client.Mgmt(ctx, *cluster.Spec.Federation.HeartbeatDatabase, stmt)
+	createResult, err := client.Mgmt(ctx, *cluster.Spec.Federation.HeartbeatDatabase, stmt)
+	if err == nil {
+		createResult.Stop()
+	}
 	return true, err
 }
 
@@ -1173,7 +1176,10 @@ func heartbeatFederatedCluster(ctx context.Context, cluster *adxmonv1.ADXCluster
 	stmt := kql.New(".ingest inline into table ").
 		AddTable(target.HeartbeatTable).
 		AddLiteral(" <| ").AddUnsafe(row)
-	_, err = federatedClient.Mgmt(ctx, target.HeartbeatDatabase, stmt)
+	ingestResult, err := federatedClient.Mgmt(ctx, target.HeartbeatDatabase, stmt)
+	if err == nil {
+		ingestResult.Stop()
+	}
 	return err
 }
 
@@ -1578,9 +1584,11 @@ func ensureHubTables(ctx context.Context, client *kusto.Client, database string,
 			AddLiteral(" (").
 			AddUnsafe(schemaDef).
 			AddLiteral(")")
-		if _, err := client.Mgmt(ctx, database, stmt); err != nil {
+		result, err := client.Mgmt(ctx, database, stmt)
+		if err != nil {
 			return fmt.Errorf("failed to create table %s.%s: %w", database, table, err)
 		}
+		result.Stop()
 		logger.Infof("Created hub table %s.%s using schema: %s", database, table, schemaDef)
 	}
 	return nil
@@ -1714,10 +1722,11 @@ func executeKustoScripts(ctx context.Context, client *kusto.Client, database str
 	const scriptPreamble = ".execute database script with (ContinueOnErrors=true)\n<|\n"
 	for _, script := range scripts {
 		fullScript := scriptPreamble + strings.Join(script, "")
-		_, err := client.Mgmt(ctx, database, kql.New("").AddUnsafe(fullScript))
+		result, err := client.Mgmt(ctx, database, kql.New("").AddUnsafe(fullScript))
 		if err != nil {
 			return fmt.Errorf("failed to execute Kusto script: %w", err)
 		}
+		result.Stop()
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem
All calls to `client.Mgmt()` return a `*kusto.RowIterator` that must be drained or stopped to release the SDK's background goroutines and buffered JSON frame data. Several fire-and-forget DDL calls were discarding the result with `_`, allowing the SDK to accumulate decoded row data indefinitely across reconcile cycles.

Identified via heap pprof showing 182MB retained in `azure-kusto-go/kusto/internal/frames/v1.(*Decoder).processTables` and `unmarshal.Rows`.

## Changes
- `operator/adx.go`: `executeKustoScripts`, `ensureHubTables`, heartbeat table creation, federated ingest inline
- `ingestor/adx/tasks.go`: drop function, execute database script, management command execution
- `ingestor/adx/syncer.go`: create functions

## References
- [kusto.RowIterator docs](https://pkg.go.dev/github.com/Azure/azure-kusto-go/kusto#RowIterator)