### PR TITLE
Add ACR publish and rollout helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,35 @@ collection and analysis of observability data.
 
 ## Development
 
+### Build, push, and deploy images from ACR
+
+Use these helper scripts to publish ADX-Mon images to your Azure Container Registry (ACR) and update the running Kubernetes workloads to use those images.
+
+```bash
+# Build and push ingestor, collector, operator, and alerter
+tools/dev/push-all-images-to-acr.sh <acr-name-or-login-server> [tag]
+
+# Example with latest tag
+tools/dev/push-all-images-to-acr.sh myacr latest
+
+# Update adx-mon workloads to use ACR images (ingestor + collector workloads)
+tools/dev/update-adxmon-images.sh <acr-name-or-login-server> [tag]
+
+# Example
+tools/dev/update-adxmon-images.sh myacr latest
+```
+
+Notes:
+- `<acr-name-or-login-server>` accepts either `myacr` or `myacr.azurecr.io`.
+- `tag` defaults to `latest` if omitted.
+- Set `NAMESPACE` to target a non-default namespace (default: `adx-mon`).
+
+Component-specific push scripts are also available:
+- `tools/dev/push-ingestor-to-acr.sh`
+- `tools/dev/push-collector-to-acr.sh`
+- `tools/dev/push-operator-to-acr.sh`
+- `tools/dev/push-alerter-to-acr.sh`
+
 ### Collector backend verification
 
 - `/readyz` returns `status=ok backend=<value>` when healthy and 503 with the same backend annotation if max disk usage or segment thresholds trigger backpressure.

--- a/tools/dev/acr-image-common.sh
+++ b/tools/dev/acr-image-common.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}" >&2
+    exit 1
+  fi
+}
+
+require_basics() {
+  require_cmd docker
+  require_cmd az
+}
+
+resolve_acr_login_server() {
+  local input="$1"
+
+  if [[ -z "${input}" ]]; then
+    echo "ACR name/login-server cannot be empty" >&2
+    exit 1
+  fi
+
+  if [[ "${input}" == *.azurecr.io ]]; then
+    printf "%s" "${input}"
+    return
+  fi
+
+  az acr show --name "${input}" --query loginServer -o tsv
+}
+
+acr_name_from_login_server() {
+  local login_server="$1"
+  printf "%s" "${login_server%%.azurecr.io}"
+}
+
+compute_build_vars() {
+  VERSION="${VERSION:-${TAG:-latest}}"
+  GIT_COMMIT="${GIT_COMMIT:-$(git -C "${REPO_ROOT}" rev-parse --short HEAD)}"
+  BUILD_TIME="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+}
+
+docker_build_and_push() {
+  local dockerfile="$1"
+  local image_ref="$2"
+
+  compute_build_vars
+
+  docker build \
+    --build-arg VERSION="${VERSION}" \
+    --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+    --build-arg BUILD_TIME="${BUILD_TIME}" \
+    -f "${dockerfile}" \
+    -t "${image_ref}" \
+    "${REPO_ROOT}"
+
+  docker push "${image_ref}"
+}

--- a/tools/dev/push-alerter-to-acr.sh
+++ b/tools/dev/push-alerter-to-acr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/acr-image-common.sh"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+require_basics
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+LOGIN_SERVER="$(resolve_acr_login_server "${ACR_INPUT}")"
+ACR_NAME="$(acr_name_from_login_server "${LOGIN_SERVER}")"
+
+az acr login --name "${ACR_NAME}" >/dev/null
+
+IMAGE_REF="${LOGIN_SERVER}/adx-mon/alerter:${TAG}"
+docker_build_and_push "${REPO_ROOT}/build/images/Dockerfile.alerter" "${IMAGE_REF}"
+
+echo "Pushed ${IMAGE_REF}"

--- a/tools/dev/push-all-images-to-acr.sh
+++ b/tools/dev/push-all-images-to-acr.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+
+"${SCRIPT_DIR}/push-ingestor-to-acr.sh" "${ACR_INPUT}" "${TAG}"
+"${SCRIPT_DIR}/push-collector-to-acr.sh" "${ACR_INPUT}" "${TAG}"
+"${SCRIPT_DIR}/push-operator-to-acr.sh" "${ACR_INPUT}" "${TAG}"
+"${SCRIPT_DIR}/push-alerter-to-acr.sh" "${ACR_INPUT}" "${TAG}"

--- a/tools/dev/push-collector-to-acr.sh
+++ b/tools/dev/push-collector-to-acr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/acr-image-common.sh"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+require_basics
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+LOGIN_SERVER="$(resolve_acr_login_server "${ACR_INPUT}")"
+ACR_NAME="$(acr_name_from_login_server "${LOGIN_SERVER}")"
+
+az acr login --name "${ACR_NAME}" >/dev/null
+
+IMAGE_REF="${LOGIN_SERVER}/adx-mon/collector:${TAG}"
+docker_build_and_push "${REPO_ROOT}/build/images/Dockerfile.collector" "${IMAGE_REF}"
+
+echo "Pushed ${IMAGE_REF}"

--- a/tools/dev/push-ingestor-to-acr.sh
+++ b/tools/dev/push-ingestor-to-acr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/acr-image-common.sh"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+require_basics
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+LOGIN_SERVER="$(resolve_acr_login_server "${ACR_INPUT}")"
+ACR_NAME="$(acr_name_from_login_server "${LOGIN_SERVER}")"
+
+az acr login --name "${ACR_NAME}" >/dev/null
+
+IMAGE_REF="${LOGIN_SERVER}/adx-mon/ingestor:${TAG}"
+docker_build_and_push "${REPO_ROOT}/build/images/Dockerfile.ingestor" "${IMAGE_REF}"
+
+echo "Pushed ${IMAGE_REF}"

--- a/tools/dev/push-operator-to-acr.sh
+++ b/tools/dev/push-operator-to-acr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/acr-image-common.sh"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+require_basics
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+LOGIN_SERVER="$(resolve_acr_login_server "${ACR_INPUT}")"
+ACR_NAME="$(acr_name_from_login_server "${LOGIN_SERVER}")"
+
+az acr login --name "${ACR_NAME}" >/dev/null
+
+IMAGE_REF="${LOGIN_SERVER}/adx-mon/operator:${TAG}"
+docker_build_and_push "${REPO_ROOT}/build/images/Dockerfile.operator" "${IMAGE_REF}"
+
+echo "Pushed ${IMAGE_REF}"

--- a/tools/dev/update-adxmon-images.sh
+++ b/tools/dev/update-adxmon-images.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <acr-name-or-login-server> [tag]" >&2
+  exit 1
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "Missing required command: kubectl" >&2
+  exit 1
+fi
+
+ACR_INPUT="$1"
+TAG="${2:-latest}"
+NAMESPACE="${NAMESPACE:-adx-mon}"
+
+if [[ "${ACR_INPUT}" == *.azurecr.io ]]; then
+  LOGIN_SERVER="${ACR_INPUT}"
+else
+  LOGIN_SERVER="${ACR_INPUT}.azurecr.io"
+fi
+
+INGESTOR_IMAGE="${LOGIN_SERVER}/adx-mon/ingestor:${TAG}"
+COLLECTOR_IMAGE="${LOGIN_SERVER}/adx-mon/collector:${TAG}"
+
+kubectl -n "${NAMESPACE}" set image statefulset/ingestor ingestor="${INGESTOR_IMAGE}"
+kubectl -n "${NAMESPACE}" set image daemonset/collector collector="${COLLECTOR_IMAGE}"
+kubectl -n "${NAMESPACE}" set image deployment/collector-singleton collector="${COLLECTOR_IMAGE}"
+
+kubectl -n "${NAMESPACE}" rollout status statefulset/ingestor
+kubectl -n "${NAMESPACE}" rollout status daemonset/collector
+kubectl -n "${NAMESPACE}" rollout status deployment/collector-singleton
+
+echo "Updated workloads in namespace ${NAMESPACE}"
+echo "- statefulset/ingestor -> ${INGESTOR_IMAGE}"
+echo "- daemonset/collector -> ${COLLECTOR_IMAGE}"
+echo "- deployment/collector-singleton -> ${COLLECTOR_IMAGE}"


### PR DESCRIPTION
## Summary
- add reusable `tools/dev` scripts to build and push ingestor, collector, operator, and alerter images to a specified ACR
- add a helper script to update adx-mon ingestor and collector workloads to use a chosen ACR/tag and wait for rollout completion
- document the ACR publish/deploy workflow and script usage in `README.md`