### PR TITLE
feat: add adx-mon Helm chart

### DIFF
--- a/charts/adx-mon/Chart.yaml
+++ b/charts/adx-mon/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: adx-mon
+description: Deployment of adx-mon
+type: application
+version: 0.2.0-alpha
+appVersion: 0.2.0

--- a/charts/adx-mon/README.md
+++ b/charts/adx-mon/README.md
@@ -1,0 +1,189 @@
+# adx-mon Helm Chart
+
+> [!WARNING]
+> This chart is a work-in-progress. It has been validated in specific production environments but does not yet cover all common deployment scenarios. Contributions for typical use cases are welcome — please open a pull request or issue at [Azure/adx-mon](https://github.com/Azure/adx-mon).
+
+Deploys [adx-mon](https://github.com/Azure/adx-mon) — a Kubernetes-native observability platform — to an AKS cluster. The chart includes the collector, ingestor, alerter, and operator components, along with all required CRDs.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.10+
+- An Azure Data Explorer (ADX/Kusto) cluster
+- Workload identity configured on your AKS cluster
+
+## Installation
+
+```bash
+helm install adx-mon oci://ghcr.io/azure/adx-mon/charts/adx-mon \
+  --namespace adx-mon \
+  --create-namespace \
+  --set aks_cluster_name=my-cluster \
+  --set region=eastus \
+  --set environment=prod \
+  --set adx.name=my-adx-cluster \
+  --set adx.url=https://my-adx-cluster.eastus.kusto.windows.net \
+  --set adx_hub_url=https://my-hub-cluster.eastus.kusto.windows.net \
+  --set ingestor.client_id=<workload-identity-client-id>
+```
+
+Or with a values file:
+
+```bash
+helm install adx-mon oci://ghcr.io/azure/adx-mon/charts/adx-mon \
+  --namespace adx-mon \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+## Configuration
+
+### Required values
+
+| Key | Description |
+|-----|-------------|
+| `aks_cluster_name` | Name of the AKS cluster, added as a label to all metrics and logs |
+| `region` | Azure region identifier (e.g. `eastus`) |
+| `environment` | Environment tag (e.g. `prod`, `staging`) |
+| `adx.name` | Name of the ADX cluster |
+| `adx.url` | ADX cluster endpoint URL (e.g. `https://mycluster.eastus.kusto.windows.net`) |
+| `adx_hub_url` | ADX hub/federation cluster endpoint URL |
+| `ingestor.client_id` | Azure Workload Identity client ID for the ingestor. The corresponding identity must have the **Database Admin** role on each pre-existing database in the ADX cluster. |
+| `alerter.auth_msi_id` | Managed identity ID for the alerter (required when `alerter.enabled=true`) |
+| `alerter.alerter_address` | URL the alerter forwards alerts to (required when `alerter.enabled=true`) |
+
+### Container images
+
+Each component's image is configurable via `<component>.image.repository`, `<component>.image.tag`, and `<component>.image.pullPolicy`. When `repository` is null (default), it resolves to `<image_registry>/<component>`.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image_registry` | `ghcr.io/azure/adx-mon` | Default registry/repository prefix used when a component's `image.repository` is unset |
+| `<component>.image.repository` | `null` (uses `<image_registry>/<component>`) | Override image repository per component |
+| `<component>.image.tag` | `latest` | Image tag |
+| `<component>.image.pullPolicy` | `IfNotPresent` (`Always` for operator) | Pull policy |
+
+### Component resources
+
+Each component exposes a Kubernetes-style `resources` block. The collector also has a separate `singleton_resources` block for its singleton Deployment (cluster-wide scrape):
+
+```yaml
+collector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 2000Mi
+  singleton_resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 2000Mi
+```
+
+### Log destinations
+
+Each component routes its own logs to a configurable database/table via the `<component>.log_destination` value (format: `<database>:<table>`):
+
+| Key | Default |
+|-----|---------|
+| `collector.log_destination` | `Logs:Collector` |
+| `ingestor.log_destination` | `Logs:Ingestor` |
+| `alerter.log_destination` | `Logs:Alerter` |
+| `operator.log_destination` | `Logs:Operator` |
+
+### Collector config tunables
+
+A subset of collector config options are exposed under `collector.config`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `collector.config.max_connections` | `100` | Maximum number of connections to accept |
+| `collector.config.max_batch_size` | `10000` | Maximum number of samples per batch |
+| `collector.config.wal_flush_interval_ms` | `1000` | WAL flush interval (ms) |
+| `collector.config.metrics_database` | `Metrics` | Database for prometheus-scrape, prometheus-remote-write, and otel-metric |
+| `collector.config.logs_database` | `Logs` | Database for journal log targets |
+
+For deeper customization, replace `templates/collector-config.yaml` in your own values overlay or fork.
+
+### Other optional values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `cloud` | `azure` | Cloud identifier (e.g. `azure`, `azureusgovernment`) |
+| `adx.databases` | Logs + Metrics | Databases to route telemetry to, by type. Each entry has `name`, `telemetryType` (`Logs` or `Metrics`), and optional `retentionInDays` (default `30`). |
+| `collector.enabled` | `true` | Deploy the collector DaemonSet |
+| `collector.ingestor_endpoint` | `https://ingestor.<release-namespace>.svc.cluster.local` | Ingestor endpoint the collector forwards telemetry to. Leave unset to use the in-namespace default. |
+| `collector.insecure_skip_verify` | `true` | Skip TLS verification on the collector→ingestor connection. |
+| `ingestor.enabled` | `true` | Deploy the ingestor StatefulSet |
+| `ingestor.replicas` | `1` | Number of ingestor replicas |
+| `ingestor.insecure_skip_verify` | `true` | Skip TLS verification on the ingestor→ADX connection. |
+| `alerter.enabled` | `false` | Deploy the alerter |
+| `operator.enabled` | `false` | Deploy the operator |
+| `operator.client_id` | `null` | Azure Workload Identity client ID for the operator. Required when `operator.enabled=true`. |
+
+### ADX database routing
+
+Telemetry is routed to ADX databases based on the `adx.databases` list. Each entry specifies a database `name` and a `telemetryType` of either `Logs` or `Metrics`. Multiple databases of the same type are supported.
+
+```yaml
+adx:
+  name: my-adx-cluster
+  url: https://my-adx-cluster.eastus.kusto.windows.net
+  databases:
+    - name: Logs
+      telemetryType: Logs
+      retentionInDays: 30
+    - name: Metrics
+      telemetryType: Metrics
+      retentionInDays: 30
+```
+
+### Node affinity
+
+The ingestor, alerter, and operator all support optional node affinity via their respective `affinity` blocks:
+
+```yaml
+ingestor:
+  affinity:
+    required: true   # true = requiredDuringScheduling, false = preferred
+    key: agentpool
+    value: system
+```
+
+## CRDs
+
+The chart installs the following CRDs:
+
+- `adxclusters.adx-mon.azure.com`
+- `alerters.adx-mon.azure.com`
+- `alertrules.adx-mon.azure.com`
+- `collectors.adx-mon.azure.com`
+- `functions.adx-mon.azure.com`
+- `ingestors.adx-mon.azure.com`
+- `managementcommands.adx-mon.azure.com`
+- `metricsexporters.adx-mon.azure.com`
+- `summaryrules.adx-mon.azure.com`
+
+Each CRD carries the `helm.sh/resource-policy: keep` annotation, so `helm uninstall` leaves them (and any custom resources of those kinds) intact. To fully remove them, delete each CRD manually after uninstalling the release, e.g.:
+
+```bash
+kubectl delete crd \
+  adxclusters.adx-mon.azure.com \
+  alerters.adx-mon.azure.com \
+  alertrules.adx-mon.azure.com \
+  collectors.adx-mon.azure.com \
+  functions.adx-mon.azure.com \
+  ingestors.adx-mon.azure.com \
+  managementcommands.adx-mon.azure.com \
+  metricsexporters.adx-mon.azure.com \
+  summaryrules.adx-mon.azure.com
+```
+
+## Contributing
+
+This chart covers the core deployment scenario but contributions for additional use cases (custom TLS, additional ingress configurations, multi-cluster setups, etc.) are welcome. Please see [CONTRIBUTING.md](../../CONTRIBUTING.md) or open an issue at [Azure/adx-mon](https://github.com/Azure/adx-mon/issues).

--- a/charts/adx-mon/templates/_helpers.tpl
+++ b/charts/adx-mon/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+Resolve a component image reference. Usage: {{ include "adx-mon.image" (dict "image" .Values.collector.image "component" "collector" "registry" .Values.image_registry) }}
+*/}}
+{{- define "adx-mon.image" -}}
+{{- $image := .image -}}
+{{- $registry := .registry -}}
+{{- $repo := $image.repository | default (printf "%s/%s" $registry .component) -}}
+{{- $tag := $image.tag | default "latest" -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}

--- a/charts/adx-mon/templates/alerter.yaml
+++ b/charts/adx-mon/templates/alerter.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.alerter.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alerter
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: adx-mon:alerter
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - alertrules
+      - functions
+      - managementcommands
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - alertrules/status
+      - functions/status
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - alertrules/finalizers
+      - functions/finalizers
+    verbs:
+      - get
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: adx-mon:alerter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: adx-mon:alerter
+subjects:
+  - kind: ServiceAccount
+    name: alerter
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alerter
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: alerter
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alerter
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.alerter.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app: alerter
+  template:
+    metadata:
+      labels:
+        app: alerter
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/port: "8080"
+        adx-mon/path: "/metrics"
+        adx-mon/log-destination: {{ .Values.alerter.log_destination | quote }}
+        adx-mon/log-parsers: json
+    spec:
+      serviceAccountName: alerter
+      automountServiceAccountToken: true
+      priorityClassName: system-cluster-critical
+      {{- if .Values.alerter.affinity }}
+      {{- if .Values.alerter.affinity.required }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.alerter.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.alerter.affinity.value | default "system" }}
+      {{- else }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: {{ .Values.alerter.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.alerter.affinity.value | default "system" }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: alerter
+          image: {{ include "adx-mon.image" (dict "image" .Values.alerter.image "component" "alerter" "registry" .Values.image_registry) }}
+          imagePullPolicy: {{ .Values.alerter.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /alerter
+          args:
+            - "--alerter-address={{ required "alerter.alerter_address must be set when alerter.enabled=true" (.Values.alerter.alerter_address | default "" | trim) }}"
+            - "--port=8080"
+            - "--cloud={{ .Values.cloud }}"
+            - "--region={{ required "region must be set" (.Values.region | default "" | trim) }}"
+            - "--tag=environment={{ required "environment must be set" (.Values.environment | default "" | trim) }}"
+            - "--auth-msi-id={{ required "alerter.auth_msi_id must be set" (.Values.alerter.auth_msi_id | default "" | trim) }}"
+            {{- range .Values.adx.databases }}
+            - "--kusto-endpoint={{ .name }}={{ $.Values.adx.url }}"
+            {{- end }}
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: GODEBUG
+              value: http2client=0
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs
+              readOnly: true
+            - mountPath: /etc/pki/ca-trust/extracted
+              name: etc-pki-ca-certs
+              readOnly: true
+          resources:
+            {{- toYaml .Values.alerter.resources | nindent 12 }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: Directory
+        - name: etc-pki-ca-certs
+          hostPath:
+            path: /etc/pki/ca-trust/extracted
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/adx-mon/templates/collector-config.yaml
+++ b/charts/adx-mon/templates/collector-config.yaml
@@ -1,0 +1,244 @@
+{{- if .Values.collector.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.toml: |
+    # Ingestor URL to send collected telemetry.
+    endpoint = {{ .Values.collector.ingestor_endpoint | default (printf "https://ingestor.%s.svc.cluster.local" .Release.Namespace) | toToml }}
+
+    # Region is a location identifier
+    region = '{{ .Values.region }}'
+
+    # Skip TLS verification.
+    insecure-skip-verify = {{ .Values.collector.insecure_skip_verify | default true }}
+
+    # Address to listen on for endpoints.
+    listen-addr = ':8080'
+
+    # Maximum number of connections to accept.
+    max-connections = {{ .Values.collector.config.max_connections | default 100 }}
+
+    # Maximum number of samples to send in a single batch.
+    max-batch-size = {{ .Values.collector.config.max_batch_size | default 10000 }}
+
+    # Storage directory for the WAL.
+    storage-dir = '/mnt/data'
+
+    # Regexes of metrics to drop from all sources.
+    drop-metrics = {{ .Values.global_drop_metrics | default (list) | toToml }}
+    keep-metrics = {{ .Values.global_keep_metrics | default (list) | toToml }}
+
+    # Disable metrics forwarding to endpoints.
+    disable-metrics-forwarding = false
+
+    # WAL flush interval in milliseconds.  For collector it's lowered to reduce CPU usage since
+    # fewer metrics are in flight.
+    wal-flush-interval-ms = {{ .Values.collector.config.wal_flush_interval_ms | default 1000 }}
+
+    # Add target host,cluster and pod information as columns for tables in Metrics
+    # For metrics, adxmon_* take on the target pod's values
+    lift-labels = [
+      { name = 'host' },
+      { name = 'cluster' },
+      { name = 'adxmon_pod', column = 'Pod' },
+      { name = 'adxmon_namespace', column = 'Namespace' },
+      { name = 'adxmon_container', column = 'Container' },
+    ]
+
+    # Add target host,cluster and pod information as columns for tables in Logs
+    lift-resources = [
+      { name = 'host' },
+      { name = 'cluster' },
+      { name = 'pod', column = 'Pod' },
+      { name = 'namespace', column = 'Namespace' },
+      { name = 'container', column = 'Container' },
+    ]
+
+    # Key/value pairs of labels to add to all metrics and logs.
+    [add-labels]
+      host = '$(HOSTNAME)'
+      cluster = '{{ required "aks_cluster_name must be set" (.Values.aks_cluster_name | default "" | trim) }}'
+      cloud = '{{ .Values.cloud }}'
+      region = '{{ .Values.region }}'
+      environment = '{{ required "environment must be set" (.Values.environment | default "" | trim) }}'
+
+      # Database to store metrics in.
+      database = '{{ .Values.collector.config.metrics_database | default "Metrics" }}'
+
+      default-drop-metrics = false
+
+      # Defines a static scrape target.
+      static-scrape-target = [
+        # Scrape our own metrics
+        { host-regex = '.*', url = 'http://$(HOSTNAME):3100/metrics', namespace = '{{ .Release.Namespace }}', pod = 'collector', container = 'collector' },
+
+        # Scrape kubelet metrics
+        { host-regex = '.*', url = 'https://$(HOSTNAME):10250/metrics/cadvisor', namespace = 'kube-system', pod = 'kubelet', container = 'cadvisor' },
+        { host-regex = '.*', url = 'https://$(HOSTNAME):10250/metrics/resource', namespace = 'kube-system', pod = 'kubelet', container = 'resource' },
+      ]
+
+      # Scrape interval in seconds.
+      scrape-interval = 30
+
+      # Scrape timeout in seconds.
+      scrape-timeout = 25
+
+      # Disable metrics forwarding to endpoints.
+      disable-metrics-forwarding = false
+
+      # Regexes of metrics to keep from scraping source.
+      keep-metrics = []
+
+      # Regexes of metrics to drop from scraping source.
+      drop-metrics = []
+
+    # Defines a prometheus remote write endpoint.
+    [[prometheus-remote-write]]
+
+      # Database to store metrics in.
+      database = '{{ .Values.collector.config.metrics_database | default "Metrics" }}'
+
+      # The path to listen on for prometheus remote write requests.  Defaults to /receive.
+      path = '/receive'
+
+      # Regexes of metrics to drop.
+      drop-metrics = []
+
+      # Disable metrics forwarding to endpoints.
+      disable-metrics-forwarding = false
+
+      # Key/value pairs of labels to add to this source.
+      [prometheus-remote-write.add-labels]
+
+    # Defines an OpenTelemetry log endpoint.
+    [otel-log]
+      # Attributes lifted from the Body and added to Attributes.
+      lift-attributes = ['kusto.database', 'kusto.table']
+
+    [[otel-metric]]
+      # Database to store metrics in.
+      database = '{{ .Values.collector.config.metrics_database | default "Metrics" }}'
+      # The path to listen on for OTLP/HTTP requests.
+      path = '/v1/metrics'
+      # The port to listen on for OTLP/gRPC requests.
+      grpc-port = 4317
+      # Regexes of metrics to drop.
+      drop-metrics = []
+      # Regexes of metrics to keep.
+      keep-metrics = []
+      # List of exporter names to forward metrics to.
+      exporters = []
+
+    [[host-log]]
+      parsers = ['json']
+
+      journal-target = [
+        # matches are optional and are parsed like MATCHES in journalctl.
+        # If different fields are matched, only entries matching all terms are included.
+        # If the same fields are matched, entries matching any term are included.
+        # + can be added between to include a disjunction of terms.
+        # See examples under man 1 journalctl
+        { matches = [ '_SYSTEMD_UNIT=kubelet.service' ], database = '{{ .Values.collector.config.logs_database | default "Logs" }}', table = 'Kubelet' },
+        { matches = [ '_TRANSPORT=kernel' ], database = '{{ .Values.collector.config.logs_database | default "Logs" }}', table = 'Kernel' },
+        { matches = [ '_TRANSPORT=syslog' ], database = '{{ .Values.collector.config.logs_database | default "Logs" }}', table = 'Syslog' }
+      ]
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-singleton-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.toml: |
+    # Ingestor URL to send collected telemetry.
+    endpoint = {{ .Values.collector.ingestor_endpoint | default (printf "https://ingestor.%s.svc.cluster.local" .Release.Namespace) | toToml }}
+
+    # Region is a location identifier
+    region = '{{ .Values.region }}'
+
+    # Skip TLS verification.
+    insecure-skip-verify = {{ .Values.collector.insecure_skip_verify | default true }}
+
+    # Address to listen on for endpoints.
+    listen-addr = ':8080'
+
+    # Maximum number of connections to accept.
+    max-connections = {{ .Values.collector.config.max_connections | default 100 }}
+
+    # Maximum number of samples to send in a single batch.
+    max-batch-size = {{ .Values.collector.config.max_batch_size | default 10000 }}
+
+    # Storage directory for the WAL.
+    storage-dir = '/mnt/data/singleton'
+
+    # Regexes of metrics to drop from all sources.
+    drop-metrics = []
+
+    # Disable metrics forwarding to endpoints.
+    disable-metrics-forwarding = false
+
+    # WAL flush interval in milliseconds.  For collector it's lowered to reduce CPU usage since
+    # fewer metrics are in flight.
+    wal-flush-interval-ms = {{ .Values.collector.config.wal_flush_interval_ms | default 1000 }}
+
+    lift-labels = [
+      { name = 'host' },
+      { name = 'cluster' },
+      { name = 'adxmon_pod', column = 'Pod' },
+      { name = 'adxmon_namespace', column = 'Namespace' },
+      { name = 'adxmon_container', column = 'Container' },
+    ]
+
+    # Key/value pairs of labels to add to all metrics.
+    lift-resources = [
+      { name = 'host' },
+      { name = 'cluster' },
+      { name = 'adxmon_pod', column = 'Pod' },
+      { name = 'adxmon_namespace', column = 'Namespace' },
+      { name = 'adxmon_container', column = 'Container' },
+    ]
+
+    # Key/value pairs of labels to add to all metrics.
+    [add-labels]
+      host = '$(HOSTNAME)'
+      cluster = '{{ required "aks_cluster_name must be set" (.Values.aks_cluster_name | default "" | trim) }}'
+      cloud = '{{ .Values.cloud }}'
+      region = '{{ required "region must be set" (.Values.region | default "" | trim) }}'
+      environment = '{{ required "environment must be set" (.Values.environment | default "" | trim) }}'
+
+    # Defines a prometheus scrape endpoint.
+    [prometheus-scrape]
+
+      # Database to store metrics in.
+      database = '{{ .Values.collector.config.metrics_database | default "Metrics" }}'
+
+      default-drop-metrics = false
+
+      # Defines a static scrape target.
+      static-scrape-target = [
+        # Scrape api server endpoint
+        { host-regex = '.*', url = 'https://kubernetes.default.svc/metrics', namespace = 'kube-system', pod = 'kube-apiserver', container = 'kube-apiserver' },
+      ]
+
+      # Scrape interval in seconds.
+      scrape-interval = 30
+
+      # Scrape timeout in seconds.
+      scrape-timeout = 25
+
+      # Disable dynamic discovery of scrape targets.
+      disable-discovery = true
+
+      # Disable metrics forwarding to endpoints.
+      disable-metrics-forwarding = false
+
+      # Regexes of metrics to keep from scraping source.
+      drop-metrics = {{ .Values.singleton_drop_metrics | default (list) | toToml }}
+      keep-metrics = {{ .Values.singleton_keep_metrics | default (list) | toToml }}
+{{- end }}

--- a/charts/adx-mon/templates/collector.yaml
+++ b/charts/adx-mon/templates/collector.yaml
@@ -1,0 +1,260 @@
+{{- if .Values.collector.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: collector
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: adx-mon:collector
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes # required if reading node labels into metrics labels and logs attributes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: adx-mon:collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: adx-mon:collector
+subjects:
+  - kind: ServiceAccount
+    name: collector
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: collector
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      adxmon: collector
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        adxmon: collector
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/port: "9091"
+        adx-mon/path: "/metrics"
+        adx-mon/log-destination: {{ .Values.collector.log_destination | quote }}
+        adx-mon/log-parsers: json
+        configmap-hash: {{ include (print $.Template.BasePath "/collector-config.yaml") . | sha256sum }}
+    spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      serviceAccountName: collector
+      priorityClassName: system-node-critical
+      containers:
+        - name: collector
+          securityContext:
+            privileged: true
+          image: {{ include "adx-mon.image" (dict "image" .Values.collector.image "component" "collector" "registry" .Values.image_registry) }}
+          imagePullPolicy: {{ .Values.collector.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /collector
+          args:
+            - "--config=/etc/config/config.toml"
+            - "--hostname=$(HOSTNAME)"
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              hostPort: 3100
+            - containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "GODEBUG"
+              value: "http2client=0"
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs
+              readOnly: true
+            - mountPath: /etc/pki/ca-trust/extracted
+              name: etc-pki-ca-certs
+              readOnly: true
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage
+              mountPath: /mnt/data
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: runlog
+              mountPath: /run/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: etcmachineid
+              mountPath: /etc/machine-id
+              readOnly: true
+          resources:
+            {{- toYaml .Values.collector.resources | nindent 12 }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: Directory
+        - name: etc-pki-ca-certs
+          hostPath:
+            path: /etc/pki/ca-trust/extracted
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: collector-config
+        - name: storage
+          hostPath:
+            path: /mnt/collector
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: runlog  # used for non-persistent storage mode of journalctl
+          hostPath:
+            path: /run/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+            type: File
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector-singleton
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      adxmon: collector
+  template:
+    metadata:
+      labels:
+        adxmon: collector
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/port: "9091"
+        adx-mon/path: "/metrics"
+        adx-mon/log-destination: {{ .Values.collector.log_destination | quote }}
+        adx-mon/log-parsers: json
+        configmap-hash: {{ include (print $.Template.BasePath "/collector-config.yaml") . | sha256sum }}
+    spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      serviceAccountName: collector
+      priorityClassName: system-node-critical
+      containers:
+        - name: collector
+          image: {{ include "adx-mon.image" (dict "image" .Values.collector.image "component" "collector" "registry" .Values.image_registry) }}
+          imagePullPolicy: {{ .Values.collector.image.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /collector
+          args:
+            - "--config=/etc/config/config.toml"
+            - "--hostname=$(HOSTNAME)"
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "GODEBUG"
+              value: "http2client=0"
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: ssl-certs
+              readOnly: true
+            - mountPath: /etc/pki/ca-trust/extracted
+              name: etc-pki-ca-certs
+              readOnly: true
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage
+              mountPath: /mnt/data
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            {{- toYaml .Values.collector.singleton_resources | nindent 12 }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: Directory
+        - name: etc-pki-ca-certs
+          hostPath:
+            path: /etc/pki/ca-trust/extracted
+            type: DirectoryOrCreate
+        - name: config-volume
+          configMap:
+            name: collector-singleton-config
+        - name: storage
+          hostPath:
+            path: /mnt/collector
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+{{- end }}

--- a/charts/adx-mon/templates/crds/adxclusters_crd.yaml
+++ b/charts/adx-mon/templates/crds/adxclusters_crd.yaml
@@ -1,0 +1,302 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: adxclusters.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: ADXCluster
+    listKind: ADXClusterList
+    plural: adxclusters
+    singular: adxcluster
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ADXCluster is the Schema for the adxclusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ADXClusterSpec defines the desired state of ADXCluster
+            properties:
+              clusterName:
+                description: ClusterName is the unique, valid name for the ADX cluster.
+                  Must match ^[a-zA-Z0-9-]+$ and be at most 100 characters. Used for
+                  resource identification and naming in Azure.
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-]+$
+                type: string
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator cluster labels (region, environment, cloud, and any --cluster-labels key/value pairs).
+                  Every label is exposed as a string variable that can be referenced directly, for example:
+
+                    criteriaExpression: "region in ['eastus','westus'] && environment == 'prod'"
+
+                  Semantics:
+                    * Empty / omitted expression => the ADXCluster always reconciles.
+                    * When specified, the expression must evaluate to true for reconciliation; false skips quietly.
+                    * CEL parse, type-check, or evaluation errors are surfaced via status and block reconciliation
+                      until corrected.
+                type: string
+              databases:
+                description: Databases is an array of ADXClusterDatabaseSpec objects.
+                  Each object defines a database to be created in the ADX cluster.
+                  If not specified, no databases will be created.
+                items:
+                  properties:
+                    databaseName:
+                      description: ADX valid database name, required
+                      maxLength: 64
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9_]+$
+                      type: string
+                    retentionInDays:
+                      default: 30
+                      description: default 30, optional
+                      type: integer
+                    retentionPolicy:
+                      description: ADX retention policy, optional
+                      type: string
+                    telemetryType:
+                      description: 'TelemetryType: Required'
+                      enum:
+                      - Metrics
+                      - Logs
+                      - Traces
+                      type: string
+                  required:
+                  - databaseName
+                  - telemetryType
+                  type: object
+                type: array
+              endpoint:
+                description: 'Endpoint is the URI of an existing ADX cluster. When
+                  set, the controller treats the cluster as bring-your-own (no Azure
+                  provisioning is attempted). Example: "https://mycluster.kusto.windows.net"'
+                format: uri
+                type: string
+              federation:
+                description: Supports cluster partitioning. Only relevant if Role
+                  is set.
+                properties:
+                  federatedTargets:
+                    description: If role is "Partition", specifies the Federated cluster(s)
+                      details for heartbeating.
+                    items:
+                      properties:
+                        endpoint:
+                          description: 'Endpoint is the URI of the federated ADX cluster.
+                            Example: "https://mycluster.kusto.windows.net"'
+                          type: string
+                        heartbeatDatabase:
+                          pattern: ^[a-zA-Z0-9_]+$
+                          type: string
+                        heartbeatTable:
+                          pattern: ^[a-zA-Z0-9_]+$
+                          type: string
+                        managedIdentityClientId:
+                          description: Used for writing logs to the federated cluster.
+                          type: string
+                      required:
+                      - endpoint
+                      - heartbeatDatabase
+                      - heartbeatTable
+                      - managedIdentityClientId
+                      type: object
+                    type: array
+                  heartbeatDatabase:
+                    description: If role is "Federated", specifies the ADX cluster's
+                      heartbeat database.
+                    pattern: ^[a-zA-Z0-9_]+$
+                    type: string
+                  heartbeatTTL:
+                    default: 1h
+                    description: If role is "Federated", specifies the ADX cluster's
+                      heartbeat table TTL.
+                    pattern: ^(\d+h)?(\d+m)?(\d+s)?$
+                    type: string
+                  heartbeatTable:
+                    description: If role is "Federated", specifies the ADX cluster's
+                      heartbeat table.
+                    pattern: ^[a-zA-Z0-9_]+$
+                    type: string
+                  partitioning:
+                    additionalProperties:
+                      type: string
+                    description: If role is "Partition", specifies the ADX cluster's
+                      partition details.  Open-ended map/object for partitioning metadata
+                      (geo, location, tenant, etc.).
+                    type: object
+                type: object
+              provision:
+                description: Provision contains Azure provisioning details for the
+                  ADX cluster. Reconciliation of Azure resources only occurs when
+                  this section is provided. If omitted, the operator skips provisioning
+                  and treats the cluster as bring-your-own.
+                properties:
+                  autoScale:
+                    description: |-
+                      //+kubebuilder:default=false
+                      AutoScale indicates whether to enable auto-scaling for the ADX cluster. Optional. Defaults to false if not specified.
+                    type: boolean
+                  autoScaleMax:
+                    default: 10
+                    description: AutoScaleMax is the maximum number of nodes for auto-scaling.
+                      Optional. Defaults to 10 if not specified.
+                    type: integer
+                  autoScaleMin:
+                    default: 2
+                    description: AutoScaleMin is the minimum number of nodes for auto-scaling.
+                      Optional. Defaults to 2 if not specified.
+                    type: integer
+                  location:
+                    description: Location is the Azure region for the ADX cluster
+                      (e.g., "eastus2"). Required when the operator provisions the
+                      cluster and must be set explicitly by the user.
+                    type: string
+                  resourceGroup:
+                    description: ResourceGroup is the Azure resource group for the
+                      ADX cluster. This must be provided when provisioning is enabled;
+                      the operator no longer mutates the spec to fill this value.
+                    type: string
+                  skuName:
+                    description: SkuName is the Azure SKU for the ADX cluster (e.g.,
+                      "Standard_L8as_v3"). Required when provisioning is enabled;
+                      defaults are not applied automatically by the controller.
+                    type: string
+                  subscriptionId:
+                    description: SubscriptionId is the Azure subscription ID to use
+                      for provisioning. When the operator manages provisioning this
+                      value must be supplied explicitly; it is no longer auto-detected
+                      or defaulted by the controller.
+                    type: string
+                  tier:
+                    description: Tier is the Azure ADX tier (e.g., "Standard"). Required
+                      when provisioning is enabled; the operator no longer assigns
+                      a default.
+                    type: string
+                  userAssignedIdentities:
+                    description: |-
+                      UserAssignedIdentities is a list of MSIs that can be attached to the cluster. They should be resource-ids of the form
+                      /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                    items:
+                      type: string
+                    type: array
+                type: object
+              role:
+                description: 'Role specifies the cluster''s role: "Partition" (default,
+                  for data-holding clusters) or "Federated" (for the central federating
+                  cluster).'
+                enum:
+                - Partition
+                - Federated
+                type: string
+            required:
+            - clusterName
+            type: object
+          status:
+            description: ADXClusterStatus defines the observed state of ADXCluster
+            properties:
+              appliedProvisionState:
+                description: AppliedProvisionState captures the last Azure provisioning
+                  state reconciled by the controller.
+                properties:
+                  skuName:
+                    type: string
+                  tier:
+                    type: string
+                  userAssignedIdentities:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoint:
+                description: Endpoint reflects the observed Kusto endpoint when the
+                  controller manages provisioning, or mirrors spec.endpoint when running
+                  in BYO mode.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/alerters_crd.yaml
+++ b/charts/adx-mon/templates/crds/alerters_crd.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: alerters.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: Alerter
+    listKind: AlerterList
+    plural: alerters
+    singular: alerter
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Alerter is the Schema for the alerters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AlerterSpec defines the desired state of Alerter
+            properties:
+              adxClusterSelector:
+                description: ADXClusterSelector is a label selector used to select
+                  the ADXCluster CRDs this alerter should target. This field is required.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              appliedProvisionState:
+                description: |-
+                  AppliedProvisionState is a JSON-serialized snapshot of the CRD
+                  as last applied by the operator. This is set by the operator and is read-only for users.
+                type: string
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator cluster labels (region, environment, cloud, and any --cluster-labels key/value pairs).
+                  All labels are exposed as string variables that can be referenced directly. Example:
+
+                    criteriaExpression: "region == 'eastus' && environment == 'prod'"
+
+                  Semantics:
+                    * Empty / omitted expression => the Alerter always reconciles.
+                    * When specified, the expression must evaluate to true for reconciliation; false skips quietly.
+                    * CEL parse, type-check, or evaluation errors surface via status and block reconciliation until
+                      corrected.
+                type: string
+              image:
+                description: Image is the container image to use for the alerter component.
+                  Optional; if omitted, a default image will be used.
+                type: string
+              notificationEndpoint:
+                description: NotificationEndpoint is the URI where alert notifications
+                  will be sent. This field is required.
+                format: uri
+                type: string
+            required:
+            - adxClusterSelector
+            - notificationEndpoint
+            type: object
+          status:
+            description: AlerterStatus defines the observed state of Alerter
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/alertrules_crd.yaml
+++ b/charts/adx-mon/templates/crds/alertrules_crd.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: alertrules.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: AlertRule
+    listKind: AlertRuleList
+    plural: alertrules
+    singular: alertrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AlertRule is the Schema for the alertrules API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AlertRuleSpec defines the desired state of AlertRule
+            properties:
+              autoMitigateAfter:
+                type: string
+                x-kubernetes-validations:
+                - message: autoMitigateAfter must be a valid duration
+                  rule: self == '' || duration(self) >= duration('0s')
+              criteria:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Key/Value pairs used to determine when an alert can execute.  If empty, always execute.  Keys and values
+                  are deployment specific and configured on alerter instances.  For example, an alerter instance may be
+                  started with `--tag cloud=public`. If an AlertRule has `criteria: {cloud: public}`, then the rule will only
+                  execute on that alerter. Any key/values pairs must match (case-insensitive) for the rule to execute.
+                type: object
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression that provides a richer way
+                  to determine if the alert should execute. The CEL environment is dynamically constructed from the alerter's
+                  execution context (cloud, region, and any --tag key/value pairs). All variables are exposed as strings and
+                  can be referenced directly by their tag name. For example:
+
+                    criteriaExpression: "cloud == 'public' && region in ['eastus','westus'] && env == 'prod'"
+
+                  Execution semantics:
+                    * If neither criteria nor criteriaExpression are specified, the rule always executes.
+                    * If only criteriaExpression is specified, it must evaluate to true for the rule to execute.
+                    * If only criteria (map) is specified, existing matching behavior (any key/value match) applies.
+                    * If both are specified, the rule executes when BOTH the criteria map matches AND the expression evaluates to true.
+
+                  An invalid expression (parse or type check error) will treated as an error and prevent the rule from executing.
+                type: string
+              database:
+                type: string
+              destination:
+                type: string
+              interval:
+                type: string
+                x-kubernetes-validations:
+                - message: interval must be a valid positive duration
+                  rule: self == '' || duration(self) > duration('0s')
+              query:
+                type: string
+            type: object
+          status:
+            description: AlertRuleStatus defines the observed state of AlertRule
+            properties:
+              conditions:
+                description: |-
+                  Conditions provide standardized status signaling. Controllers may
+                  set shared conditions defined in conditions.go such as ConditionCriteria
+                  to reflect evaluation of Spec.Criteria / Spec.CriteriaExpression.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAlertTime:
+                format: date-time
+                type: string
+              lastQueryTime:
+                format: date-time
+                type: string
+              message:
+                type: string
+              status:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/collectors_crd.yaml
+++ b/charts/adx-mon/templates/crds/collectors_crd.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: collectors.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: Collector
+    listKind: CollectorList
+    plural: collectors
+    singular: collector
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Collector is the Schema for the collectors API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CollectorSpec defines the desired state of Collector
+            properties:
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator cluster labels (region, environment, cloud, and any --cluster-labels key/value pairs).
+                  All labels are exposed as string variables. Example:
+
+                    criteriaExpression: "environment == 'prod' && region == 'eastus'"
+
+                  Semantics:
+                    * Empty / omitted expression => the Collector always reconciles.
+                    * When specified, the expression must evaluate to true for reconciliation; false skips quietly.
+                    * CEL parse, type-check, or evaluation errors surface via status and block reconciliation until
+                      corrected.
+                type: string
+              image:
+                description: Image is the container image to use for the collector
+                  component. Optional; if omitted, a default image will be used.
+                type: string
+              ingestorEndpoint:
+                description: IngestorEndpoint is the URI endpoint for the ingestor
+                  service that this collector should send data to. Optional; if omitted,
+                  the operator will configure it automatically.
+                format: uri
+                type: string
+            type: object
+          status:
+            description: CollectorStatus defines the observed state of Collector
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/functions_crd.yaml
+++ b/charts/adx-mon/templates/crds/functions_crd.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: functions.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: Function
+    listKind: FunctionList
+    plural: functions
+    singular: function
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Function defines a KQL function to be maintained in the Kusto
+          cluster
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FunctionSpec defines the desired state of Function
+            properties:
+              allDatabases:
+                description: |-
+                  AllDatabases indicates whether the function should be applied to all databases.
+                  When true, the Database field should be empty. Mutually exclusive with a specific
+                  database name in the Database field.
+                type: boolean
+              appliedEndpoint:
+                description: |-
+                  AppliedEndpoint is a JSON-serialized of the endpoints that the function
+                  is applied to. This is set by the operator and is read-only for users.
+                type: string
+              body:
+                description: Body is the KQL body of the function
+                type: string
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator cluster labels (region, environment, cloud, and any --cluster-labels key/value pairs).
+                  Every label is exposed as a string variable. Example:
+
+                    criteriaExpression: "environment == 'prod' && region in ['eastus','westus']"
+
+                  Semantics:
+                    * Empty / omitted expression => the Function always reconciles.
+                    * When specified, the expression must evaluate to true for reconciliation; false skips quietly.
+                    * CEL parse, type-check, or evaluation errors surface via status and block reconciliation until
+                      corrected.
+                type: string
+              database:
+                description: |-
+                  Database is the name of the database in which the function will be created.
+                  Deprecated: Use of wildcard "*" is deprecated; use AllDatabases field instead.
+                  Mutually exclusive with AllDatabases when a specific database name is provided.
+                type: string
+              suspend:
+                description: |-
+                  This flag tells the controller to suspend subsequent executions, it does
+                  not apply to already started executions.  Defaults to false.
+                type: boolean
+            required:
+            - body
+            type: object
+          status:
+            description: FunctionStatus defines the observed state of Function
+            properties:
+              conditions:
+                description: |-
+                  Conditions conveys detailed reconciliation state in a Kubernetes-native format.
+                  Controllers set FunctionCriteriaMatch to surface criteria gating decisions and
+                  FunctionReconciled to report the outcome of the most recent reconciliation attempt.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              error:
+                description: Error is a string that communicates any error message
+                  if one exists
+                type: string
+              lastTimeReconciled:
+                description: LastTimeReconciled is the last time the Function was
+                  reconciled
+                format: date-time
+                type: string
+              message:
+                description: Message is a human-readable message indicating details
+                  about the Function
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this Function
+                format: int64
+                type: integer
+              reason:
+                description: Reason is a string that communicates the reason for a
+                  transition
+                type: string
+              status:
+                description: Status is an enum that represents the status of the Function
+                type: string
+            required:
+            - lastTimeReconciled
+            - observedGeneration
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/ingestors_crd.yaml
+++ b/charts/adx-mon/templates/crds/ingestors_crd.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: ingestors.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: Ingestor
+    listKind: IngestorList
+    plural: ingestors
+    singular: ingestor
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Ingestor is the Schema for the ingestors API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngestorSpec defines the desired state of Ingestor
+            properties:
+              adxClusterSelector:
+                description: ADXClusterSelector is a label selector used to select
+                  the ADXCluster CRDs this ingestor should target. This field is required.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              appliedProvisionState:
+                description: |-
+                  AppliedProvisionState is a JSON-serialized snapshot of the CRD
+                  as last applied by the operator. This is set by the operator and is read-only for users.
+                type: string
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator cluster labels (region, environment, cloud, and any --cluster-labels key/value pairs).
+                  All labels are exposed as string variables. Example:
+
+                    criteriaExpression: "environment == 'prod' && region == 'eastus'"
+
+                  Semantics:
+                    * Empty / omitted expression => the Ingestor always reconciles.
+                    * When specified, the expression must evaluate to true for reconciliation; false skips quietly.
+                    * CEL parse, type-check, or evaluation errors surface via status and block reconciliation until
+                      corrected.
+                type: string
+              endpoint:
+                description: Endpoint is the endpoint to use for the ingestor. If
+                  running in a cluster, this should be the service name; otherwise,
+                  the operator will generate an endpoint. Optional.
+                type: string
+              exposeExternally:
+                default: false
+                description: ExposeExternally indicates if the ingestor should be
+                  exposed externally as reflected in the Endpoint. Optional; defaults
+                  to false.
+                type: boolean
+              image:
+                description: Image is the container image to use for the ingestor
+                  component. Optional; if omitted, a default image will be used.
+                type: string
+              replicas:
+                default: 1
+                description: Replicas is the number of ingestor replicas to run. Optional;
+                  defaults to 1 if omitted.
+                format: int32
+                type: integer
+            required:
+            - adxClusterSelector
+            type: object
+          status:
+            description: IngestorStatus defines the observed state of Ingestor
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/managementcommands_crd.yaml
+++ b/charts/adx-mon/templates/crds/managementcommands_crd.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: managementcommands.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: ManagementCommand
+    listKind: ManagementCommandList
+    plural: managementcommands
+    singular: managementcommand
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ManagementCommand is the Schema for the managementcommands API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagementCommandSpec defines the desired state of ManagementCommand
+            properties:
+              body:
+                description: Body is the management command to execute
+                type: string
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression evaluated against
+                  operator / ingestor cluster labels (region, environment, cloud, and any --cluster-labels key/value
+                  pairs). All labels are exposed as string variables. Example:
+
+                    criteriaExpression: "environment == 'prod' && region == 'eastus'"
+
+                  Semantics:
+                    * Empty / omitted expression => the ManagementCommand always executes when selected.
+                    * When specified, the expression must evaluate to true; false skips execution.
+                    * CEL parse, type-check, or evaluation errors surface via status and block execution until
+                      corrected.
+                type: string
+              database:
+                description: |-
+                  Database is the target database for a management command. Not all management commands
+                  are database specific. When non-empty, this field takes precedence over Scope.
+                  Deprecated: For cluster-scoped commands, use Scope: Cluster instead of leaving empty.
+                type: string
+              scope:
+                description: |-
+                  Scope defines the execution scope of the management command.
+                  - "Database": Command targets the database specified in the Database field (requires Database)
+                  - "AllDatabases": Command is applied to all databases in the cluster
+                  - "Cluster": Command is cluster-scoped (e.g., cluster policies)
+                  When Database field is non-empty, it takes precedence over this field for backwards compatibility.
+                enum:
+                - Database
+                - AllDatabases
+                - Cluster
+                type: string
+            required:
+            - body
+            type: object
+          status:
+            description: ManagementCommandStatus defines the observed state of ManagementCommand
+            properties:
+              conditions:
+                description: Conditions is a list of conditions that apply to the
+                  Function
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/metricsexporters_crd.yaml
+++ b/charts/adx-mon/templates/crds/metricsexporters_crd.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: metricsexporters.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: MetricsExporter
+    listKind: MetricsExporterList
+    plural: metricsexporters
+    singular: metricsexporter
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: MetricsExporter is the Schema for the metricsexporters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MetricsExporterSpec defines the desired state of MetricsExporter
+            properties:
+              body:
+                description: Body is the KQL query to execute
+                type: string
+              criteria:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Criteria for cluster-based execution selection (same pattern as SummaryRule)
+                  Key/Value pairs used to determine when a metrics exporter can execute. If empty, always execute. Keys and values
+                  are deployment specific and configured on adxexporter instances. For example, an adxexporter instance may be
+                  started with `--cluster-labels=region=eastus,environment=production`. If a MetricsExporter has `criteria: {region: [eastus], environment: [production]}`, then the rule will only
+                  execute on that adxexporter. Any key/values pairs must match (case-insensitive) for the rule to execute.
+                type: object
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression that provides a richer way
+                  to determine if the metrics exporter should execute. The CEL environment is dynamically constructed from the
+                  exporter's cluster labels (e.g. region, cloud, environment, and any --cluster-labels key/value pairs). All variables
+                  are exposed as strings and can be referenced directly by their label name. For example:
+
+                    criteriaExpression: "region in ['eastus','westus'] && environment == 'prod'"
+
+                  Execution semantics mirror AlertRule:
+                    * If neither criteria nor criteriaExpression are specified, the exporter always executes.
+                    * If only criteriaExpression is specified, it must evaluate to true for execution.
+                    * If only criteria is specified, existing matching behavior (any key/value match) applies.
+                    * If both are specified, BOTH must match (criteria map match AND expression true).
+
+                  An invalid expression (parse or type check error) will be treated as an error and prevent execution.
+                type: string
+              database:
+                description: Database is the name of the database to query
+                type: string
+              interval:
+                description: Interval defines how often to execute the query and refresh
+                  metrics
+                type: string
+              transform:
+                description: Transform defines how to convert query results to metrics
+                properties:
+                  defaultMetricName:
+                    description: DefaultMetricName provides a fallback if MetricNameColumn
+                      is not specified
+                    type: string
+                  labelColumns:
+                    description: LabelColumns specifies columns to use as metric labels
+                    items:
+                      type: string
+                    type: array
+                  metricNameColumn:
+                    description: MetricNameColumn specifies which column contains
+                      the metric name
+                    type: string
+                  metricNamePrefix:
+                    description: MetricNamePrefix provides optional team/project namespacing
+                      for all metrics
+                    type: string
+                  timestampColumn:
+                    description: TimestampColumn specifies which column contains the
+                      timestamp
+                    type: string
+                  valueColumns:
+                    description: ValueColumns specifies columns to use as metric values
+                    items:
+                      type: string
+                    type: array
+                required:
+                - timestampColumn
+                - valueColumns
+                type: object
+            required:
+            - body
+            - database
+            - interval
+            - transform
+            type: object
+          status:
+            description: MetricsExporterStatus defines the observed state of MetricsExporter
+            properties:
+              conditions:
+                description: |-
+                  Conditions is an array of current observed MetricsExporter conditions.
+                  Controllers set at minimum the owner condition (MetricsExporterOwner) and may also
+                  use shared conditions defined in conditions.go: ConditionCriteria, ConditionCompleted, ConditionFailed.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/crds/summaryrules_crd.yaml
+++ b/charts/adx-mon/templates/crds/summaryrules_crd.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  name: summaryrules.adx-mon.azure.com
+spec:
+  group: adx-mon.azure.com
+  names:
+    kind: SummaryRule
+    listKind: SummaryRuleList
+    plural: summaryrules
+    singular: summaryrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SummaryRule is the Schema for the summaryrules API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SummaryRuleSpec defines the desired state of SummaryRule
+            properties:
+              body:
+                description: Body is the KQL body of the function
+                type: string
+              criteria:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Key/Value pairs used to determine when a summary rule can execute. If empty, always execute. Keys and values
+                  are deployment specific and configured on ingestor instances. For example, an ingestor instance may be
+                  started with `--cluster-labels=region=eastus`. If a SummaryRule has `criteria: {region: [eastus]}`, then the rule will only
+                  execute on that ingestor. Any key/values pairs must match (case-insensitive) for the rule to execute.
+                type: object
+              criteriaExpression:
+                description: |-
+                  CriteriaExpression is an optional CEL (Common Expression Language) expression that provides a richer way
+                  to determine if the summary rule should execute. The CEL environment is dynamically constructed from the
+                  ingestor's cluster labels (e.g. region, cloud, and any --cluster-labels key/value pairs). All variables are
+                  exposed as strings and can be referenced directly by their label name. For example:
+
+                    criteriaExpression: "region in ['eastus','westus'] && environment == 'prod'"
+
+                  Execution semantics:
+                    * If neither criteria nor criteriaExpression are specified, the rule always executes.
+                    * If only criteriaExpression is specified, it must evaluate to true for the rule to execute.
+                    * If only criteria (map) is specified, existing matching behavior (any key/value match) applies.
+                    * If both are specified, the rule executes when BOTH the criteria map matches AND the expression evaluates to true.
+
+                  An invalid expression (parse or type check error) will be treated as an error and prevent the rule from executing.
+                type: string
+              database:
+                description: Database is the name of the database in which the function
+                  will be created
+                type: string
+              ingestionDelay:
+                description: |-
+                  IngestionDelay is subtracted from the execution window start and end times to account
+                  for data ingestion latency, ensuring the query only processes fully ingested data.
+                  NOTE: Current implementation also subtracts this delay from the "now" used to decide
+                  whether an interval has elapsed (i.e. scheduling readiness). This effectively lengthens
+                  wall‑clock spacing between executions to Interval + IngestionDelay. If you intend only
+                  to shift the processed window but keep wall‑clock cadence at Interval, this behavior
+                  will be adjusted in a future release.
+                type: string
+                x-kubernetes-validations:
+                - message: ingestionDelay must be a valid duration
+                  rule: self == '' || duration(self) >= duration('0s')
+              interval:
+                description: Interval is the cadence at which the rule will be executed
+                type: string
+                x-kubernetes-validations:
+                - message: interval must be a valid positive duration
+                  rule: duration(self) > duration('0s')
+              name:
+                description: Name is the name of the rule (deprecated and not used
+                  - use `metadata.name` instead)
+                type: string
+              table:
+                description: Table is rule output destination
+                type: string
+              backfill:
+                description: Backfill optionally specifies a historical time range to
+                  process.
+                type: object
+                properties:
+                  requestId:
+                    description: RequestID is a user-chosen identifier for this backfill
+                      request. The same RequestID resumes an in-progress backfill; a
+                      new RequestID starts a fresh backfill.
+                    minLength: 1
+                    type: string
+                  startTime:
+                    description: StartTime is the inclusive start of the historical
+                      range to backfill.
+                    format: date-time
+                    type: string
+                  endTime:
+                    description: EndTime is the exclusive end of the historical range
+                      to backfill.
+                    format: date-time
+                    type: string
+                  maxInFlight:
+                    description: MaxInFlight limits the number of concurrent async
+                      operations for backfill windows. Defaults to 1 if unset or zero.
+                      Values greater than 20 are rejected to keep historical processing
+                      throttled.
+                    maximum: 20
+                    type: integer
+                    minimum: 0
+                required:
+                - requestId
+                - startTime
+                - endTime
+            required:
+            - body
+            - database
+            - interval
+            - table
+            type: object
+          status:
+            description: SummaryRuleStatus defines the observed state of Function
+            properties:
+              conditions:
+                description: |-
+                  Conditions is an array of current observed SummaryRule conditions.
+                  SummaryRule controllers set at minimum the owner condition (SummaryRuleOwner) and may also
+                  use shared conditions defined in conditions.go: ConditionCriteria, ConditionCompleted, ConditionFailed.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              backfill:
+                description: Backfill tracks the progress of a user-requested historical
+                  backfill.
+                type: object
+                properties:
+                  requestId:
+                    type: string
+                  phase:
+                    type: string
+                    enum:
+                    - Pending
+                    - Running
+                    - Completed
+                    - Failed
+                  observedGeneration:
+                    type: integer
+                    format: int64
+                  nextWindowStart:
+                    type: string
+                    format: date-time
+                  submittedWindows:
+                    type: integer
+                  completedWindows:
+                    type: integer
+                  retriedWindows:
+                    type: integer
+                  activeOperations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        operationId:
+                          type: string
+                        startTime:
+                          type: string
+                        endTime:
+                          type: string
+                  message:
+                    type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/adx-mon/templates/ingestor.yaml
+++ b/charts/adx-mon/templates/ingestor.yaml
@@ -1,0 +1,238 @@
+{{- if .Values.ingestor.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ingestor
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.ingestor.client_id }}
+  annotations:
+    azure.workload.identity/client-id: {{ .Values.ingestor.client_id | quote }}
+  {{- end }}
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: adx-mon:ingestor
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - functions
+      - managementcommands
+      - summaryrules
+    verbs:
+      - get
+      - list
+      - update
+      - patch
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - functions/status
+      - managementcommands/status
+      - summaryrules/status
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - functions/finalizers
+      - managementcommands/finalizers
+      - summaryrules/finalizers
+    verbs:
+      - get
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: adx-mon:ingestor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: adx-mon:ingestor
+subjects:
+  - kind: ServiceAccount
+    name: ingestor
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingestor
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: ingestor
+  ports:
+    # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+    - port: 443
+      targetPort: 9090
+      # Optional field
+      # By default and for convenience, the Kubernetes control plane will allocate a port from a range (default: 30000-32767)
+      #nodePort: 30007
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ingestor
+  namespace: {{ .Release.Namespace }}
+spec:
+  serviceName: ingestor
+  replicas: {{ .Values.ingestor.replicas | default 1 }}
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ingestor
+  template:
+    metadata:
+      labels:
+        app: ingestor
+        {{- if .Values.ingestor.client_id }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/port: "9091"
+        adx-mon/path: "/metrics"
+        adx-mon/log-destination: {{ .Values.ingestor.log_destination | quote }}
+        adx-mon/log-parsers: json
+    spec:
+      automountServiceAccountToken: true
+      securityContext: {}
+      serviceAccountName: ingestor
+      priorityClassName: system-node-critical
+      containers:
+        - name: ingestor
+          image: {{ include "adx-mon.image" (dict "image" .Values.ingestor.image "component" "ingestor" "registry" .Values.image_registry) }}
+          imagePullPolicy: {{ .Values.ingestor.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 9090
+              name: ingestor
+            - containerPort: 9091
+              name: metrics
+          env:
+            - name: LOG_LEVEL
+              value: INFO
+            - name: "GODEBUG"
+              value: "http2client=0"
+            - name: "AZURE_RESOURCE"
+              value: {{ required "adx.url must be set" (.Values.adx.url | default "" | trim) | quote }}
+            - name:  "AZURE_CLIENT_ID"
+              value: {{ required "ingestor.client_id must be set" (.Values.ingestor.client_id | default "" | trim) | quote }}
+          command:
+            - /ingestor
+          args:
+            - "--storage-dir=/mnt/data"
+            - "--max-segment-age=5s"
+            - "--max-disk-usage=21474836480"
+            - "--max-transfer-size=10485760"
+            - "--max-connections=8000"
+            {{- if .Values.ingestor.insecure_skip_verify }}
+            - "--insecure-skip-verify"
+            {{- end }}
+            {{- range .Values.adx.databases }}
+            {{- if eq .telemetryType "Metrics" }}
+            - "--metrics-kusto-endpoints={{ .name }}={{ $.Values.adx.url }}"
+            {{- end }}
+            {{- if eq .telemetryType "Logs" }}
+            - "--logs-kusto-endpoints={{ .name }}={{ $.Values.adx.url }}"
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: metrics
+              mountPath: /mnt/data
+            - mountPath: /etc/pki/ca-trust/extracted
+              name: etc-pki-ca-certs
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.ingestor.resources | nindent 12 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - ingestor
+              topologyKey: kubernetes.io/hostname
+        {{- if .Values.ingestor.affinity }}
+        {{- if .Values.ingestor.affinity.required }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.ingestor.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.ingestor.affinity.value | default "system" }}
+        {{- else }}
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: {{ .Values.ingestor.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.ingestor.affinity.value | default "system" }}
+        {{- end }}
+        {{- end }}
+      volumes:
+        - name: ca-certs
+          hostPath:
+            path: /etc/ssl/certs
+            type: Directory
+        - name: etc-pki-ca-certs
+          hostPath:
+            path: /etc/pki/ca-trust/extracted
+            type: DirectoryOrCreate
+        - name: metrics
+          hostPath:
+            path: /mnt/ingestor
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+{{- end }}

--- a/charts/adx-mon/templates/operator.yaml
+++ b/charts/adx-mon/templates/operator.yaml
@@ -1,0 +1,235 @@
+{{- if .Values.operator.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: {{ required "operator.client_id must be set when operator.enabled=true" (.Values.operator.client_id | default "" | trim) | quote }}
+  name: operator
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: adx-mon:operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - adxclusters
+      - alerters
+      - alertrules
+      - collectors
+      - functions
+      - ingestors
+      - managementcommands
+      - metricsexporters
+      - summaryrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - adxclusters/status
+      - alerters/status
+      - alertrules/status
+      - collectors/status
+      - functions/status
+      - ingestors/status
+      - managementcommands/status
+      - metricsexporters/status
+      - summaryrules/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - adx-mon.azure.com
+    resources:
+      - adxclusters/finalizers
+      - alerters/finalizers
+      - alertrules/finalizers
+      - collectors/finalizers
+      - functions/finalizers
+      - ingestors/finalizers
+      - managementcommands/finalizers
+      - metricsexporters/finalizers
+      - summaryrules/finalizers
+    verbs:
+      - get
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: adx-mon:operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: adx-mon:operator
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operator
+  template:
+    metadata:
+      annotations:
+        adx-mon/scrape: "true"
+        adx-mon/log-destination: {{ .Values.operator.log_destination | quote }}
+        adx-mon/log-parsers: json
+      labels:
+        app: operator
+        azure.workload.identity/use: "true"
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: operator
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 65534
+      containers:
+        - name: operator
+          image: {{ include "adx-mon.image" (dict "image" .Values.operator.image "component" "operator" "registry" .Values.image_registry) }}
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy | default "Always" }}
+          args:
+            - --pprof-bind-address=:6060
+          ports:
+            - containerPort: 6060
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      {{- if .Values.operator.affinity }}
+      {{- if .Values.operator.affinity.required }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.operator.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.operator.affinity.value | default "system" }}
+      {{- else }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: {{ .Values.operator.affinity.key | default "agentpool"}}
+                    operator: In
+                    values:
+                      - {{ .Values.operator.affinity.value | default "system" }}
+      {{- end }}
+      {{- end }}
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 300
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 300
+---
+apiVersion: adx-mon.azure.com/v1
+kind: ADXCluster
+metadata:
+  name: {{ required "adx.name must be set" (.Values.adx.name | default "" | trim) }}
+spec:
+  clusterName: {{ .Values.adx.name }}
+  databases:
+  {{- range .Values.adx.databases }}
+  - databaseName: {{ .name }}
+    retentionInDays: {{ .retentionInDays | default 30 }}
+    telemetryType: {{ .telemetryType }}
+  {{- end }}
+  endpoint: {{ .Values.adx.url }}
+  federation:
+    # Hub clusters
+    federatedTargets:
+    - endpoint: {{ required "adx_hub_url must be set" (.Values.adx_hub_url | default "" | trim) }}
+      heartbeatDatabase: Federation
+      heartbeatTable: Heartbeats
+      # Empty string uses DefaultAzureCredential for all authentication and authorization.
+      # To use a specific managed identity, set this to the client ID of the identity.
+      # See: https://github.com/Azure/adx-mon/blob/main/docs/adxcluster-controller.md#partition-clusters
+      # Tracking workload identity support: https://github.com/Azure/adx-mon/issues/1073
+      managedIdentityClientId: ""
+    heartbeatTTL: 1h
+    partitioning:
+      region: {{ required "region must be set" (.Values.region | default "" | trim) }}
+  role: Partition
+{{- end }}

--- a/charts/adx-mon/values.yaml
+++ b/charts/adx-mon/values.yaml
@@ -1,0 +1,121 @@
+---
+aks_cluster_name: null
+region: null
+cloud: azure
+environment: null
+global_drop_metrics: []
+global_keep_metrics: []
+singleton_drop_metrics: []
+singleton_keep_metrics: []
+adx:
+  name: null
+  url: null
+  databases:
+    - name: Logs
+      telemetryType: Logs
+      retentionInDays: 30
+    - name: Metrics
+      telemetryType: Metrics
+      retentionInDays: 30
+adx_hub_url: null
+
+# Default container image registry/repository prefix. Each component's
+# `image.repository` defaults to `<image_registry>/<component>` and can be
+# overridden individually.
+image_registry: ghcr.io/azure/adx-mon
+
+collector:
+  enabled: true
+  # Defaults to https://ingestor.<release-namespace>.svc.cluster.local when unset.
+  ingestor_endpoint: null
+  insecure_skip_verify: true
+  log_destination: "Logs:Collector"
+  image:
+    repository: null  # defaults to <image_registry>/collector
+    tag: latest
+    pullPolicy: IfNotPresent
+  # Resources for the per-node DaemonSet collectors.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 2000Mi
+  # Resources for the singleton Deployment collector (cluster-wide scrapes).
+  singleton_resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 2000Mi
+  # Collector config options surfaced to Helm. See pkg/collector for full reference.
+  config:
+    max_connections: 100
+    max_batch_size: 10000
+    wal_flush_interval_ms: 1000
+    metrics_database: Metrics
+    logs_database: Logs
+
+ingestor:
+  enabled: true
+  replicas: 1
+  affinity:
+    required: false
+    key: agentpool
+    value: system
+  client_id: null
+  insecure_skip_verify: true
+  log_destination: "Logs:Ingestor"
+  image:
+    repository: null  # defaults to <image_registry>/ingestor
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+alerter:
+  enabled: false
+  replicas: 1
+  affinity:
+    required: false
+    key: agentpool
+    value: system
+  auth_msi_id: null
+  log_destination: "Logs:Alerter"
+  # Address of the notifier service the alerter forwards alerts to. Required
+  # when alerter.enabled=true.
+  alerter_address: null
+  image:
+    repository: null  # defaults to <image_registry>/alerter
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+operator:
+  enabled: false
+  # Azure Workload Identity client ID for the operator. Required when
+  # operator.enabled=true.
+  client_id: null
+  affinity:
+    required: false
+    key: agentpool
+    value: system
+  log_destination: "Logs:Operator"
+  image:
+    repository: null  # defaults to <image_registry>/operator
+    tag: latest
+    pullPolicy: Always
+  resources: {}


### PR DESCRIPTION
## Summary

Adds a Helm chart for deploying adx-mon components under `charts/adx-mon/`. Chart version `0.2.0-alpha`, appVersion `0.2.0`.

## Chart contents

**Templates:** collector (DaemonSet + singleton Deployment + ConfigMaps), ingestor (StatefulSet + Service), alerter, operator

**CRDs:** `adxclusters`, `alerters`, `alertrules`, `collectors`, `functions`, `ingestors`, `managementcommands`, `metricsexporters`, `summaryrules` — each annotated with `helm.sh/resource-policy: keep` so `helm uninstall` leaves them (and existing CRs) intact.

## ADX database routing

A single `adx.databases` list drives Kusto endpoint routing across ingestor, alerter, and the `ADXCluster` CR. Each entry has `name`, `telemetryType` (`Logs` or `Metrics`), and optional `retentionInDays` (default `30`).

```yaml
adx:
  name: my-adx-cluster
  url: https://my-adx-cluster.eastus.kusto.windows.net
  databases:
    - name: Logs
      telemetryType: Logs
      retentionInDays: 30
    - name: Metrics
      telemetryType: Metrics
      retentionInDays: 30
```

## Required values

All of the following must be provided at install time — missing values produce a clear `required`-message error at render time. `required` runs before `trim` (via `| default "" | trim`) so null defaults don’t blow up inside `trim`.

| Key | Description |
|-----|-------------|
| `aks_cluster_name` | Name of the AKS cluster |
| `region` | Azure region (e.g. `eastus`) |
| `environment` | Environment tag (e.g. `prod`) |
| `adx.name` | ADX cluster name |
| `adx.url` | ADX cluster endpoint URL |
| `adx_hub_url` | ADX hub/federation cluster endpoint URL |
| `ingestor.client_id` | Workload Identity client ID; must have **Database Admin** on each ADX database |
| `alerter.auth_msi_id` | Managed identity ID for the alerter (when `alerter.enabled=true`) |
| `alerter.alerter_address` | Notifier URL the alerter forwards alerts to (when `alerter.enabled=true`) |
| `operator.client_id` | Workload Identity client ID for the operator (when `operator.enabled=true`) |

## Configurability

Knobs surfaced through `values.yaml`:

- **Container images** — `image_registry` (default `ghcr.io/azure/adx-mon`) plus per-component `image.{repository,tag,pullPolicy}`, resolved by a shared `adx-mon.image` template helper.
- **Log destinations** — per-component `log_destination` (e.g. `Logs:Collector`) drives the `adx-mon/log-destination` pod annotation.
- **Resources** — per-component `resources` blocks, plus `collector.singleton_resources` for the singleton Deployment.
- **Collector config** — `collector.config.{max_connections, max_batch_size, wal_flush_interval_ms, metrics_database, logs_database}`.
- **TLS skip** — `collector.insecure_skip_verify` and `ingestor.insecure_skip_verify` (default `true` today; can be flipped per env).
- **Alerter target** — `alerter.alerter_address` replaces the previously hard-coded `icmnotifier` URL.

## Namespace portability

- `collector.ingestor_endpoint` defaults to `https://ingestor.<release-namespace>.svc.cluster.local`.
- Collector self-scrape `static-scrape-target` uses `.Release.Namespace` instead of a hard-coded `adx-mon`.
- Ingestor `StatefulSet.spec.serviceName` is `ingestor` (matches the headless Service).
- Singleton collector WAL is rooted at `/mnt/data/singleton` to avoid colliding with the DaemonSet collector if they share storage.

## Notes

- Namespace creation is delegated to `helm install --create-namespace`.
- `ADXCluster` federation `managedIdentityClientId` defaults to `""` (uses `DefaultAzureCredential`); see #1073 for workload identity support.
- CRDs are kept on uninstall. Delete them manually with `kubectl delete crd ...` for a full cleanup; the README has the full command.
- README under `charts/adx-mon/README.md` documents required/optional values, image/log/resource/config knobs, and CRD retention behavior.