### PR TITLE
fix(journal): handle disjunction matches

### DIFF
--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -21,6 +21,7 @@ const (
 // journalReader is an interface for reading journal entries.
 type journalReader interface {
 	AddMatch(match string) error
+	AddDisjunction() error
 	Next() (uint64, error)
 	GetEntry() (*sdjournal.JournalEntry, error)
 	NextSkip(skip uint64) (uint64, error)

--- a/collector/logs/sources/journal/journal_linux_test.go
+++ b/collector/logs/sources/journal/journal_linux_test.go
@@ -194,6 +194,62 @@ func TestJournalMulipleSources(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%d", numLogs-1), types.StringOrEmpty(sink.Latest().GetBodyValue(types.BodyKeyMessage)))
 }
 
+func TestJournalDisjunction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	if !journal.Enabled() {
+		t.Skip("journal is not available - skipping")
+	}
+
+	logger.SetLevel(slog.LevelDebug)
+
+	cursorDir := t.TempDir()
+	testValue := fmt.Sprintf("testValue-%d", rand.Int())
+	branchATag := "COLLECTORE2E_OR_A"
+	branchBTag := "COLLECTORE2E_OR_B"
+	controlTag := "COLLECTORE2E_OR_CONTROL"
+	matchA := fmt.Sprintf("%s=%s", branchATag, testValue)
+	matchB := fmt.Sprintf("%s=%s", branchBTag, testValue)
+
+	const numLogs = 50
+	for i := 0; i < numLogs; i++ {
+		err := journal.Send(fmt.Sprintf("a-%d", i), journal.PriInfo, map[string]string{branchATag: testValue})
+		require.NoError(t, err)
+	}
+	for i := 0; i < numLogs; i++ {
+		err := journal.Send(fmt.Sprintf("b-%d", i), journal.PriInfo, map[string]string{branchBTag: testValue})
+		require.NoError(t, err)
+	}
+	for i := 0; i < numLogs; i++ {
+		err := journal.Send(fmt.Sprintf("control-%d", i), journal.PriInfo, map[string]string{controlTag: testValue})
+		require.NoError(t, err)
+	}
+
+	sink := sinks.NewCountingSink(int64(numLogs * 2))
+	allSinks := []types.Sink{sink}
+	source := New(SourceConfig{
+		Targets: []JournalTargetConfig{{
+			Matches:  []string{matchA, "+", matchB},
+			Database: "testdb",
+			Table:    "testtable",
+		}},
+		CursorDirectory: cursorDir,
+		WorkerCreator:   engine.WorkerCreator(nil, allSinks),
+	})
+
+	service := &logs.Service{
+		Source: source,
+		Sinks:  allSinks,
+	}
+	err := service.Open(context.Background())
+	require.NoError(t, err)
+	defer service.Close()
+
+	count := <-sink.DoneChan()
+	require.EqualValues(t, numLogs*2, count)
+}
+
 func TestJournalInvalidCursor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/collector/logs/sources/journal/tailer_linux.go
+++ b/collector/logs/sources/journal/tailer_linux.go
@@ -165,17 +165,9 @@ func (t *tailer) openJournal(mode openmode) (*sdjournal.Journal, error) {
 		return nil, fmt.Errorf("failed to open journal: %w", err)
 	}
 
-	for _, match := range t.matches {
-		if match == "+" {
-			err := reader.AddDisjunction()
-			if err != nil {
-				return nil, fmt.Errorf("failed to create journal disjunction: %w", err)
-			}
-		}
-
-		if err := reader.AddMatch(match); err != nil {
-			return nil, fmt.Errorf("failed to add journal match %s: %w", match, err)
-		}
+	if err := applyMatches(reader, t.matches); err != nil {
+		reader.Close()
+		return nil, err
 	}
 
 	if mode == journalOpenModeStartup {
@@ -187,6 +179,24 @@ func (t *tailer) openJournal(mode openmode) (*sdjournal.Journal, error) {
 	}
 
 	return reader, nil
+}
+
+func applyMatches(reader journalReader, matches []string) error {
+	for _, match := range matches {
+		if match == "+" {
+			if err := reader.AddDisjunction(); err != nil {
+				return fmt.Errorf("failed to create journal disjunction: %w", err)
+			}
+
+			continue
+		}
+
+		if err := reader.AddMatch(match); err != nil {
+			return fmt.Errorf("failed to add journal match %s: %w", match, err)
+		}
+	}
+
+	return nil
 }
 
 // recoverJournal closes the current journal reader and opens a new one in an attempt to recover from a syscall error.

--- a/collector/logs/sources/journal/tailer_linux_test.go
+++ b/collector/logs/sources/journal/tailer_linux_test.go
@@ -4,11 +4,101 @@ package journal
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/stretchr/testify/require"
 )
+
+type fakeJournalReader struct {
+	calls          []string
+	matchErr       error
+	disjunctionErr error
+}
+
+func (f *fakeJournalReader) AddMatch(match string) error {
+	f.calls = append(f.calls, "match:"+match)
+	return f.matchErr
+}
+
+func (f *fakeJournalReader) AddDisjunction() error {
+	f.calls = append(f.calls, "or")
+	return f.disjunctionErr
+}
+
+func (f *fakeJournalReader) Next() (uint64, error) { return 0, nil }
+
+func (f *fakeJournalReader) GetEntry() (*sdjournal.JournalEntry, error) { return nil, nil }
+
+func (f *fakeJournalReader) NextSkip(skip uint64) (uint64, error) { return 0, nil }
+
+func (f *fakeJournalReader) SeekHead() error { return nil }
+
+func (f *fakeJournalReader) SeekCursor(cursor string) error { return nil }
+
+func (f *fakeJournalReader) TestCursor(cursor string) error { return nil }
+
+func (f *fakeJournalReader) Wait(timeout time.Duration) int { return 0 }
+
+func (f *fakeJournalReader) Close() error { return nil }
+
+func TestApplyMatches(t *testing.T) {
+	testCases := []struct {
+		name           string
+		matches        []string
+		matchErr       error
+		disjunctionErr error
+		wantErr        string
+		wantCalls      []string
+	}{
+		{
+			name:      "only matches",
+			matches:   []string{"FIELD_A=valueA", "FIELD_B=valueB"},
+			wantCalls: []string{"match:FIELD_A=valueA", "match:FIELD_B=valueB"},
+		},
+		{
+			name:      "with disjunction",
+			matches:   []string{"FIELD_A=valueA", "+", "FIELD_B=valueB"},
+			wantCalls: []string{"match:FIELD_A=valueA", "or", "match:FIELD_B=valueB"},
+		},
+		{
+			name:      "match error",
+			matches:   []string{"FIELD_A=valueA", "FIELD_B=valueB"},
+			matchErr:  errors.New("boom"),
+			wantErr:   "failed to add journal match FIELD_A=valueA",
+			wantCalls: []string{"match:FIELD_A=valueA"},
+		},
+		{
+			name:           "disjunction error",
+			matches:        []string{"FIELD_A=valueA", "+", "FIELD_B=valueB"},
+			disjunctionErr: errors.New("boom"),
+			wantErr:        "failed to create journal disjunction",
+			wantCalls:      []string{"match:FIELD_A=valueA", "or"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &fakeJournalReader{
+				matchErr:       tc.matchErr,
+				disjunctionErr: tc.disjunctionErr,
+			}
+
+			err := applyMatches(reader, tc.matches)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+
+			require.Equal(t, tc.wantCalls, reader.calls)
+		})
+	}
+}
 
 // Test files are exports from tests.
 // We export from the system journal with the following command, assuming the variable COLLECTORE2E=testValue-3622684368965614593. This rewrites the _HOSTNAME field to testmachine. Requires the systemd-journal-remote package.


### PR DESCRIPTION
## Summary
- fix journal match application so `+` adds a disjunction without also being passed as a match
- add table-driven unit coverage for match application and an end-to-end journald test for OR semantics