### PR TITLE
fix(wal): segmentIterator gracefully handles corrupt blocks

### DIFF
--- a/ingestor/adx/uploader_test.go
+++ b/ingestor/adx/uploader_test.go
@@ -3,12 +3,16 @@ package adx
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
+	"hash/crc32"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/Azure/adx-mon/pkg/testutils"
 	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
+	"github.com/Azure/adx-mon/pkg/wal"
 	"github.com/Azure/azure-kusto-go/azkustodata"
 	kgzip "github.com/klauspost/compress/gzip"
 	"github.com/stretchr/testify/require"
@@ -71,4 +75,94 @@ func TestUploader_newGzipReader_PropagatesSourceError(t *testing.T) {
 	_, err := io.ReadAll(gzipReader)
 	require.Error(t, err)
 	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestUploader_newGzipReader_VirtualRepairOnCorruptTailSegment(t *testing.T) {
+	dir := t.TempDir()
+	u := NewUploader(nil, UploaderOpts{ConcurrentUploads: 2})
+
+	goodPath := writeSegment(t, dir, "Foo", []string{"good-a\n", "good-b\n"})
+	corruptPath := writeSegment(t, dir, "Foo", []string{"good-c\n", "bad-tail\n"})
+	trailingGoodPath := writeSegment(t, dir, "Foo", []string{"good-d\n", "good-e\n"})
+	corruptLastBlockCRCInFile(t, corruptPath)
+
+	goodReader, err := wal.NewSegmentReader(goodPath)
+	require.NoError(t, err)
+	defer goodReader.Close()
+
+	corruptReader, err := wal.NewSegmentReader(corruptPath)
+	require.NoError(t, err)
+	defer corruptReader.Close()
+
+	trailingGoodReader, err := wal.NewSegmentReader(trailingGoodPath)
+	require.NoError(t, err)
+	defer trailingGoodReader.Close()
+
+	gzipReader := u.newGzipReader(io.MultiReader(goodReader, corruptReader, trailingGoodReader))
+	defer gzipReader.Close()
+
+	decoder, err := kgzip.NewReader(gzipReader)
+	require.NoError(t, err)
+	defer decoder.Close()
+
+	output, err := io.ReadAll(decoder)
+	require.NoError(t, err)
+	require.Equal(t, "good-a\ngood-b\ngood-c\ngood-d\ngood-e\n", string(output))
+}
+
+func writeSegment(t *testing.T, dir, prefix string, rows []string) string {
+	t.Helper()
+
+	s, err := wal.NewSegment(dir, prefix)
+	require.NoError(t, err)
+	defer s.Close()
+
+	for _, row := range rows {
+		_, err = s.Write(context.Background(), []byte(row))
+		require.NoError(t, err)
+	}
+
+	path := s.Path()
+	require.NoError(t, s.Close())
+	return path
+}
+
+func corruptLastBlockCRCInFile(t *testing.T, path string) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	_, err = f.Seek(8, io.SeekStart)
+	require.NoError(t, err)
+
+	var header [8]byte
+	for {
+		headerPos, err := f.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+
+		_, err = io.ReadFull(f, header[:])
+		require.NoError(t, err)
+
+		blockLen := binary.BigEndian.Uint32(header[:4])
+		crcPos := headerPos + 4
+
+		block := make([]byte, blockLen)
+		_, err = io.ReadFull(f, block)
+		require.NoError(t, err)
+
+		nextHeaderPos, err := f.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+		if _, err = io.ReadFull(f, header[:]); err == io.EOF {
+			checksum := crc32.ChecksumIEEE(block)
+			binary.BigEndian.PutUint32(header[:4], checksum+1)
+			_, err = f.WriteAt(header[:4], crcPos)
+			require.NoError(t, err)
+			return
+		}
+		require.NoError(t, err)
+		_, err = f.Seek(nextHeaderPos, io.SeekStart)
+		require.NoError(t, err)
+	}
 }

--- a/pkg/wal/iterator.go
+++ b/pkg/wal/iterator.go
@@ -8,6 +8,7 @@ import (
 	"hash/crc32"
 	"io"
 
+	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/klauspost/compress/s2"
 )
 
@@ -57,13 +58,32 @@ func NewSegmentIterator(r io.ReadCloser) (Iterator, error) {
 		value:     nil,
 	}, nil
 }
+
+// Next reads the next block from the segment.  It returns true if a valid block was read and false if the
+// iterator has reached the end of the segment or encounters a block that is corrupt. This matches the behavior
+// of Repair() that drops any trailing corrupt blocks at the end of a segment.
+//
+// If a block read will never succeed (no header, corruption, etc) we return false with no error to send whatever
+// valid blocks we can, then retire the segment so we don't keep retrying.
+//
+// If the read fails for other reasons (disk error, underlying reader failure, etc) then we return the error so
+// the segment read can be retried with the segment being returned to the queue with Release().
 func (b *segmentIterator) Next() (bool, error) {
 	// Read the block length and CRC
-	n, err := io.ReadFull(b.br, b.lenCrcBuf[:8])
-	if err == io.EOF {
+	_, err := io.ReadFull(b.br, b.lenCrcBuf[:8])
+	if err != nil {
+		if err == io.EOF {
+			return false, nil // No more blocks to read
+		}
+
+		// ErrUnexpectedEOF is returned if we are not able to read blockLen bytes
+		if err == io.ErrUnexpectedEOF {
+			logger.Warnf("Truncating segment %s during read, short block", b.sourceName())
+			return false, nil
+		}
+
+		// Preserve non-truncation read failures instead of treating them as virtual repair.
 		return false, err
-	} else if err != nil || n != 8 {
-		return false, nil
 	}
 
 	// Extract the block length and expand the read buffer if it is too small.
@@ -82,25 +102,31 @@ func (b *segmentIterator) Next() (bool, error) {
 	// Extract the CRC value for the block
 	crc := binary.BigEndian.Uint32(b.lenCrcBuf[4:8])
 
-	// Read the expected block length bytes
-	n, err = io.ReadFull(b.br, b.buf[:blockLen])
+	// Read the expected block length bytes. If blockLen bytes cannot be read from the underlying
+	// reader, treat this block and the rest as corrupt and stop iteration.
+	_, err = io.ReadFull(b.br, b.buf[:blockLen])
 	if err != nil {
+		// ErrUnexpectedEOF is returned if we are not able to read blockLen bytes
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			logger.Warnf("Truncating segment %s during read, short block", b.sourceName())
+			return false, nil
+		}
+
+		// Preserve non-truncation read failures instead of treating them as virtual repair.
 		return false, err
 	}
 
-	// Make sure we actually read the number of bytes we were expecting.
-	if uint32(n) != blockLen {
-		return false, fmt.Errorf("short block read: expected %d, got %d", blockLen, n)
-	}
-
-	// Validate the block checksum matches still
+	// Validate the block checksum matches still. If the checksum does not match, treat this block
+	// and the rest of the segment as corrupt and stop iteration.
 	if crc32.ChecksumIEEE(b.buf[:blockLen]) != crc {
-		return false, fmt.Errorf("block checksum verification failed")
+		logger.Warnf("Truncating segment %s during read, checksum failed", b.sourceName())
+		return false, nil
 	}
 
 	b.decodeBuf, err = s2.Decode(b.decodeBuf[:0], b.buf[:blockLen])
 	if err != nil {
-		return false, err
+		logger.Warnf("Truncating segment %s during read, decode failed: %v", b.sourceName(), err)
+		return false, nil
 	}
 
 	if HasSampleMetadata(b.decodeBuf) {
@@ -117,6 +143,19 @@ func (b *segmentIterator) Next() (bool, error) {
 
 func (b *segmentIterator) Value() []byte {
 	return b.value
+}
+
+func (b *segmentIterator) sourceName() string {
+	// Includes the stdlib File type we back our normal WALs with
+	type namedReader interface {
+		Name() string
+	}
+
+	if named, ok := b.f.(namedReader); ok {
+		return named.Name()
+	}
+
+	return "<stream>"
 }
 
 func (b *segmentIterator) Close() error {

--- a/pkg/wal/iterator_test.go
+++ b/pkg/wal/iterator_test.go
@@ -3,13 +3,28 @@ package wal_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"hash/crc32"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/Azure/adx-mon/pkg/wal"
+	"github.com/klauspost/compress/s2"
 	"github.com/stretchr/testify/require"
 )
+
+type errReader struct {
+	err error
+}
+
+func (e *errReader) Read(_ []byte) (int, error) {
+	return 0, e.err
+}
+
+func (e *errReader) Close() error {
+	return nil
+}
 
 func TestSegmentIterator_Verify(t *testing.T) {
 
@@ -132,4 +147,129 @@ func TestSegmentIterator_Verify_TrailingBytes(t *testing.T) {
 
 		})
 	}
+}
+
+func TestSegmentIterator_Next_ShortReadCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  io.ReadCloser
+		payload []byte
+		err     string
+	}{
+		{
+			name:    "empty header at tail returns false nil",
+			payload: []byte("ADXWAL  "),
+		},
+		{
+			name:    "short header at tail returns false nil",
+			payload: append([]byte("ADXWAL  "), 1, 2, 3),
+		},
+		{
+			name:    "almost complete header at tail returns false nil",
+			payload: append([]byte("ADXWAL  "), 1, 2, 3, 4, 5, 6, 7),
+		},
+		{
+			name:   "header read returns other error",
+			reader: io.NopCloser(io.MultiReader(bytes.NewReader([]byte("ADXWAL  ")), &errReader{err: io.ErrClosedPipe})),
+			err:    io.ErrClosedPipe.Error(),
+		},
+		{
+			name: "missing block payload returns false nil",
+			payload: appendSegmentHeader(
+				[]byte("ADXWAL  "),
+				5,
+				crc32.ChecksumIEEE([]byte("abcde")),
+			),
+		},
+		{
+			name: "partial block payload returns false nil",
+			payload: append(
+				appendSegmentHeader(
+					[]byte("ADXWAL  "),
+					5,
+					crc32.ChecksumIEEE([]byte("abcde")),
+				),
+				'a', 'b',
+			),
+		},
+		{
+			name: "checksum mismatch returns false nil",
+			payload: append(
+				appendSegmentHeader(
+					[]byte("ADXWAL  "),
+					5,
+					crc32.ChecksumIEEE([]byte("abcde"))+1,
+				),
+				[]byte("abcde")...,
+			),
+		},
+		{
+			name:   "payload read returns other error",
+			reader: io.NopCloser(io.MultiReader(bytes.NewReader(appendSegmentHeader([]byte("ADXWAL  "), 5, crc32.ChecksumIEEE([]byte("abcde")))), &errReader{err: io.ErrClosedPipe})),
+			err:    io.ErrClosedPipe.Error(),
+		},
+		{
+			name:    "s2 decode error returns false nil",
+			payload: append(appendSegmentHeader([]byte("ADXWAL  "), 3, crc32.ChecksumIEEE([]byte("bad"))), []byte("bad")...),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			reader := tt.reader
+			if reader == nil {
+				reader = io.NopCloser(bytes.NewReader(tt.payload))
+			}
+
+			iter, err := wal.NewSegmentIterator(reader)
+			require.NoError(t, err)
+			defer iter.Close()
+
+			next, err := iter.Next()
+			if tt.err == "" {
+				require.NoError(t, err)
+				require.False(t, next)
+				return
+			}
+
+			require.False(t, next)
+			require.EqualError(t, err, tt.err)
+		})
+	}
+}
+
+func TestSegmentIterator_Next_ZeroLengthBlockStopsIteration(t *testing.T) {
+	iter, err := wal.NewSegmentIterator(io.NopCloser(bytes.NewReader(appendSegmentHeader([]byte("ADXWAL  "), 0, 0))))
+	require.NoError(t, err)
+	defer iter.Close()
+
+	next, err := iter.Next()
+	require.NoError(t, err)
+	require.False(t, next)
+}
+
+func TestSegmentIterator_Next_BlockWithoutSampleMetadata(t *testing.T) {
+	encoded := s2.EncodeBetter(nil, []byte("plain-value"))
+	payload := append(appendSegmentHeader([]byte("ADXWAL  "), uint32(len(encoded)), crc32.ChecksumIEEE(encoded)), encoded...)
+
+	iter, err := wal.NewSegmentIterator(io.NopCloser(bytes.NewReader(payload)))
+	require.NoError(t, err)
+	defer iter.Close()
+
+	next, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, next)
+	require.Equal(t, []byte("plain-value"), iter.Value())
+
+	st, count := iter.Metadata()
+	require.Equal(t, wal.UnknownSampleType, st)
+	require.Zero(t, count)
+}
+
+func appendSegmentHeader(dst []byte, blockLen uint32, crc uint32) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint32(buf[:4], blockLen)
+	binary.BigEndian.PutUint32(buf[4:], crc)
+	return append(dst, buf...)
 }

--- a/pkg/wal/reader_test.go
+++ b/pkg/wal/reader_test.go
@@ -2,7 +2,10 @@ package wal_test
 
 import (
 	"context"
+	"encoding/binary"
+	"hash/crc32"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/Azure/adx-mon/pkg/wal"
@@ -43,5 +46,148 @@ func TestSegmentReader(t *testing.T) {
 
 			require.Equal(t, "testtest1test2", string(b))
 		})
+	}
+}
+
+func TestSegmentReader_VirtualRepair_DropsCorruptTail(t *testing.T) {
+	dir := t.TempDir()
+	s, err := wal.NewSegment(dir, "Foo")
+	require.NoError(t, err)
+
+	_, err = s.Write(context.Background(), []byte("good1\n"))
+	require.NoError(t, err)
+	_, err = s.Write(context.Background(), []byte("good2\n"))
+	require.NoError(t, err)
+	_, err = s.Write(context.Background(), []byte("bad\n"))
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	corruptLastBlockCRC(t, s.Path())
+
+	r, err := wal.NewSegmentReader(s.Path())
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "good1\ngood2\n", string(data))
+	require.NoError(t, r.Close())
+
+	r2, err := wal.NewSegmentReader(s.Path())
+	require.NoError(t, err)
+
+	data, err = io.ReadAll(r2)
+	require.NoError(t, err)
+	require.Equal(t, "good1\ngood2\n", string(data))
+	require.NoError(t, r2.Close())
+
+	iterFile, err := os.Open(s.Path())
+	require.NoError(t, err)
+
+	iter, err := wal.NewSegmentIterator(iterFile)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, iter.Close()) }()
+
+	n, err := iter.Verify()
+	require.EqualError(t, err, "block checksum verification failed")
+	require.Zero(t, n)
+}
+
+func TestSegmentReader_VirtualRepair_MatchesRepairDiscardPoint(t *testing.T) {
+	dir := t.TempDir()
+	s, err := wal.NewSegment(dir, "Foo")
+	require.NoError(t, err)
+
+	_, err = s.Write(context.Background(), []byte("good1\n"))
+	require.NoError(t, err)
+	_, err = s.Write(context.Background(), []byte("bad\n"))
+	require.NoError(t, err)
+	_, err = s.Write(context.Background(), []byte("good-after-bad\n"))
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	corruptBlockCRCByIndex(t, s.Path(), 1)
+
+	r, err := wal.NewSegmentReader(s.Path())
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "good1\n", string(data))
+	require.NoError(t, r.Close())
+
+	seg, err := wal.Open(s.Path())
+	require.NoError(t, err)
+	require.NoError(t, seg.Close())
+
+	repairedReader, err := wal.NewSegmentReader(s.Path())
+	require.NoError(t, err)
+	defer repairedReader.Close()
+
+	repairedData, err := io.ReadAll(repairedReader)
+	require.NoError(t, err)
+	require.Equal(t, string(data), string(repairedData))
+}
+
+func corruptLastBlockCRC(t *testing.T, path string) {
+	t.Helper()
+	corruptBlockCRCByIndex(t, path, -1)
+}
+
+func corruptBlockCRCByIndex(t *testing.T, path string, blockIndex int) {
+	t.Helper()
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	_, err = f.Seek(8, io.SeekStart)
+	require.NoError(t, err)
+
+	var (
+		header [8]byte
+		blocks []int64
+	)
+
+	for {
+		headerPos, err := f.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+
+		_, err = io.ReadFull(f, header[:])
+		require.NoError(t, err)
+
+		blockLen := binary.BigEndian.Uint32(header[:4])
+		blocks = append(blocks, headerPos+4)
+
+		block := make([]byte, blockLen)
+		_, err = io.ReadFull(f, block)
+		require.NoError(t, err)
+
+		nextHeaderPos, err := f.Seek(0, io.SeekCurrent)
+		require.NoError(t, err)
+		if _, err = io.ReadFull(f, header[:]); err == io.EOF {
+			if blockIndex < 0 {
+				blockIndex = len(blocks) - 1
+			}
+			require.GreaterOrEqual(t, blockIndex, 0)
+			require.Less(t, blockIndex, len(blocks))
+
+			blockPos := blocks[blockIndex] - 4
+			_, err = f.ReadAt(header[:], blockPos)
+			require.NoError(t, err)
+
+			blockLen = binary.BigEndian.Uint32(header[:4])
+			block = make([]byte, blockLen)
+			_, err = f.ReadAt(block, blockPos+8)
+			require.NoError(t, err)
+
+			checksum := crc32.ChecksumIEEE(block)
+			binary.BigEndian.PutUint32(header[:4], checksum+1)
+			_, err = f.WriteAt(header[:4], blocks[blockIndex])
+			require.NoError(t, err)
+			return
+		}
+		require.NoError(t, err)
+		_, err = f.Seek(nextHeaderPos, io.SeekStart)
+		require.NoError(t, err)
 	}
 }

--- a/pkg/wal/segment_test.go
+++ b/pkg/wal/segment_test.go
@@ -233,7 +233,7 @@ func TestSegment_Iterator(t *testing.T) {
 			require.Equal(t, []byte("test2"), iter.Value())
 
 			next, err = iter.Next()
-			require.ErrorIs(t, err, io.EOF)
+			require.NoError(t, err)
 			require.False(t, next)
 		})
 	}
@@ -430,7 +430,7 @@ func TestSegment_Append(t *testing.T) {
 			require.Equal(t, []byte("test1"), iter.Value())
 
 			next, err = iter.Next()
-			require.ErrorIs(t, err, io.EOF)
+			require.NoError(t, err)
 			require.False(t, next)
 		})
 	}
@@ -497,7 +497,7 @@ func TestSegment_Write(t *testing.T) {
 			require.Equal(t, []byte("test1"), iter.Value())
 
 			next, err = iter.Next()
-			require.ErrorIs(t, err, io.EOF)
+			require.NoError(t, err)
 			require.False(t, next)
 		})
 	}


### PR DESCRIPTION
WAL machinery within Collector and Ingestor contains a Repair() mechanism that is called on startup. This mechanism iterates through blocks within a given segment and truncates any files that contain corruption. Once a given block is considered corrupted, it and all of the following blocks are all considered corrupt as well.

If corruption happens during runtime, perhaps from a collector instance that crashed, the segmentIterator.Next() implementation would handle some types of corruption (zero block lengths) gracefully but would return errors for other cases like short blocks or those that don't contain a valid checksum. Instead of returning errors, do a virtual truncation where we report there are no more blocks to iterate to.