### PR TITLE
perf(cluster): pool gzip.Writer in Client.Write

### DIFF
--- a/ingestor/cluster/client.go
+++ b/ingestor/cluster/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	adxhttp "github.com/Azure/adx-mon/pkg/http"
@@ -14,6 +15,14 @@ import (
 	"github.com/davidnarayan/go-flake"
 	"github.com/klauspost/compress/gzip"
 )
+
+// gzipWriterPool reuses *gzip.Writer instances across Client.Write invocations.
+// gzip.NewWriter allocates the underlying flate encoder state (~256KiB of hash
+// tables) on every call, which is one of the largest allocators in the
+// collector. Reset(w) is the documented reuse contract for gzip.Writer.
+var gzipWriterPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
+}
 
 // PeerOverloadedError represents a peer overloaded error with optional requestId.
 type PeerOverloadedError struct {
@@ -220,8 +229,14 @@ func (c *Client) Write(ctx context.Context, endpoint string, filename string, bo
 		gzipReader, gzipWriter := io.Pipe()
 		go func() {
 			defer gzipWriter.Close()
-			gzipCompressor := gzip.NewWriter(gzipWriter)
-			defer gzipCompressor.Close()
+			gzipCompressor := gzipWriterPool.Get().(*gzip.Writer)
+			gzipCompressor.Reset(gzipWriter)
+			defer func() {
+				// Close flushes the trailer; Reset on the next Get re-initializes
+				// header state, so it is safe to return the writer to the pool here.
+				gzipCompressor.Close()
+				gzipWriterPool.Put(gzipCompressor)
+			}()
 			if _, err := io.Copy(gzipCompressor, body); err != nil {
 				if err := gzipWriter.CloseWithError(err); err != nil {
 					logger.Errorf("failed to close gzip writer: %s requestId=%s", err, requestId)

--- a/ingestor/cluster/client_test.go
+++ b/ingestor/cluster/client_test.go
@@ -5,10 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +37,124 @@ func TestClient_Write_Success(t *testing.T) {
 
 	err = client.Write(context.Background(), server.URL, "testfile", strings.NewReader("testdata"))
 	require.NoError(t, err)
+}
+
+// TestClient_Write_Gzip_SequentialReuse verifies that successive Client.Write
+// calls produce the correct decompressed payload. Catches state bleed across
+// pooled *gzip.Writer instances (e.g. forgetting to Reset).
+func TestClient_Write_Gzip_SequentialReuse(t *testing.T) {
+	var got [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+		gzipReader, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		defer gzipReader.Close()
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzipReader)
+		require.NoError(t, err)
+		got = append(got, append([]byte(nil), buf.Bytes()...))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientOpts{Timeout: 5 * time.Second, DisableGzip: false})
+	require.NoError(t, err)
+
+	payloads := [][]byte{
+		[]byte("first payload"),
+		bytes.Repeat([]byte("ABCDEFGH"), 1024),                      // 8 KiB, highly compressible
+		bytes.Repeat([]byte("xyz"), 50000),                          // ~150 KiB, spans many flate blocks
+		[]byte("short"),                                             // tiny again, writer state must be clean
+		bytes.Repeat([]byte("payload-five-distinct-content"), 8000), // ~232 KiB
+	}
+
+	for i, p := range payloads {
+		err := client.Write(context.Background(), server.URL, "testfile", bytes.NewReader(p))
+		require.NoError(t, err, "write %d", i)
+	}
+
+	require.Equal(t, len(payloads), len(got))
+	for i, p := range payloads {
+		require.Equal(t, p, got[i], "payload %d mismatch", i)
+	}
+}
+
+// TestClient_Write_Gzip_ConcurrentReuse exercises the gzip pool from many
+// goroutines simultaneously. With -race this catches accidental sharing of a
+// pooled *gzip.Writer across goroutines.
+func TestClient_Write_Gzip_ConcurrentReuse(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		got = map[string]int{}
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gzipReader, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		defer gzipReader.Close()
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzipReader)
+		require.NoError(t, err)
+		mu.Lock()
+		got[buf.String()]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientOpts{
+		Timeout:             5 * time.Second,
+		DisableGzip:         false,
+		MaxConnsPerHost:     32,
+		MaxIdleConnsPerHost: 32,
+	})
+	require.NoError(t, err)
+
+	const workers, perWorker = 16, 25
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			payload := bytes.Repeat([]byte(fmt.Sprintf("worker-%02d-data ", w)), 2048) // ~32 KiB each, distinct per worker
+			for i := 0; i < perWorker; i++ {
+				err := client.Write(context.Background(), server.URL, "testfile", bytes.NewReader(payload))
+				require.NoError(t, err)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, got, workers, "each worker's payload should have been received intact and distinct")
+	for k, count := range got {
+		require.Equal(t, perWorker, count, "payload %q received %d times, expected %d", k[:32], count, perWorker)
+	}
+}
+
+func BenchmarkClientWrite_GzipReuse(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientOpts{
+		Timeout:     30 * time.Second,
+		DisableGzip: false,
+	})
+	require.NoError(b, err)
+
+	// Representative payload size for a transfer batch.
+	payload := bytes.Repeat([]byte("metric,value,timestamp\n"), 4096)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := client.Write(context.Background(), server.URL, "testfile", bytes.NewReader(payload)); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func TestClient_Write_BadRequest(t *testing.T) {


### PR DESCRIPTION
gzip.NewWriter allocates ~256KiB of flate hash tables per call, making it the top allocator in the collector write path (~33% of allocated bytes). Reuse writers via sync.Pool with Reset(w).

This is similar to the strategy used for gzip writer sharing with the Kusto ingestion path where we share the writers with sync.Pool. We use this instead of the custom pools we use elsewhere to help limit maximum memory usage. In the Kusto upload case, which I think is similar to this workflow, using sync.Pool instead of our custom pools led to a very small increase in cpu but dramatic decreases in memory usage as idle writers can get GC'd with large allocations within them.

Simple Benchmark:
  before: 811768 ns/op  1112543 B/op  136 allocs/op
  after:  327141 ns/op    15804 B/op  112 allocs/op