### PR TITLE
build(deps): bump azkustoingest caching branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 
 replace (
 	github.com/Azure/azure-kusto-go => github.com/jwilder/azure-kusto-go v0.15.3-0.20240403192022-0d7016e79525
-	github.com/Azure/azure-kusto-go/azkustoingest => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260409225124-9d78ed1a0d21
+	github.com/Azure/azure-kusto-go/azkustoingest => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260515201423-2ab6d60df35a
 	github.com/redis/go-redis/v9 => github.com/redis/go-redis/v9 v9.7.3
 	github.com/tenebris-tech/tail => github.com/mkeesey/tail v1.1.1-0.20240917203328-d83cd4147445
 )

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/mattn/go-ieproxy v0.0.11 h1:MQ/5BuGSgDAHZOJe6YY80IF2UVCfGkwfo6AeD7HtH
 github.com/mattn/go-ieproxy v0.0.11/go.mod h1:/NsJd+kxZBmjMc5hrJCKMbP57B84rvq9BiDRbtO9AS0=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260409225124-9d78ed1a0d21 h1:NyRYfVZ4OGtfEKUlFWJsJUddTfz06cLUIpiS73AO6C0=
-github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260409225124-9d78ed1a0d21/go.mod h1:rQO8D24q/a/2OMgtsiIo2HcBC6Ub3f+6WF2ttK7aN3I=
+github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260515201423-2ab6d60df35a h1:zbc7qHc+V5QijxoROI/MeageMi2HE/SdmXVhOc89sSc=
+github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260515201423-2ab6d60df35a/go.mod h1:ttDjL9q6ldGul19cNa0NZf4zXjucNVSoWYrM8aTFQGo=
 github.com/mkeesey/tail v1.1.1-0.20240917203328-d83cd4147445 h1:kAwHCQ2tUrUb7+TMRfZL2P19ubFQoPbYAapUVd/bA0s=
 github.com/mkeesey/tail v1.1.1-0.20240917203328-d83cd4147445/go.mod h1:m0u5w2Jq02XaCeiUYJk+u4Pa3DDY9kK4jNcyrsBGMOs=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/queued/queued.go
+++ b/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/queued/queued.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-kusto-go/azkustoingest/ingestoptions"
@@ -190,7 +191,7 @@ func (i *Ingestion) UploadReaderToBlob(ctx context.Context, reader io.Reader, pr
 		return "", 0, errors.ES(errors.OpFileIngest, errors.KBlobstore, "no Kusto queue resources are defined, there is no queue to upload to").SetNoRetry()
 	}
 
-	compression := effectiveCompressionType(&props, props.Source.OriginalSource)
+	compression := EffectiveCompressionType(&props, props.Source.OriginalSource)
 	shouldCompress := ShouldCompress(&props, compression)
 	blobName := GenBlobName(i.db, i.table, nower(), filepath.Base(uuid.New().String()), filepath.Base(props.Source.OriginalSource), compression, shouldCompress, props.Ingestion.Additional.Format.String())
 	seeker, isSeekable := reader.(io.Seeker)
@@ -353,7 +354,7 @@ var nower = time.Now
 // localToBlob copies from a local to an Azure Blobstore blob. It returns the URL of the Blob, the local file info and an
 // error if there was one.
 func (i *Ingestion) localToBlob(ctx context.Context, from string, client *azblob.Client, container string, props *properties.All) (string, int64, error) {
-	compression := effectiveCompressionType(props, from)
+	compression := EffectiveCompressionType(props, from)
 	shouldCompress := ShouldCompress(props, compression)
 	blobName := GenBlobName(i.db, i.table, nower(), filepath.Base(uuid.New().String()), filepath.Base(from), compression, shouldCompress, props.Ingestion.Additional.Format.String())
 
@@ -425,12 +426,27 @@ func GenBlobName(databaseName string, tableName string, time time.Time, guid str
 		}
 	}
 
+	fileName = stripCompressionSuffix(fileName)
 	blobName := fmt.Sprintf("%s_%s_%s_%s_%s.%s", databaseName, tableName, time, guid, fileName, extension)
 
 	return blobName
 }
 
-func effectiveCompressionType(props *properties.All, sourcePath string) ingestoptions.CompressionType {
+// stripCompressionSuffix removes a known compression extension (.gz, .zip) from a filename
+// to prevent double-extensions like "file.json.gz.gz" when GenBlobName appends the extension.
+func stripCompressionSuffix(fileName string) string {
+	lower := strings.ToLower(fileName)
+	for _, suffix := range []string{".gz", ".zip"} {
+		if strings.HasSuffix(lower, suffix) {
+			return fileName[:len(fileName)-len(suffix)]
+		}
+	}
+	return fileName
+}
+
+// EffectiveCompressionType returns the user-configured compression type if set,
+// otherwise falls back to file-extension discovery.
+func EffectiveCompressionType(props *properties.All, sourcePath string) ingestoptions.CompressionType {
 	if props.Source.CompressionType != ingestoptions.CTUnknown {
 		return props.Source.CompressionType
 	}

--- a/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/resources/resources.go
+++ b/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/resources/resources.go
@@ -26,6 +26,11 @@ const (
 	defaultMultiplier      = 2
 	retryCount             = 4
 	fetchInterval          = 1 * time.Hour
+	authRefreshInterval    = 1 * time.Hour
+	authNoRefreshTimeout   = 10 * time.Hour
+
+	authRetryIntervalWithCachedToken    = 15 * time.Minute
+	authRetryIntervalWithoutCachedToken = 3 * time.Second
 )
 
 // mgmter is a private interface that allows us to write hermetic tests against the azkustodata.Client.Mgmt() method.
@@ -116,15 +121,19 @@ type ResourcesManager interface {
 
 // Manager manages Kusto resources.
 type Manager struct {
-	client                   mgmter
-	done                     chan struct{}
-	resources                atomic.Value // Stores Ingestion
-	lastFetchTime            atomic.Value // Stores time.Time
-	kustoToken               token
-	authTokenCacheExpiration time.Time
-	authLock                 sync.Mutex
-	fetchLock                sync.Mutex
-	rankedStorageAccount     *RankedStorageAccountSet
+	client                 mgmter
+	done                   chan struct{}
+	resources              atomic.Value // Stores Ingestion
+	lastFetchTime          atomic.Value // Stores time.Time
+	kustoToken             token
+	hasAuthToken           bool
+	authTokenRefreshTime   time.Time
+	authTokenValidUntil    time.Time
+	nextAuthRefreshAttempt time.Time
+	authLock               sync.Mutex
+	fetchLock              sync.Mutex
+	rankedStorageAccount   *RankedStorageAccountSet
+	now                    func() time.Time
 }
 
 var _ ResourcesManager = (*Manager)(nil)
@@ -134,8 +143,9 @@ func New(client mgmter) (*Manager, error) {
 	m := &Manager{client: client, done: make(chan struct{}), rankedStorageAccount: newDefaultRankedStorageAccountSet()}
 	m.authLock = sync.Mutex{}
 	m.fetchLock = sync.Mutex{}
+	m.now = func() time.Time { return time.Now().UTC() }
 
-	m.authTokenCacheExpiration = time.Now().UTC()
+	m.authTokenRefreshTime = m.now()
 	go m.renewResources()
 
 	return m, nil
@@ -180,10 +190,44 @@ func (m *Manager) renewResources() {
 func (m *Manager) AuthContext(ctx context.Context) (string, error) {
 	m.authLock.Lock()
 	defer m.authLock.Unlock()
-	if m.authTokenCacheExpiration.After(time.Now().UTC()) {
+	now := m.currentTime()
+
+	if m.hasAuthToken && m.authTokenRefreshTime.After(now) {
 		return m.kustoToken.AuthContext, nil
 	}
 
+	if m.nextAuthRefreshAttempt.After(now) {
+		if m.hasAuthToken && m.authTokenValidUntil.After(now) {
+			return m.kustoToken.AuthContext, nil
+		}
+
+		if m.nextAuthRefreshAttempt.Sub(now) <= authRetryIntervalWithoutCachedToken {
+			return "", fmt.Errorf("problem getting authorization context from Kusto via Mgmt: refresh is temporarily throttled")
+		}
+	}
+
+	tk, err := m.refreshAuthContext(ctx)
+	now = m.currentTime()
+	if err != nil {
+		if m.hasAuthToken && m.authTokenValidUntil.After(now) {
+			m.nextAuthRefreshAttempt = now.Add(authRetryIntervalWithCachedToken)
+			return m.kustoToken.AuthContext, nil
+		}
+
+		m.nextAuthRefreshAttempt = now.Add(authRetryIntervalWithoutCachedToken)
+		return "", fmt.Errorf("problem getting authorization context from Kusto via Mgmt: %w", err)
+	}
+
+	m.kustoToken = tk
+	m.hasAuthToken = true
+	m.authTokenRefreshTime = now.Add(authRefreshInterval)
+	m.authTokenValidUntil = now.Add(authNoRefreshTimeout)
+	m.nextAuthRefreshAttempt = time.Time{}
+
+	return tk.AuthContext, nil
+}
+
+func (m *Manager) refreshAuthContext(ctx context.Context) (token, error) {
 	var dataset v1.Dataset
 	retryCtx := backoff.WithContext(initBackoff(), ctx)
 	err := backoff.Retry(func() error {
@@ -202,24 +246,26 @@ func (m *Manager) AuthContext(ctx context.Context) (string, error) {
 	}, retryCtx)
 
 	if err != nil {
-		return "", fmt.Errorf("problem getting authorization context from Kusto via Mgmt: %s", err)
+		return token{}, err
 	}
 
 	tokens, err := query.ToStructs[token](dataset)
 	if err != nil {
-		return "", err
+		return token{}, err
 	}
 	if tokens == nil {
-		return "", fmt.Errorf("call for AuthContext returned no Rows")
+		return token{}, fmt.Errorf("call for AuthContext returned no Rows")
 	}
 
 	if len(tokens) != 1 {
-		return "", fmt.Errorf("call for AuthContext returned more than 1 Row")
+		return token{}, fmt.Errorf("call for AuthContext returned more than 1 Row")
 	}
 
-	m.kustoToken = tokens[0]
-	m.authTokenCacheExpiration = time.Now().UTC().Add(time.Hour)
-	return tokens[0].AuthContext, nil
+	return tokens[0], nil
+}
+
+func (m *Manager) currentTime() time.Time {
+	return m.now().UTC()
 }
 
 // ingestResc represents a kusto Mgmt() record about a resource

--- a/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/utils/ingestion_utils.go
+++ b/vendor/github.com/Azure/azure-kusto-go/azkustoingest/internal/utils/ingestion_utils.go
@@ -81,8 +81,7 @@ func FetchBlobSize(fPath string, ctx context.Context, client *http.Client) (size
 
 func EstimateRawDataSize(compression ingestoptions.CompressionType, fileSize int64) int64 {
 	switch compression {
-	case ingestoptions.GZIP:
-	case ingestoptions.ZIP:
+	case ingestoptions.GZIP, ingestoptions.ZIP:
 		return fileSize * EstimatedCompressionFactor
 	}
 

--- a/vendor/github.com/Azure/azure-kusto-go/azkustoingest/managed.go
+++ b/vendor/github.com/Azure/azure-kusto-go/azkustoingest/managed.go
@@ -124,7 +124,7 @@ func (m *Managed) FromFile(ctx context.Context, fPath string, options ...FileOpt
 				// Failed fetch blob properties
 				return nil, err
 			}
-			compressionTypeForEstimation = utils.CompressionDiscovery(fPath)
+			compressionTypeForEstimation = queued.EffectiveCompressionType(&props, fPath)
 			props.Ingestion.RawDataSize = utils.EstimateRawDataSize(compressionTypeForEstimation, size)
 		} else {
 			// If user sets raw data size we always want to devide it for estimation

--- a/vendor/github.com/Azure/azure-kusto-go/azkustoingest/streaming.go
+++ b/vendor/github.com/Azure/azure-kusto-go/azkustoingest/streaming.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/Azure/azure-kusto-go/azkustoingest/ingestoptions"
-	"github.com/Azure/azure-kusto-go/azkustoingest/internal/utils"
 	"io"
 	"os"
 
@@ -117,7 +116,7 @@ func prepFileAndProps(fPath string, props *properties.All, options []FileOption,
 	}
 
 	props.Source.OriginalSource = fPath
-	compression := utils.CompressionDiscovery(fPath)
+	compression := queued.EffectiveCompressionType(props, fPath)
 	err = queued.CompleteFormatFromFileName(props, fPath)
 	if err != nil {
 		return nil, err, true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -57,7 +57,7 @@ github.com/Azure/azure-kusto-go/azkustodata/trusted_endpoints
 github.com/Azure/azure-kusto-go/azkustodata/types
 github.com/Azure/azure-kusto-go/azkustodata/utils
 github.com/Azure/azure-kusto-go/azkustodata/value
-# github.com/Azure/azure-kusto-go/azkustoingest v1.2.0 => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260409225124-9d78ed1a0d21
+# github.com/Azure/azure-kusto-go/azkustoingest v1.2.0 => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260515201423-2ab6d60df35a
 ## explicit; go 1.24.0
 github.com/Azure/azure-kusto-go/azkustoingest
 github.com/Azure/azure-kusto-go/azkustoingest/ingestoptions
@@ -1408,6 +1408,6 @@ sigs.k8s.io/structured-merge-diff/v6/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/Azure/azure-kusto-go => github.com/jwilder/azure-kusto-go v0.15.3-0.20240403192022-0d7016e79525
-# github.com/Azure/azure-kusto-go/azkustoingest => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260409225124-9d78ed1a0d21
+# github.com/Azure/azure-kusto-go/azkustoingest => github.com/mkeesey/azure-kusto-go/azkustoingest v0.0.0-20260515201423-2ab6d60df35a
 # github.com/redis/go-redis/v9 => github.com/redis/go-redis/v9 v9.7.3
 # github.com/tenebris-tech/tail => github.com/mkeesey/tail v1.1.1-0.20240917203328-d83cd4147445


### PR DESCRIPTION
Bring in the azkustoingest caching branch changes so ingestion auth context tokens are cached and reused across refresh failures instead of forcing every ingestion path to refetch from Kusto.

This pulls in the upstream v1.2.2 release (they rejiggered my fixes for gzipping outside of the library itself), and changes for PR [Azure/azure-kusto-go#334](https://github.com/Azure/azure-kusto-go/pull/334)