### PR TITLE
Emit ingestor health metric from status state

### DIFF
--- a/ingestor/metrics/service.go
+++ b/ingestor/metrics/service.go
@@ -38,6 +38,7 @@ type ServiceOpts struct {
 	// KustoCli is the Kusto clients for all clusters.
 	KustoCli         []StatementExecutor
 	PeerHealthReport adxmetrics.HealthReporter
+	Region           string
 }
 
 // service manages the collection of metrics for ingestors.
@@ -48,6 +49,7 @@ type service struct {
 	metricsKustoCli []StatementExecutor
 	allKustoClis    []StatementExecutor
 	health          adxmetrics.HealthReporter
+	region          string
 }
 
 func NewService(opts ServiceOpts) Service {
@@ -56,6 +58,7 @@ func NewService(opts ServiceOpts) Service {
 		metricsKustoCli: opts.MetricsKustoCli,
 		allKustoClis:    opts.KustoCli,
 		health:          opts.PeerHealthReport,
+		region:          opts.Region,
 	}
 }
 
@@ -145,18 +148,31 @@ func (s *service) collect(ctx context.Context) {
 				}
 			}
 
+			healthy, unhealthyReason := s.reportHealth()
+
 			logger.Infof("Status IsHealthy=%v "+
 				"UploadQueueSize=%d TransferQueueSize=%d SegmentsTotal=%d SegmentsSize=%d UnhealthyReason=%s "+
 				"ActiveConnections=%d DroppedConnections=%d MaxSegmentAgeSeconds=%0.2f",
-				s.health.IsHealthy(),
+				healthy,
 				s.health.UploadQueueSize(),
 				s.health.TransferQueueSize(),
 				s.health.SegmentsTotal(),
 				s.health.SegmentsSize(),
-				s.health.UnhealthyReason(),
+				unhealthyReason,
 				int(activeConns),
 				int(droppedConns),
 				s.health.MaxSegmentAge().Seconds())
 		}
 	}
+}
+
+func (s *service) reportHealth() (bool, string) {
+	unhealthyReason := s.health.UnhealthyReason()
+	if unhealthyReason == "" {
+		adxmetrics.IngestorHealthCheck.WithLabelValues(s.region).Set(1)
+		return true, ""
+	}
+
+	adxmetrics.IngestorHealthCheck.WithLabelValues(s.region).Set(0)
+	return false, unhealthyReason
 }

--- a/ingestor/metrics/service_test.go
+++ b/ingestor/metrics/service_test.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	adxmetrics "github.com/Azure/adx-mon/metrics"
+	"github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_ReportHealth(t *testing.T) {
+	region := "test-report-health"
+	s := &service{
+		health: &fakeHealthReporter{},
+		region: region,
+	}
+
+	healthy, unhealthyReason := s.reportHealth()
+	require.True(t, healthy)
+	require.Empty(t, unhealthyReason)
+	require.Equal(t, float64(1), ingestorHealthCheckValue(t, region))
+
+	s.health = &fakeHealthReporter{unhealthyReason: "MaxDiskUsageExceeded"}
+
+	healthy, unhealthyReason = s.reportHealth()
+	require.False(t, healthy)
+	require.Equal(t, "MaxDiskUsageExceeded", unhealthyReason)
+	require.Equal(t, float64(0), ingestorHealthCheckValue(t, region))
+}
+
+func ingestorHealthCheckValue(t *testing.T, region string) float64 {
+	t.Helper()
+
+	m := &io_prometheus_client.Metric{}
+	require.NoError(t, adxmetrics.IngestorHealthCheck.WithLabelValues(region).Write(m))
+	return m.GetGauge().GetValue()
+}
+
+type fakeHealthReporter struct {
+	unhealthyReason string
+}
+
+func (f *fakeHealthReporter) IsHealthy() bool {
+	return f.unhealthyReason == ""
+}
+
+func (f *fakeHealthReporter) TransferQueueSize() int {
+	return 0
+}
+
+func (f *fakeHealthReporter) UploadQueueSize() int {
+	return 0
+}
+
+func (f *fakeHealthReporter) SegmentsTotal() int64 {
+	return 0
+}
+
+func (f *fakeHealthReporter) SegmentsSize() int64 {
+	return 0
+}
+
+func (f *fakeHealthReporter) UnhealthyReason() string {
+	return f.unhealthyReason
+}
+
+func (f *fakeHealthReporter) MaxSegmentAge() time.Duration {
+	return 0
+}

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -64,7 +64,10 @@ type Service struct {
 	scheduler *scheduler.Periodic
 
 	dropFilePrefixes []string
-	health           interface{ IsHealthy() bool }
+	health           interface {
+		IsHealthy() bool
+		UnhealthyReason() string
+	}
 }
 
 type ServiceOpts struct {
@@ -388,13 +391,22 @@ func (s *Service) HandleDebugStore(w http.ResponseWriter, r *http.Request) {
 
 // HandleReady handles the readiness probe.
 func (s *Service) HandleReady(w http.ResponseWriter, r *http.Request) {
-	if s.health.IsHealthy() {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	backend := s.opts.StorageBackend
+	if backend == "" {
+		backend = storage.BackendADX
+	}
+
+	unhealthyReason := s.health.UnhealthyReason()
+	if unhealthyReason == "" {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		fmt.Fprintf(w, "status=ok backend=%s\n", backend)
 		return
 	}
+
 	w.WriteHeader(http.StatusServiceUnavailable)
-	w.Write([]byte("not ready"))
+	fmt.Fprintf(w, "status=not_ready reason=%s backend=%s\n", unhealthyReason, backend)
 }
 
 // HandleTransfer handles the transfer WAL segments from other nodes in the cluster.

--- a/ingestor/service.go
+++ b/ingestor/service.go
@@ -64,10 +64,7 @@ type Service struct {
 	scheduler *scheduler.Periodic
 
 	dropFilePrefixes []string
-	health           interface {
-		IsHealthy() bool
-		UnhealthyReason() string
-	}
+	health           interface{ IsHealthy() bool }
 }
 
 type ServiceOpts struct {
@@ -234,6 +231,7 @@ func NewService(opts ServiceOpts) (*Service, error) {
 		MetricsKustoCli:  opts.MetricsKustoCli,
 		KustoCli:         allKustoCli,
 		PeerHealthReport: health,
+		Region:           opts.Region,
 	})
 
 	dbs := make(map[string]struct{}, len(opts.AllowedDatabase))
@@ -293,11 +291,6 @@ func (s *Service) Open(ctx context.Context) error {
 	if err := s.scheduler.Open(svcCtx); err != nil {
 		return err
 	}
-
-	s.scheduler.ScheduleEvery(time.Minute, "ingestor-health-check", func(ctx context.Context) error {
-		metrics.IngestorHealthCheck.WithLabelValues(s.opts.Region).Set(1)
-		return nil
-	})
 
 	if s.opts.StorageBackend == storage.BackendADX {
 		fnStore := ingestorstorage.NewFunctions(s.opts.K8sCtrlCli, s.coordinator)
@@ -391,22 +384,13 @@ func (s *Service) HandleDebugStore(w http.ResponseWriter, r *http.Request) {
 
 // HandleReady handles the readiness probe.
 func (s *Service) HandleReady(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-
-	backend := s.opts.StorageBackend
-	if backend == "" {
-		backend = storage.BackendADX
-	}
-
-	unhealthyReason := s.health.UnhealthyReason()
-	if unhealthyReason == "" {
+	if s.health.IsHealthy() {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "status=ok backend=%s\n", backend)
+		w.Write([]byte("ok"))
 		return
 	}
-
 	w.WriteHeader(http.StatusServiceUnavailable)
-	fmt.Fprintf(w, "status=not_ready reason=%s backend=%s\n", unhealthyReason, backend)
+	w.Write([]byte("not ready"))
 }
 
 // HandleTransfer handles the transfer WAL segments from other nodes in the cluster.

--- a/ingestor/service_test.go
+++ b/ingestor/service_test.go
@@ -11,17 +11,60 @@ import (
 	"testing"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
+	"github.com/Azure/adx-mon/ingestor/cluster"
 	"github.com/Azure/adx-mon/pkg/otlp"
 	"github.com/Azure/adx-mon/pkg/prompb"
+	"github.com/Azure/adx-mon/storage"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeHealthChecker struct {
-	healthy bool
+	healthy         bool
+	unhealthyReason string
 }
 
 func (f *fakeHealthChecker) IsHealthy() bool {
+	if f.unhealthyReason != "" {
+		return false
+	}
 	return f.healthy
+}
+
+func (f *fakeHealthChecker) UnhealthyReason() string {
+	return f.unhealthyReason
+}
+
+func TestService_HandleReady_Healthy(t *testing.T) {
+	s := &Service{
+		opts:   ServiceOpts{StorageBackend: storage.BackendClickHouse},
+		health: &fakeHealthChecker{healthy: true},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/readyz", nil)
+	require.NoError(t, err)
+
+	resp := httptest.NewRecorder()
+	s.HandleReady(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
+	require.Equal(t, "status=ok backend=clickhouse\n", resp.Body.String())
+}
+
+func TestService_HandleReady_Unhealthy(t *testing.T) {
+	s := &Service{
+		health: &fakeHealthChecker{unhealthyReason: cluster.ReasonMaxDiskUsageExceeded},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/readyz", nil)
+	require.NoError(t, err)
+
+	resp := httptest.NewRecorder()
+	s.HandleReady(resp, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, resp.Code)
+	require.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
+	require.Equal(t, "status=not_ready reason=MaxDiskUsageExceeded backend=adx\n", resp.Body.String())
 }
 
 func TestService_HandleTransfer_DroppedPrefix(t *testing.T) {

--- a/ingestor/service_test.go
+++ b/ingestor/service_test.go
@@ -11,60 +11,17 @@ import (
 	"testing"
 
 	"github.com/Azure/adx-mon/collector/logs/types"
-	"github.com/Azure/adx-mon/ingestor/cluster"
 	"github.com/Azure/adx-mon/pkg/otlp"
 	"github.com/Azure/adx-mon/pkg/prompb"
-	"github.com/Azure/adx-mon/storage"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeHealthChecker struct {
-	healthy         bool
-	unhealthyReason string
+	healthy bool
 }
 
 func (f *fakeHealthChecker) IsHealthy() bool {
-	if f.unhealthyReason != "" {
-		return false
-	}
 	return f.healthy
-}
-
-func (f *fakeHealthChecker) UnhealthyReason() string {
-	return f.unhealthyReason
-}
-
-func TestService_HandleReady_Healthy(t *testing.T) {
-	s := &Service{
-		opts:   ServiceOpts{StorageBackend: storage.BackendClickHouse},
-		health: &fakeHealthChecker{healthy: true},
-	}
-
-	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/readyz", nil)
-	require.NoError(t, err)
-
-	resp := httptest.NewRecorder()
-	s.HandleReady(resp, req)
-
-	require.Equal(t, http.StatusOK, resp.Code)
-	require.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
-	require.Equal(t, "status=ok backend=clickhouse\n", resp.Body.String())
-}
-
-func TestService_HandleReady_Unhealthy(t *testing.T) {
-	s := &Service{
-		health: &fakeHealthChecker{unhealthyReason: cluster.ReasonMaxDiskUsageExceeded},
-	}
-
-	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/readyz", nil)
-	require.NoError(t, err)
-
-	resp := httptest.NewRecorder()
-	s.HandleReady(resp, req)
-
-	require.Equal(t, http.StatusServiceUnavailable, resp.Code)
-	require.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
-	require.Equal(t, "status=not_ready reason=MaxDiskUsageExceeded backend=adx\n", resp.Body.String())
 }
 
 func TestService_HandleTransfer_DroppedPrefix(t *testing.T) {


### PR DESCRIPTION
The ingestor health check metric was emitted from a scheduler path that always set it to healthy, so it behaved like a liveness signal instead of reflecting the backpressure health state.

This moves the existing `adxmon_ingestor_health_check` gauge emission into the ingestor metrics status path, next to the `UnhealthyReason` log. The metric keeps its existing name and `region` label, and now emits `1` when the ingestor is healthy and `0` when the same health state reports an unhealthy reason. The prior `/readyz` response-shape change has been reverted.

Testing:
- `go test ./ingestor ./ingestor/metrics ./ingestor/cluster`
- `go test ./...`

Fixes: azure-management-and-platforms/aks-infra-obs#381
