### PR TITLE
perf(ingestor): optimize prom_rate to a single per-series pass

### DIFF
--- a/ingestor/adx/fake.go
+++ b/ingestor/adx/fake.go
@@ -83,10 +83,12 @@ func (f *fakeUploader) upload(ctx context.Context) {
 
 type fakeKustoMgmt struct {
 	expectedQuery, actualQuery string
+	queries                    []string
 }
 
 func (f *fakeKustoMgmt) Mgmt(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (kustov1.Dataset, error) {
 	f.actualQuery = query.String()
+	f.queries = append(f.queries, f.actualQuery)
 	return kustov1.NewDataset(ctx, kustoerrors.OpMgmt, kustov1.V1{Tables: []kustov1.RawTable{
 		{
 			TableName: "Table_0",

--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -271,11 +271,6 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 		)}`},
 
 		{
-			// prom_rate fuses the counter-increase and rate division into a single
-			// per-series partition pass. prev/next require a serialized (single-threaded)
-			// row set, so the per-series time-ordered scan is the dominant cost; doing it
-			// once (instead of prom_increase plus a second serialized prev pass over every
-			// row) roughly halves peak memory with identical results.
 			name: "prom_rate",
 			body: `.create-or-alter function prom_rate (T:(Timestamp:datetime, SeriesId: long, Labels:dynamic, Value:real), interval:timespan=1m) {
 		T

--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -271,13 +271,23 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 		)}`},
 
 		{
+			// prom_rate fuses the counter-increase and rate division into a single
+			// per-series partition pass. prev/next require a serialized (single-threaded)
+			// row set, so the per-series time-ordered scan is the dominant cost; doing it
+			// once (instead of prom_increase plus a second serialized prev pass over every
+			// row) roughly halves peak memory with identical results.
 			name: "prom_rate",
 			body: `.create-or-alter function prom_rate (T:(Timestamp:datetime, SeriesId: long, Labels:dynamic, Value:real), interval:timespan=1m) {
 		T
-		| invoke prom_increase(interval=interval)
-		| extend Value=Value/((Timestamp-prev(Timestamp))/1s)
-		| where isnotnull(Value)
-		| where isnan(Value) == false}`},
+		| where isnan(Value) == false
+		| partition hint.strategy=shuffle by SeriesId (
+			order by Timestamp asc
+			| extend prevVal=prev(Value), prevTs=prev(Timestamp)
+			| extend inc=case(isnull(prevVal), real(null), Value-prevVal < 0, next(Value)-Value, Value-prevVal)
+			| extend Value=inc/((Timestamp-prevTs)/1s)
+			| project Timestamp, SeriesId, Labels, Value
+		)
+		| where isnotnull(Value) and isnan(Value) == false}`},
 
 		{
 

--- a/ingestor/adx/syncer.go
+++ b/ingestor/adx/syncer.go
@@ -278,11 +278,12 @@ func (s *Syncer) ensurePromMetricsFunctions(ctx context.Context) error {
 		| partition hint.strategy=shuffle by SeriesId (
 			order by Timestamp asc
 			| extend prevVal=prev(Value), prevTs=prev(Timestamp)
+			| extend sampleGap=(Timestamp-prevTs)/1s
 			| extend inc=case(isnull(prevVal), real(null), Value-prevVal < 0, next(Value)-Value, Value-prevVal)
-			| extend Value=inc/((Timestamp-prevTs)/1s)
+			| extend Value=iff(sampleGap > 0, inc/sampleGap, real(null))
 			| project Timestamp, SeriesId, Labels, Value
 		)
-		| where isnotnull(Value) and isnan(Value) == false}`},
+		| where isfinite(Value)}`},
 
 		{
 

--- a/ingestor/adx/syncer_test.go
+++ b/ingestor/adx/syncer_test.go
@@ -1,6 +1,7 @@
 package adx
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -25,6 +26,26 @@ func TestSyncer_EnsureTable(t *testing.T) {
 	s := NewSyncer(kcli, "db", schema.SchemaMapping{}, PromMetrics)
 	require.NoError(t, s.EnsureDefaultTable("Test"))
 	kcli.Verify(t)
+}
+
+func TestSyncer_EnsurePromMetricsFunctionsCreatesPromRate(t *testing.T) {
+	kcli := &fakeKustoMgmt{}
+
+	s := NewSyncer(kcli, "db", schema.SchemaMapping{}, PromMetrics)
+	require.NoError(t, s.ensurePromMetricsFunctions(context.Background()))
+	require.Len(t, kcli.queries, 3)
+	require.Equal(t, `.create-or-alter function prom_rate (T:(Timestamp:datetime, SeriesId: long, Labels:dynamic, Value:real), interval:timespan=1m) {
+		T
+		| where isnan(Value) == false
+		| partition hint.strategy=shuffle by SeriesId (
+			order by Timestamp asc
+			| extend prevVal=prev(Value), prevTs=prev(Timestamp)
+			| extend sampleGap=(Timestamp-prevTs)/1s
+			| extend inc=case(isnull(prevVal), real(null), Value-prevVal < 0, next(Value)-Value, Value-prevVal)
+			| extend Value=iff(sampleGap > 0, inc/sampleGap, real(null))
+			| project Timestamp, SeriesId, Labels, Value
+		)
+		| where isfinite(Value)}`, kcli.queries[1])
 }
 
 func TestSanitizerErrorString(t *testing.T) {

--- a/ingestor/adx/syncer_test.go
+++ b/ingestor/adx/syncer_test.go
@@ -3,6 +3,7 @@ package adx
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Azure/adx-mon/schema"
@@ -34,18 +35,19 @@ func TestSyncer_EnsurePromMetricsFunctionsCreatesPromRate(t *testing.T) {
 	s := NewSyncer(kcli, "db", schema.SchemaMapping{}, PromMetrics)
 	require.NoError(t, s.ensurePromMetricsFunctions(context.Background()))
 	require.Len(t, kcli.queries, 3)
-	require.Equal(t, `.create-or-alter function prom_rate (T:(Timestamp:datetime, SeriesId: long, Labels:dynamic, Value:real), interval:timespan=1m) {
-		T
-		| where isnan(Value) == false
-		| partition hint.strategy=shuffle by SeriesId (
-			order by Timestamp asc
-			| extend prevVal=prev(Value), prevTs=prev(Timestamp)
-			| extend sampleGap=(Timestamp-prevTs)/1s
-			| extend inc=case(isnull(prevVal), real(null), Value-prevVal < 0, next(Value)-Value, Value-prevVal)
-			| extend Value=iff(sampleGap > 0, inc/sampleGap, real(null))
-			| project Timestamp, SeriesId, Labels, Value
-		)
-		| where isfinite(Value)}`, kcli.queries[1])
+
+	require.Contains(t, kcli.queries[0], ".create-or-alter function prom_increase")
+	require.Contains(t, kcli.queries[1], ".create-or-alter function prom_rate")
+	require.Contains(t, kcli.queries[2], ".create-or-alter function prom_delta")
+
+	promRate := kcli.queries[1]
+	require.True(t, strings.HasPrefix(promRate, ".create-or-alter function prom_rate "), promRate)
+	require.Contains(t, promRate, "| partition hint.strategy=shuffle by SeriesId (")
+	require.Contains(t, promRate, "| extend sampleGap=(Timestamp-prevTs)/1s")
+	require.Contains(t, promRate, "| extend Value=iff(sampleGap > 0, inc/sampleGap, real(null))")
+	require.Contains(t, promRate, "| where isfinite(Value)")
+	require.NotContains(t, promRate, "| invoke prom_increase")
+	require.NotContains(t, promRate, "Value=inc/((Timestamp-prevTs)/1s)")
 }
 
 func TestSanitizerErrorString(t *testing.T) {


### PR DESCRIPTION
This is a follow up to a recent meeting regarding the performance of `prom_rate`. The git commit explains the issue with the current implementation and how the optimized version helps. The optimization reduces memory consumption by 30%.