### PR TITLE
Migrate alerter to azkustodata

### DIFF
--- a/alerter/engine/client.go
+++ b/alerter/engine/client.go
@@ -3,12 +3,12 @@ package engine
 import (
 	"context"
 
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 )
 
 type Client interface {
 	Endpoint(db string) string
-	Query(ctx context.Context, qc *QueryContext, fn func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error) (error, int)
+	Query(ctx context.Context, qc *QueryContext, fn func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error) (error, int)
 	AvailableDatabases() []string
 	FindCaseInsensitiveMatch(db string) string
 }

--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -2,22 +2,27 @@ package engine
 
 import (
 	"fmt"
-	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/Azure/azure-kusto-go/kusto"
-	kustotypes "github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/unsafe"
 	"strings"
 	"time"
+
+	"github.com/Azure/adx-mon/alerter/rules"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 )
 
 type QueryContext struct {
 	Rule      *rules.Rule
 	Query     string
-	Stmt      kusto.Stmt
-	Params    kusto.Parameters
+	Stmt      azkustodata.Statement
+	Params    *kql.Parameters
 	Region    string
 	StartTime time.Time
 	EndTime   time.Time
+}
+
+type queryParam struct {
+	name  string
+	value any
 }
 
 func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*QueryContext, error) {
@@ -46,51 +51,27 @@ let _region = _adxmonRegion;
 %s
 `, strings.TrimSpace(q.Rule.Query))
 
-	stmt := kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(query)
-
-	// Setup the query execution parameters that can be reference in the query
-	var err error
-	def := kusto.NewDefinitions()
-	def, err = def.With(kusto.ParamTypes{
-		"_adxmonStartTime": kusto.ParamType{Type: kustotypes.DateTime},
-		"_adxmonEndTime":   kusto.ParamType{Type: kustotypes.DateTime},
-		"_adxmonRegion":    kusto.ParamType{Type: kustotypes.String},
-		"ParamRegion":      kusto.ParamType{Type: kustotypes.String}, // This is a deprecated parameter
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create query definitions: %w", err)
+	stmt := kql.New("").AddUnsafe(query)
+	queryParams := []queryParam{
+		{name: "_adxmonStartTime", value: q.StartTime},
+		{name: "_adxmonEndTime", value: q.EndTime},
+		{name: "_adxmonRegion", value: q.Region},
+		{name: "ParamRegion", value: q.Region}, // This is a deprecated parameter.
 	}
-
-	stmt, err = stmt.WithDefinitions(def)
-	if err != nil {
-		return fmt.Errorf("failed to create query statement: %w", err)
-	}
-
-	qv := kusto.QueryValues{}
-	qv["_adxmonStartTime"] = q.StartTime
-	qv["_adxmonEndTime"] = q.EndTime
-	qv["_adxmonRegion"] = q.Region
-	qv["ParamRegion"] = q.Region
-
-	for k, v := range qv {
-		switch vv := v.(type) {
+	params := kql.NewParameters()
+	for _, param := range queryParams {
+		var literal string
+		switch v := param.value.(type) {
 		case string:
-			query = strings.Replace(query, k, fmt.Sprintf("\"%s\"", vv), -1)
+			params.AddString(param.name, v)
+			literal = fmt.Sprintf("%q", v)
 		case time.Time:
-			query = strings.Replace(query, k, fmt.Sprintf("datetime(%s)", vv.Format("2006-01-02T15:04:05.999999Z")), -1)
+			params.AddDateTime(param.name, v)
+			literal = fmt.Sprintf("datetime(%s)", v.Format("2006-01-02T15:04:05.999999Z"))
 		default:
-			panic(fmt.Sprintf("unimplemented query type: %v", vv))
+			return fmt.Errorf("unsupported query parameter %s type %T", param.name, v)
 		}
-	}
-
-	params, err := kusto.NewParameters().With(qv)
-	if err != nil {
-		return fmt.Errorf("failed to create kusto parameters: %w", err)
-	}
-
-	stmt, err = stmt.WithParameters(params)
-	if err != nil {
-		return fmt.Errorf("failed to create kusto statement: %w", err)
+		query = strings.ReplaceAll(query, param.name, literal)
 	}
 
 	q.Query = query

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -187,7 +187,7 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 		Title:         res.Title,
 		Summary:       summary,
 		Description:   res.Description,
-		Severity:      int(res.Severity),
+		Severity:      clampInt64ToInt(res.Severity),
 		Source:        fmt.Sprintf("%s/%s", qc.Rule.Namespace, qc.Rule.Name),
 		CorrelationID: res.CorrelationID,
 		CustomFields:  res.CustomFields,
@@ -210,6 +210,16 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 	metrics.NotificationUnhealthy.WithLabelValues(qc.Rule.Namespace, qc.Rule.Name).Set(0)
 
 	return nil
+}
+
+func clampInt64ToInt(v int64) int {
+	if v > int64(math.MaxInt) {
+		return math.MaxInt
+	}
+	if v < int64(math.MinInt) {
+		return math.MinInt
+	}
+	return int(v)
 }
 
 func validateNotificationColumns(columns []string) error {

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -15,8 +15,10 @@ import (
 	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	kustovalues "github.com/Azure/azure-kusto-go/kusto/data/value"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
+	"github.com/shopspring/decimal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -121,19 +123,23 @@ func (e *Executor) Close() error {
 }
 
 // HandlerFn converts rows of a query to Alerts.
-func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error {
+func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error {
 	res := Notification{
 		Severity:     math.MinInt64,
 		CustomFields: map[string]string{},
 	}
 
-	columns := row.ColumnNames()
-	if err := validateNotificationColumns(columns); err != nil {
+	columns := row.Columns()
+	columnNames := make([]string, 0, len(columns))
+	for _, column := range columns {
+		columnNames = append(columnNames, column.Name())
+	}
+	if err := validateNotificationColumns(columnNames); err != nil {
 		return err
 	}
 
-	for i, value := range row.Values {
-		switch strings.ToLower(columns[i]) {
+	for i, value := range row.Values() {
+		switch strings.ToLower(columnNames[i]) {
 		case "title":
 			res.Title = value.String()
 		case "description":
@@ -151,7 +157,7 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 		case "correlationid":
 			res.CorrelationID = value.String()
 		default:
-			res.CustomFields[columns[i]] = value.String()
+			res.CustomFields[columnNames[i]] = value.String()
 		}
 	}
 
@@ -224,29 +230,43 @@ func validateNotificationColumns(columns []string) error {
 	return nil
 }
 
-func (e *Executor) asInt64(value kustovalues.Kusto) (int64, error) {
-	switch t := value.(type) {
-	case kustovalues.Long:
-		return t.Value, nil
-	case kustovalues.Real:
-		return int64(t.Value), nil
-	case kustovalues.String:
-		v, err := strconv.ParseInt(t.Value, 10, 64)
+func (e *Executor) asInt64(value azvalue.Kusto) (int64, error) {
+	if value == nil {
+		return 0, fmt.Errorf("failed to convert severity to int: <nil>")
+	}
+	switch value.GetType() {
+	case aztypes.Long:
+		v, ok := value.GetValue().(*int64)
+		if !ok || v == nil {
+			break
+		}
+		return *v, nil
+	case aztypes.Real:
+		v, ok := value.GetValue().(*float64)
+		if !ok || v == nil {
+			break
+		}
+		return int64(*v), nil
+	case aztypes.String:
+		v, err := strconv.ParseInt(value.String(), 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("failed to convert severity to int: %w", err)
 		}
 		return v, nil
-	case kustovalues.Int:
-		return int64(t.Value), nil
-	case kustovalues.Decimal:
-		v, err := strconv.ParseFloat(t.Value, 64)
-		if err != nil {
-			return 0, fmt.Errorf("failed to convert severity to int: %w", err)
+	case aztypes.Int:
+		v, ok := value.GetValue().(*int32)
+		if !ok || v == nil {
+			break
 		}
-		return int64(v), nil
-	default:
-		return 0, fmt.Errorf("failed to convert severity to int: %s", value.String())
+		return int64(*v), nil
+	case aztypes.Decimal:
+		v, ok := value.GetValue().(*decimal.Decimal)
+		if !ok || v == nil {
+			break
+		}
+		return v.IntPart(), nil
 	}
+	return 0, fmt.Errorf("failed to convert severity to int: %v", value.GetValue())
 }
 
 func (e *Executor) RunOnce(ctx context.Context) {

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -203,6 +204,44 @@ func TestExecutor_asInt64_Errors(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			_, err := e.asInt64(tt.value)
 			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
+func TestClampInt64ToInt(t *testing.T) {
+	for _, tt := range []struct {
+		desc string
+		in   int64
+		want int
+	}{
+		{
+			desc: "within range",
+			in:   10,
+			want: 10,
+		},
+		{
+			desc: "max int",
+			in:   int64(math.MaxInt),
+			want: math.MaxInt,
+		},
+		{
+			desc: "min int",
+			in:   int64(math.MinInt),
+			want: math.MinInt,
+		},
+		{
+			desc: "max int64",
+			in:   math.MaxInt64,
+			want: math.MaxInt,
+		},
+		{
+			desc: "min int64",
+			in:   math.MinInt64,
+			want: math.MinInt,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			require.Equal(t, tt.want, clampInt64ToInt(tt.in))
 		})
 	}
 }

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -3,16 +3,18 @@ package engine
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/queue"
 	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
+	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,25 +28,19 @@ func TestExecutor_Handler_MissingTitle(t *testing.T) {
 		Rule: rule,
 	}
 
-	iter := &kusto.RowIterator{}
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "Severity", Type: types.Long},
-		{Name: "Summary", Type: types.String},
-		{Name: "CorrelationId", Type: types.String},
-	})
-	require.NoError(t, err)
-
-	rows.Row(value.Values{
-		value.Long{Value: 1, Valid: true},
-		value.String{Value: "Fake Alert Summary", Valid: true},
-		value.String{Value: "Fake CorrelationId", Valid: true},
-	})
-
-	require.NoError(t, iter.Mock(rows))
-
-	row, _, _ := iter.NextRowOrError()
-	err = e.HandlerFn(context.Background(), "http://endpoint", qc, row)
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "Severity", aztypes.Long),
+			testColumn(1, "Summary", aztypes.String),
+			testColumn(2, "CorrelationId", aztypes.String),
+		},
+		azvalue.Values{
+			azvalue.NewLong(1),
+			azvalue.NewString("Fake Alert Summary"),
+			azvalue.NewString("Fake CorrelationId"),
+		},
+	)
+	err := e.HandlerFn(context.Background(), "http://endpoint", qc, row)
 	require.ErrorContains(t, err, "title must be between 1 and 512 chars")
 	require.True(t, isUserError(err))
 }
@@ -82,88 +78,61 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 
 	for _, tt := range []struct {
 		desc     string
-		columns  []table.Column
-		rows     value.Values
+		columns  azquery.Columns
+		values   azvalue.Values
 		err      string
 		severity int
 	}{
 		{
 			desc:    "missing severity",
-			columns: table.Columns{{Name: "Title", Type: types.String}},
-			rows:    value.Values{value.String{Value: "Title", Valid: true}},
+			columns: azquery.Columns{testColumn(0, "Title", aztypes.String)},
+			values:  azvalue.Values{azvalue.NewString("Title")},
 			err:     "severity must be specified",
 		},
 		{
-			desc: "severity not convertable to a number",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.String}},
-			rows: value.Values{
-				value.String{Value: "Title", Valid: true},
-				value.String{Value: "not a number", Valid: false}},
-			err: "failed to convert severity to int",
+			desc:    "severity not convertable to a number",
+			columns: azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.String)},
+			values:  azvalue.Values{azvalue.NewString("Title"), azvalue.NewString("not a number")},
+			err:     "failed to convert severity to int",
 		},
 		{
-			desc: "severity as long",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Long}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Long{Value: 1, Valid: false}},
+			desc:     "severity as long",
+			columns:  azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Long)},
+			values:   azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1)},
 			err:      "",
 			severity: 1,
 		},
 		{
-			desc: "severity as string",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.String}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.String{Value: "10", Valid: false}},
+			desc:     "severity as string",
+			columns:  azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.String)},
+			values:   azvalue.Values{azvalue.NewString("Title"), azvalue.NewString("10")},
 			err:      "",
 			severity: 10,
 		},
 		{
-			desc: "severity as real",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Real}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Real{Value: 10.1, Valid: false}},
+			desc:     "severity as real",
+			columns:  azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Real)},
+			values:   azvalue.Values{azvalue.NewString("Title"), azvalue.NewReal(10.1)},
 			err:      "",
 			severity: 10,
 		},
 		{
-			desc: "severity as int",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Int}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Int{Value: 10, Valid: false}},
+			desc:     "severity as int",
+			columns:  azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Int)},
+			values:   azvalue.Values{azvalue.NewString("Title"), azvalue.NewInt(10)},
 			err:      "",
 			severity: 10,
 		},
 		{
-			desc: "severity as decimal",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Decimal}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Decimal{Value: "10.1", Valid: false}},
+			desc:     "severity as decimal",
+			columns:  azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Decimal)},
+			values:   azvalue.Values{azvalue.NewString("Title"), azvalue.NewDecimal(decimal.RequireFromString("10.1"))},
 			err:      "",
 			severity: 10,
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			iter := &kusto.RowIterator{}
-
-			rows, err := kusto.NewMockRows(tt.columns)
-			require.NoError(t, err)
-
-			rows.Row(tt.rows)
-			require.NoError(t, iter.Mock(rows))
-
-			row, _, _ := iter.NextRowOrError()
+			row := testRow(tt.columns, tt.values)
 
 			client := &fakeAlertClient{}
 			e := Executor{
@@ -175,7 +144,7 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 				Rule: rule,
 			}
 
-			err = e.HandlerFn(context.Background(), "http://endpoint", qc, row)
+			err := e.HandlerFn(context.Background(), "http://endpoint", qc, row)
 			if tt.err == "" {
 				require.NoError(t, err)
 				require.Equal(t, tt.severity, client.alert.Severity)
@@ -187,51 +156,83 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 	}
 }
 
+func TestExecutor_asInt64_Errors(t *testing.T) {
+	e := &Executor{}
+
+	for _, tt := range []struct {
+		desc  string
+		value azvalue.Kusto
+		err   string
+	}{
+		{
+			desc:  "nil value",
+			value: nil,
+			err:   "failed to convert severity to int: <nil>",
+		},
+		{
+			desc:  "invalid string",
+			value: azvalue.NewString("not a number"),
+			err:   "failed to convert severity to int: strconv.ParseInt",
+		},
+		{
+			desc:  "null long",
+			value: azvalue.NewNullLong(),
+			err:   "failed to convert severity to int:",
+		},
+		{
+			desc:  "null real",
+			value: azvalue.NewNullReal(),
+			err:   "failed to convert severity to int:",
+		},
+		{
+			desc:  "null int",
+			value: azvalue.NewNullInt(),
+			err:   "failed to convert severity to int:",
+		},
+		{
+			desc:  "null decimal",
+			value: azvalue.NewNullDecimal(),
+			err:   "failed to convert severity to int:",
+		},
+		{
+			desc:  "unsupported type",
+			value: unsupportedKustoValue{},
+			err:   "failed to convert severity to int:",
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := e.asInt64(tt.value)
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
 func TestExecutor_Handler_DuplicateReservedColumnsDifferentCase(t *testing.T) {
-	iter := &kusto.RowIterator{}
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "Title", Type: types.String},
-		{Name: "Severity", Type: types.Long},
-		{Name: "severity", Type: types.Long},
-	})
-	require.NoError(t, err)
-
-	rows.Row(value.Values{
-		value.String{Value: "Title", Valid: true},
-		value.Long{Value: 1, Valid: true},
-		value.Long{Value: 2, Valid: true},
-	})
-	require.NoError(t, iter.Mock(rows))
-
-	row, _, _ := iter.NextRowOrError()
-	err = (&Executor{alertCli: &fakeAlertClient{}}).HandlerFn(context.Background(), "http://endpoint", &QueryContext{Rule: &rules.Rule{}}, row)
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "Title", aztypes.String),
+			testColumn(1, "Severity", aztypes.Long),
+			testColumn(2, "severity", aztypes.Long),
+		},
+		azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewLong(2)},
+	)
+	err := (&Executor{alertCli: &fakeAlertClient{}}).HandlerFn(context.Background(), "http://endpoint", &QueryContext{Rule: &rules.Rule{}}, row)
 	require.ErrorContains(t, err, `query results include multiple columns for reserved alert field "Severity": Severity, severity`)
 	require.True(t, isUserError(err))
 }
 
 func TestExecutor_Handler_DuplicateCustomColumnsDifferentCase(t *testing.T) {
-	iter := &kusto.RowIterator{}
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "Title", Type: types.String},
-		{Name: "Severity", Type: types.Long},
-		{Name: "CustomField", Type: types.String},
-		{Name: "customfield", Type: types.String},
-	})
-	require.NoError(t, err)
-
-	rows.Row(value.Values{
-		value.String{Value: "Title", Valid: true},
-		value.Long{Value: 1, Valid: true},
-		value.String{Value: "upper", Valid: true},
-		value.String{Value: "lower", Valid: true},
-	})
-	require.NoError(t, iter.Mock(rows))
-
 	client := &fakeAlertClient{}
-	row, _, _ := iter.NextRowOrError()
-	err = (&Executor{alertCli: client}).HandlerFn(context.Background(), "http://endpoint", &QueryContext{Rule: &rules.Rule{Destination: "destination"}}, row)
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "Title", aztypes.String),
+			testColumn(1, "Severity", aztypes.Long),
+			testColumn(2, "CustomField", aztypes.String),
+			testColumn(3, "customfield", aztypes.String),
+		},
+		azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("upper"), azvalue.NewString("lower")},
+	)
+	err := (&Executor{alertCli: client}).HandlerFn(context.Background(), "http://endpoint", &QueryContext{Rule: &rules.Rule{Destination: "destination"}}, row)
 	require.NoError(t, err)
 	require.Equal(t, "upper", client.alert.CustomFields["CustomField"])
 	require.Equal(t, "lower", client.alert.CustomFields["customfield"])
@@ -246,66 +247,38 @@ func TestExecutor_Handler_CorrelationId(t *testing.T) {
 
 	testcases := []struct {
 		desc          string
-		columns       []table.Column
-		rows          value.Values
+		columns       azquery.Columns
+		values        azvalue.Values
 		correlationId string
 	}{
 		{
-			desc: "normal correlation id",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Long},
-				{Name: "CorrelationId", Type: types.String}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Long{Value: 1, Valid: false},
-				value.String{Value: "Fake CorrelationId", Valid: true}},
+			desc:          "normal correlation id",
+			columns:       azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Long), testColumn(2, "CorrelationId", aztypes.String)},
+			values:        azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("Fake CorrelationId")},
 			correlationId: fmt.Sprintf("%s%s", prefix, "Fake CorrelationId"),
 		},
 		{
-			desc: "correlation id already has prefix",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Long},
-				{Name: "CorrelationId", Type: types.String}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Long{Value: 1, Valid: false},
-				value.String{Value: "rulesns/rulename://Fake Correlation Id", Valid: true}},
+			desc:          "correlation id already has prefix",
+			columns:       azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Long), testColumn(2, "CorrelationId", aztypes.String)},
+			values:        azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("rulesns/rulename://Fake Correlation Id")},
 			correlationId: fmt.Sprintf("%s%s", prefix, "Fake Correlation Id"),
 		},
 		{
-			desc: "empty correlation id",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Long},
-				{Name: "CorrelationId", Type: types.String}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Long{Value: 1, Valid: false},
-				value.String{Value: "", Valid: true}},
+			desc:          "empty correlation id",
+			columns:       azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Long), testColumn(2, "CorrelationId", aztypes.String)},
+			values:        azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("")},
 			correlationId: "",
 		},
 		{
-			desc: "no correlation id",
-			columns: table.Columns{
-				{Name: "Title", Type: types.String},
-				{Name: "Severity", Type: types.Long}},
-			rows: value.Values{value.String{Value: "Title", Valid: true},
-				value.Long{Value: 1, Valid: false}},
+			desc:          "no correlation id",
+			columns:       azquery.Columns{testColumn(0, "Title", aztypes.String), testColumn(1, "Severity", aztypes.Long)},
+			values:        azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1)},
 			correlationId: "",
 		},
 	}
 
 	for _, tt := range testcases {
 		t.Run(tt.desc, func(t *testing.T) {
-			iter := &kusto.RowIterator{}
-
-			rows, err := kusto.NewMockRows(tt.columns)
-			require.NoError(t, err)
-
-			rows.Row(tt.rows)
-			require.NoError(t, iter.Mock(rows))
-
-			row, _, _ := iter.NextRowOrError()
-
 			client := &fakeAlertClient{}
 			e := Executor{
 				alertCli: client,
@@ -319,11 +292,43 @@ func TestExecutor_Handler_CorrelationId(t *testing.T) {
 				Rule: rule,
 			}
 
-			err = e.HandlerFn(context.Background(), "http://endpoint", qc, row)
+			err := e.HandlerFn(context.Background(), "http://endpoint", qc, testRow(tt.columns, tt.values))
 			require.NoError(t, err)
 			require.Equal(t, tt.correlationId, client.alert.CorrelationID)
 		})
 	}
+}
+
+func testRow(columns azquery.Columns, values azvalue.Values) azquery.Row {
+	base := azquery.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	table := azquery.NewBaseTable(base, 0, "", "QueryResult", "QueryResult", columns)
+	return azquery.NewRow(table, 0, values)
+}
+
+func testColumn(index int, name string, columnType aztypes.Column) azquery.Column {
+	return azquery.NewColumn(index, name, columnType)
+}
+
+type unsupportedKustoValue struct{}
+
+func (unsupportedKustoValue) String() string {
+	panic("String should not be called")
+}
+
+func (unsupportedKustoValue) Convert(reflect.Value) error {
+	return nil
+}
+
+func (unsupportedKustoValue) GetValue() interface{} {
+	return nil
+}
+
+func (unsupportedKustoValue) GetType() aztypes.Column {
+	return aztypes.Bool
+}
+
+func (unsupportedKustoValue) Unmarshal(interface{}) error {
+	return nil
 }
 
 func TestExecutor_RunOnce(t *testing.T) {

--- a/alerter/engine/fake.go
+++ b/alerter/engine/fake.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 )
 
 func NewFakeKustoClient() Client {
@@ -15,14 +15,14 @@ func NewFakeKustoClient() Client {
 
 type fakeKustoClient struct {
 	queryErr error
-	queryFn  func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int)
+	queryFn  func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int)
 }
 
 func (m *fakeKustoClient) Endpoint(db string) string {
 	return fmt.Sprintf("%s.mockcluster.kusto.windows.net", db)
 }
 
-func (m *fakeKustoClient) Query(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+func (m *fakeKustoClient) Query(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 	if m.queryErr != nil {
 		return m.queryErr, 0
 	}

--- a/alerter/engine/status_test.go
+++ b/alerter/engine/status_test.go
@@ -6,16 +6,16 @@ import (
 	"testing"
 
 	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWorker_StatusUpdate_NoKubernetesClient(t *testing.T) {
 	// Test that status updates are gracefully skipped when no Kubernetes client is available
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			// Simulate 1 row being processed
-			fn(ctx, "fake.endpoint", qc, &table.Row{})
+			fn(ctx, "fake.endpoint", qc, testRow(nil, nil))
 			return nil, 1
 		},
 	}
@@ -26,7 +26,7 @@ func TestWorker_StatusUpdate_NoKubernetesClient(t *testing.T) {
 		Database:  "TestDB",
 	}
 
-	w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: &fakeAlerter{}, AlertAddr: "http://fake.alert.addr", HandlerFn: func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error {
+	w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: &fakeAlerter{}, AlertAddr: "http://fake.alert.addr", HandlerFn: func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error {
 		return nil
 	}})
 
@@ -68,9 +68,9 @@ func TestWorker_AlertCounting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kcli := &fakeKustoClient{
-				queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+				queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 					for i := 0; i < tt.numRows; i++ {
-						fn(ctx, "fake.endpoint", qc, &table.Row{})
+						fn(ctx, "fake.endpoint", qc, testRow(nil, nil))
 					}
 					return nil, tt.numRows
 				},
@@ -82,7 +82,7 @@ func TestWorker_AlertCounting(t *testing.T) {
 				Database:  "TestDB",
 			}
 
-			w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: &fakeAlerter{}, AlertAddr: "http://fake.alert.addr", HandlerFn: func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error {
+			w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: &fakeAlerter{}, AlertAddr: "http://fake.alert.addr", HandlerFn: func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error {
 				if tt.handlerSuccess {
 					return nil // Success - alert generated
 				}

--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -14,8 +14,8 @@ import (
 	alertrulev1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
-	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	kerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +38,7 @@ type worker struct {
 	alertCli    interface {
 		Create(ctx context.Context, endpoint string, alert alert.Alert) error
 	}
-	handlerFn       func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error
+	handlerFn       func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error
 	querySlots      chan struct{}
 	ctrlCli         client.Client
 	alertsGenerated int // Track alerts generated in current execution
@@ -59,7 +59,7 @@ type WorkerConfig struct {
 		Create(ctx context.Context, endpoint string, alert alert.Alert) error
 	}
 	AlertAddr        string
-	HandlerFn        func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error
+	HandlerFn        func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error
 	CtrlClient       client.Client
 	sharedQuerySlots chan struct{}
 }
@@ -201,7 +201,7 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 	logger.Infof("Executing %s/%s on %s/%s", e.rule.Namespace, e.rule.Name, e.kustoClient.Endpoint(e.rule.Database), e.rule.Database)
 
 	// Create a wrapper handler that tracks alerts generated
-	wrappedHandler := func(ctx context.Context, endpoint string, qc *QueryContext, row *table.Row) error {
+	wrappedHandler := func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error {
 		err := e.handlerFn(ctx, endpoint, qc, row)
 		if err == nil {
 			// If HandlerFn succeeded, it means an alert was generated

--- a/alerter/engine/worker_test.go
+++ b/alerter/engine/worker_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/rules"
 	"github.com/Azure/adx-mon/metrics"
-	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	kerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
@@ -33,7 +33,7 @@ const (
 
 func TestWorker_TagsMismatch(t *testing.T) {
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			t.Logf("Query should not be called")
 			t.Fail()
 			return nil, 0
@@ -68,7 +68,7 @@ func TestWorker_TagsMismatch(t *testing.T) {
 func TestWorker_TagsAtLeastOne(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -103,7 +103,7 @@ func TestWorker_TagsAtLeastOne(t *testing.T) {
 func TestWorker_ExecuteQuery_StopsWaitingForSlotOnCancel(t *testing.T) {
 	queryCalled := false
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -152,7 +152,7 @@ func TestWorker_ExecuteQuery_StopsWaitingForSlotOnCancel(t *testing.T) {
 func TestWorker_ExecuteQuery_DoesNotAcquireSlotWhenAlreadyCanceled(t *testing.T) {
 	queryCalled := false
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -182,7 +182,7 @@ func TestWorker_ExecuteQuery_DoesNotAcquireSlotWhenAlreadyCanceled(t *testing.T)
 func TestWorker_TagsNoneMatch(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -217,7 +217,7 @@ func TestWorker_TagsNoneMatch(t *testing.T) {
 func TestWorker_TagsMultiple(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -263,7 +263,7 @@ func TestWorker_TagsMultiple(t *testing.T) {
 func TestWorker_CriteriaExpression_ExecutesOnMatch(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -284,7 +284,7 @@ func TestWorker_CriteriaExpression_ExecutesOnMatch(t *testing.T) {
 func TestWorker_CriteriaExpression_ExecutesOnMatchTwo(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},
@@ -306,7 +306,7 @@ func TestWorker_CriteriaExpression_ExecutesOnMatchTwo(t *testing.T) {
 func TestWorker_CriteriaExpression_SkipsOnNoMatch(t *testing.T) {
 	var queryCalled bool
 	kcli := &fakeKustoClient{
-		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, *table.Row) error) (error, int) {
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
 			queryCalled = true
 			return nil, 0
 		},

--- a/alerter/fake.go
+++ b/alerter/fake.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"html"
 	"io"
 	"net/http"
@@ -12,52 +11,12 @@ import (
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
 )
 
 const icmTitleMaxLength = 150
 
 type fakeKustoClient struct {
 	endpoint string
-}
-
-func (f fakeKustoClient) Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
-	return nil, nil
-}
-
-func (f fakeKustoClient) Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error) {
-	iter := &kusto.RowIterator{}
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "Title", Type: types.String},
-		{Name: "Severity", Type: types.Long},
-		{Name: "Summary", Type: types.String},
-		{Name: "CorrelationId", Type: types.String},
-	})
-	if err != nil {
-		return nil, err
-	}
-	rows.Row(value.Values{
-		value.String{Value: "Fake Alert", Valid: true},
-		value.Long{Value: 1, Valid: true},
-		value.String{Value: "Fake Alert Summary", Valid: true},
-		value.String{Value: "Fake CorrelationId", Valid: true},
-	})
-
-	// Work-around to prevent the iter.Mock call from panicing because it's not running in a test.
-	if flag.Lookup("test.v") == nil {
-		flag.String("test.v", "", "")
-		if err := flag.CommandLine.Set("test.v", "true"); err != nil {
-			panic(err)
-		}
-	}
-	if err := iter.Mock(rows); err != nil {
-		panic(err)
-	}
-	return iter, nil
 }
 
 func (f fakeKustoClient) Endpoint() string {

--- a/alerter/lint_test.go
+++ b/alerter/lint_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 
 	"github.com/Azure/adx-mon/alerter/engine"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
+	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,34 +51,22 @@ func (f fakeLintKustoClient) Endpoint(db string) string {
 	return "https://fake.kusto.windows.net"
 }
 
-func (f fakeLintKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn func(context.Context, string, *engine.QueryContext, *table.Row) error) (error, int) {
-	iter := &kusto.RowIterator{}
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "Title", Type: types.String},
-		{Name: "Severity", Type: types.Long},
-		{Name: "severity", Type: types.Long},
-	})
-	if err != nil {
-		return err, 0
-	}
-
-	if err := rows.Row(value.Values{
-		value.String{Value: "Title", Valid: true},
-		value.Long{Value: 1, Valid: true},
-		value.Long{Value: 2, Valid: true},
-	}); err != nil {
-		return err, 0
-	}
-
-	if err := iter.Mock(rows); err != nil {
-		return err, 0
-	}
-
-	row, _, _ := iter.NextRowOrError()
+func (f fakeLintKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn func(context.Context, string, *engine.QueryContext, azquery.Row) error) (error, int) {
+	row := lintTestRow()
 	if err := fn(ctx, f.Endpoint(qc.Rule.Database), qc, row); err != nil {
 		return err, 0
 	}
 	return nil, 1
+}
+
+func lintTestRow() azquery.Row {
+	base := azquery.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	table := azquery.NewBaseTable(base, 0, "", "QueryResult", "QueryResult", []azquery.Column{
+		azquery.NewColumn(0, "Title", aztypes.String),
+		azquery.NewColumn(1, "Severity", aztypes.Long),
+		azquery.NewColumn(2, "severity", aztypes.Long),
+	})
+	return azquery.NewRow(table, 0, azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewLong(2)})
 }
 
 func (f fakeLintKustoClient) AvailableDatabases() []string {

--- a/alerter/multikustoclient/auth.go
+++ b/alerter/multikustoclient/auth.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
 )
 
 // AuthConfiguror is a function that can be used to configure a kusto connection's authentication method
-type authConfiguror func(*kusto.ConnectionStringBuilder) *kusto.ConnectionStringBuilder
+type authConfiguror func(*azkustodata.ConnectionStringBuilder) *azkustodata.ConnectionStringBuilder
 
 type authMethod func() (authConfiguror, error)
 
@@ -16,7 +16,7 @@ type authMethod func() (authConfiguror, error)
 func DefaultAuth() authMethod {
 	return func() (authConfiguror, error) {
 		logger.Infof("Using default authentication")
-		return func(kcsb *kusto.ConnectionStringBuilder) *kusto.ConnectionStringBuilder {
+		return func(kcsb *azkustodata.ConnectionStringBuilder) *azkustodata.ConnectionStringBuilder {
 			return kcsb.WithDefaultAzureCredential()
 		}, nil
 	}
@@ -29,8 +29,8 @@ func MsiAuth(msi string) authMethod {
 			return nil, fmt.Errorf("msi cannot be empty")
 		}
 		logger.Infof("Using MSI authentication")
-		return func(kcsb *kusto.ConnectionStringBuilder) *kusto.ConnectionStringBuilder {
-			return kcsb.WithUserManagedIdentity(msi)
+		return func(kcsb *azkustodata.ConnectionStringBuilder) *azkustodata.ConnectionStringBuilder {
+			return kcsb.WithUserAssignedIdentityClientId(msi)
 		}, nil
 	}
 }
@@ -45,7 +45,7 @@ func TokenAuth(kustoAppId string, kustoToken string) authMethod {
 			return nil, fmt.Errorf("token cannot be empty")
 		}
 		logger.Infof("Using token authentication")
-		return func(kcsb *kusto.ConnectionStringBuilder) *kusto.ConnectionStringBuilder {
+		return func(kcsb *azkustodata.ConnectionStringBuilder) *azkustodata.ConnectionStringBuilder {
 			return kcsb.WithApplicationToken(kustoAppId, kustoToken)
 		}, nil
 	}

--- a/alerter/multikustoclient/client.go
+++ b/alerter/multikustoclient/client.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/engine"
-	"github.com/Azure/azure-kusto-go/kusto"
-	kerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	azqueryv1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 )
 
 type multiKustoClient struct {
@@ -22,11 +22,11 @@ type multiKustoClient struct {
 func New(endpoints map[string]string, configureAuth authConfiguror, max int) (multiKustoClient, error) {
 	clients := make(map[string]QueryClient)
 	for name, endpoint := range endpoints {
-		kcsb := kusto.NewConnectionStringBuilder(endpoint)
+		kcsb := azkustodata.NewConnectionStringBuilder(endpoint)
 		if strings.HasPrefix(endpoint, "https://") {
 			kcsb = configureAuth(kcsb.WithAzCli())
 		}
-		client, err := kusto.New(kcsb)
+		client, err := azkustodata.New(kcsb)
 		if err != nil {
 			return multiKustoClient{}, fmt.Errorf("kusto client=%s: %w", endpoint, err)
 		}
@@ -49,7 +49,7 @@ func New(endpoints map[string]string, configureAuth authConfiguror, max int) (mu
 	}, nil
 }
 
-func (c multiKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn func(context.Context, string, *engine.QueryContext, *table.Row) error) (error, int) {
+func (c multiKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn func(context.Context, string, *engine.QueryContext, azquery.Row) error) (error, int) {
 	client := c.clients[qc.Rule.Database]
 	if client == nil {
 		return &engine.UnknownDBError{
@@ -59,52 +59,93 @@ func (c multiKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn
 		}, 0
 	}
 
-	var iter *kusto.RowIterator
-	var err error
 	if qc.Rule.IsMgmtQuery {
-		iter, err = client.Mgmt(ctx, qc.Rule.Database, qc.Stmt)
+		ds, err := client.Mgmt(ctx, qc.Rule.Database, qc.Stmt, queryOptions(qc)...)
 		if err != nil {
 			return fmt.Errorf("failed to execute management kusto query=%s/%s: %w", qc.Rule.Namespace, qc.Rule.Name, err), 0
 		}
-	} else {
-		iter, err = client.Query(ctx, qc.Rule.Database, qc.Stmt)
-		if err != nil {
-			return fmt.Errorf("failed to execute kusto query=%s/%s: %w, %s", qc.Rule.Namespace, qc.Rule.Name, err, qc.Stmt), 0
-		}
+		return c.handleDatasetRows(ctx, client.Endpoint(), qc, ds, fn)
 	}
 
-	var rows []*table.Row
-	defer iter.Stop()
+	ds, err := client.IterativeQuery(ctx, qc.Rule.Database, qc.Stmt, queryOptions(qc)...)
+	if err != nil {
+		return fmt.Errorf("failed to execute kusto query=%s/%s: %w, %s", qc.Rule.Namespace, qc.Rule.Name, err, qc.Stmt), 0
+	}
+	defer ds.Close()
 
-	// Accumulate rows and check for errors
-	if err := iter.DoOnRowOrError(func(row *table.Row, err *kerrors.Error) error {
-		if err != nil {
-			// Error encountered - don't callback any accumulated rows, just return the error
-			// This can happen in cases of internalservererrors where the returned rows can be incomplete or broken, causing incorrect alerts to fire.
-			return err
-		}
+	return c.handleIterativeRows(ctx, client.Endpoint(), qc, ds, fn)
+}
 
-		// Already have max rows, but trying to add another. Send existing rows, then return error.
-		if len(rows) >= c.maxNotifications {
-			for _, row := range rows {
-				if callbackErr := fn(ctx, client.Endpoint(), qc, row); callbackErr != nil {
-					return callbackErr
-				}
-			}
-			return fmt.Errorf("%s/%s returned more than %d icm, throttling query. %w", qc.Rule.Namespace, qc.Rule.Name, c.maxNotifications, alert.ErrTooManyRequests)
-		}
-
-		rows = append(rows, row)
-
+func queryOptions(qc *engine.QueryContext) []azkustodata.QueryOption {
+	if qc.Params == nil {
 		return nil
-	}); err != nil {
-		return err, 0
+	}
+	return []azkustodata.QueryOption{azkustodata.QueryParameters(qc.Params)}
+}
+
+// handleIterativeRows processes the rows from an iterative dataset and calls the provided function for each row.
+// If we get an error, we return prior to emitting any rows to avoid invalid alerts being emitted.
+// In some cases, Kusto will return some rows along with InternalServerError which are cases when incomplete rows have been processed, so some rows may be returned to us incorrectly.
+func (c multiKustoClient) handleIterativeRows(ctx context.Context, endpoint string, qc *engine.QueryContext, ds azquery.IterativeDataset, fn func(context.Context, string, *engine.QueryContext, azquery.Row) error) (error, int) {
+	var rows []azquery.Row
+	tooManyRows := false
+
+	for tableResult := range ds.Tables() {
+		if tableResult.Err() != nil {
+			return tableResult.Err(), 0
+		}
+
+		table := tableResult.Table()
+		if !table.IsPrimaryResult() {
+			continue
+		}
+
+		for rowResult := range table.Rows() {
+			if rowResult.Err() != nil {
+				return rowResult.Err(), 0
+			}
+
+			if len(rows) >= c.maxNotifications {
+				tooManyRows = true
+				continue // consume the rest of the rows to consume the rest of the body
+			}
+			rows = append(rows, rowResult.Row())
+		}
 	}
 
+	return c.emitRows(ctx, endpoint, qc, rows, tooManyRows, fn)
+}
+
+func (c multiKustoClient) handleDatasetRows(ctx context.Context, endpoint string, qc *engine.QueryContext, ds azquery.Dataset, fn func(context.Context, string, *engine.QueryContext, azquery.Row) error) (error, int) {
+	var rows []azquery.Row
+	tooManyRows := false
+
+	for _, table := range ds.Tables() {
+		if !table.IsPrimaryResult() {
+			continue
+		}
+
+		for _, row := range table.Rows() {
+			if len(rows) >= c.maxNotifications {
+				tooManyRows = true
+				continue
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	return c.emitRows(ctx, endpoint, qc, rows, tooManyRows, fn)
+}
+
+func (c multiKustoClient) emitRows(ctx context.Context, endpoint string, qc *engine.QueryContext, rows []azquery.Row, tooManyRows bool, fn func(context.Context, string, *engine.QueryContext, azquery.Row) error) (error, int) {
 	for _, row := range rows {
-		if err := fn(ctx, client.Endpoint(), qc, row); err != nil {
+		if err := fn(ctx, endpoint, qc, row); err != nil {
 			return err, 0
 		}
+	}
+
+	if tooManyRows {
+		return fmt.Errorf("%s/%s returned more than %d icm, throttling query. %w", qc.Rule.Namespace, qc.Rule.Name, c.maxNotifications, alert.ErrTooManyRequests), 0
 	}
 
 	return nil, len(rows)
@@ -136,7 +177,7 @@ func (c multiKustoClient) FindCaseInsensitiveMatch(db string) string {
 }
 
 type QueryClient interface {
-	Query(ctx context.Context, db string, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error)
-	Mgmt(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	IterativeQuery(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error)
+	Mgmt(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azqueryv1.Dataset, error)
 	Endpoint() string
 }

--- a/alerter/multikustoclient/client_test.go
+++ b/alerter/multikustoclient/client_test.go
@@ -5,32 +5,35 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/engine"
 	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
-	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	azqueryv1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeQueryClient struct {
-	nextQueryIter *kusto.RowIterator
-	nextQueryErr  error
+	nextQueryDataset azquery.IterativeDataset
+	nextQueryErr     error
 
-	nextMgmtIter *kusto.RowIterator
-	nextMgmtErr  error
+	nextMgmtDataset azqueryv1.Dataset
+	nextMgmtErr     error
 
 	endpoint string
 }
 
-func (f *fakeQueryClient) Query(ctx context.Context, db string, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error) {
-	return f.nextQueryIter, f.nextQueryErr
+func (f *fakeQueryClient) IterativeQuery(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error) {
+	return f.nextQueryDataset, f.nextQueryErr
 }
 
-func (f *fakeQueryClient) Mgmt(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
-	return f.nextMgmtIter, f.nextMgmtErr
+func (f *fakeQueryClient) Mgmt(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azqueryv1.Dataset, error) {
+	return f.nextMgmtDataset, f.nextMgmtErr
 }
 
 func (f *fakeQueryClient) Endpoint() string {
@@ -41,211 +44,125 @@ func TestQuery(t *testing.T) {
 	maxNotifications := 5
 
 	type testcase struct {
-		name         string
-		rows         *kusto.MockRows
-		rule         *rules.Rule
-		queryErr     error
-		callbackErr  error
-		expectedSent int
-		expectError  bool
+		name             string
+		rows             []string
+		rowErr           error
+		rule             *rules.Rule
+		queryErr         error
+		callbackErr      error
+		expectedSent     int
+		expectedConsumed int
+		expectError      bool
+		expectThrottle   bool
 	}
 
 	testcases := []testcase{
 		{
-			name: "Query with no rows",
-			rows: newRows(t, []string{}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  false,
+			name:             "Query with no rows",
+			rows:             []string{},
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedSent:     0,
+			expectedConsumed: 0,
 		},
 		{
-			name: "Two rows",
-			rows: newRows(t, []string{
-				"rowOne",
-				"rowTwo",
-			}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 2,
-			expectError:  false,
+			name:             "Two rows",
+			rows:             []string{"rowOne", "rowTwo"},
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedSent:     2,
+			expectedConsumed: 2,
 		},
 		{
-			name: "Max notifications",
-			rows: newRows(t, []string{
-				"rowOne",
-				"rowTwo",
-				"rowThree",
-				"rowFour",
-				"rowFive",
-			}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 5,
-			expectError:  false,
+			name:             "Max notifications",
+			rows:             []string{"rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"},
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedSent:     5,
+			expectedConsumed: 5,
 		},
 		{
-			name: "Over max notifications",
-			rows: newRows(t, []string{
-				"rowOne",
-				"rowTwo",
-				"rowThree",
-				"rowFour",
-				"rowFive",
-				"rowSix",
-			}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 5, // first 5 sent, then error
-			expectError:  true,
+			name:             "Over max notifications sends first batch then throttles",
+			rows:             []string{"rowOne", "rowTwo", "rowThree", "rowFour", "rowFive", "rowSix"},
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedSent:     5,
+			expectedConsumed: 6,
+			expectError:      true,
+			expectThrottle:   true,
 		},
 		{
-			name: "Unknown db",
-			rows: newRows(t, []string{}),
-			rule: &rules.Rule{
-				Database: "dbUnknown",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  true,
+			name:        "Unknown db",
+			rows:        []string{},
+			rule:        &rules.Rule{Database: "dbUnknown"},
+			expectError: true,
 		},
 		{
-			name: "Client query error",
-			rows: newRows(t, []string{}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     errors.New("query error"),
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  true,
+			name:        "Client query error",
+			rows:        []string{},
+			rule:        &rules.Rule{Database: "dbOne"},
+			queryErr:    errors.New("query error"),
+			expectError: true,
 		},
 		{
-			name: "Callback error",
-			rows: newRows(t, []string{
-				"rowOne",
-				"rowTwo",
-			}),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  errors.New("callback error"),
-			expectedSent: 1, // still attempts to send first, bails out
-			expectError:  true,
+			name:             "Callback error",
+			rows:             []string{"rowOne", "rowTwo"},
+			rule:             &rules.Rule{Database: "dbOne"},
+			callbackErr:      errors.New("callback error"),
+			expectedSent:     1,
+			expectedConsumed: 2,
+			expectError:      true,
 		},
 		{
-			name: "Client mgmt query error",
-			rows: newRows(t, []string{}),
-			rule: &rules.Rule{
-				Database:    "dbOne",
-				IsMgmtQuery: true,
-			},
-			queryErr:     errors.New("query error"),
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  true,
+			name:        "Client mgmt query error",
+			rows:        []string{},
+			rule:        &rules.Rule{Database: "dbOne", IsMgmtQuery: true},
+			queryErr:    errors.New("query error"),
+			expectError: true,
 		},
 		{
-			name: "Query with no rows mgmt query",
-			rows: newRows(t, []string{}),
-			rule: &rules.Rule{
-				Database:    "dbOne",
-				IsMgmtQuery: true,
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  false,
+			name:             "Query with no rows mgmt query",
+			rows:             []string{},
+			rule:             &rules.Rule{Database: "dbOne", IsMgmtQuery: true},
+			expectedConsumed: 0,
 		},
 		{
-			name: "Two rows mgmt query",
-			rows: newRows(t, []string{
-				"rowOne",
-				"rowTwo",
-			}),
-			rule: &rules.Rule{
-				Database:    "dbOne",
-				IsMgmtQuery: true,
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 2,
-			expectError:  false,
+			name:             "Two rows mgmt query",
+			rows:             []string{"rowOne", "rowTwo"},
+			rule:             &rules.Rule{Database: "dbOne", IsMgmtQuery: true},
+			expectedSent:     2,
+			expectedConsumed: 0,
 		},
 		{
-			name: "Error after first row - no rows should be sent",
-			rows: newRowsWithError(t, []string{
-				"rowOne",
-			}, errors.New("iterator error after first row")),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0, // no rows should be sent when error occurs
-			expectError:  true,
+			name:             "Error after first row - no rows should be sent",
+			rows:             []string{"rowOne"},
+			rowErr:           errors.New("iterator error after first row"),
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedConsumed: 1,
+			expectError:      true,
 		},
 		{
-			name: "Error after third row - no rows should be sent",
-			rows: newRowsWithError(t, []string{
-				"rowOne",
-				"rowTwo",
-				"rowThree",
-			}, errors.New("iterator error after third row")),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0, // no rows should be sent when error occurs
-			expectError:  true,
+			name:             "Error after third row - no rows should be sent",
+			rows:             []string{"rowOne", "rowTwo", "rowThree"},
+			rowErr:           errors.New("iterator error after third row"),
+			rule:             &rules.Rule{Database: "dbOne"},
+			expectedConsumed: 3,
+			expectError:      true,
 		},
 		{
-			name: "Error on first row - no rows should be sent",
-			rows: newRowsWithError(t, []string{}, errors.New("iterator error immediately")),
-			rule: &rules.Rule{
-				Database: "dbOne",
-			},
-			queryErr:     nil,
-			callbackErr:  nil,
-			expectedSent: 0,
-			expectError:  true,
+			name:        "Error on first row - no rows should be sent",
+			rowErr:      errors.New("iterator error immediately"),
+			rule:        &rules.Rule{Database: "dbOne"},
+			expectError: true,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			rowIterator := &kusto.RowIterator{}
-			err := rowIterator.Mock(tc.rows)
-			require.NoError(t, err)
-
-			var client QueryClient
+			iterative := newFakeIterativeDataset(tc.rows, tc.rowErr)
+			client := &fakeQueryClient{endpoint: "endpointOne"}
 			if tc.rule.IsMgmtQuery {
-				client = &fakeQueryClient{
-					nextMgmtIter: rowIterator,
-					nextMgmtErr:  tc.queryErr,
-					endpoint:     "endpointOne",
-				}
+				client.nextMgmtDataset = newFakeDataset(tc.rows)
+				client.nextMgmtErr = tc.queryErr
 			} else {
-				client = &fakeQueryClient{
-					nextQueryIter: rowIterator,
-					nextQueryErr:  tc.queryErr,
-					endpoint:      "endpointOne",
-				}
+				client.nextQueryDataset = iterative
+				client.nextQueryErr = tc.queryErr
 			}
 
 			multiKustoClient := multiKustoClient{
@@ -258,18 +175,27 @@ func TestQuery(t *testing.T) {
 			ctx := context.Background()
 			queryContext := &engine.QueryContext{
 				Rule: tc.rule,
-				Stmt: kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd("query"),
+				Stmt: kql.New("").AddUnsafe("query"),
 			}
 
 			callbackCounter := 0
-			callback := func(context.Context, string, *engine.QueryContext, *table.Row) error {
+			callback := func(context.Context, string, *engine.QueryContext, azquery.Row) error {
 				callbackCounter++
 				return tc.callbackErr
 			}
 
-			err, _ = multiKustoClient.Query(ctx, queryContext, callback)
+			err, _ := multiKustoClient.Query(ctx, queryContext, callback)
 
 			require.Equal(t, tc.expectedSent, callbackCounter)
+			if tc.rule.IsMgmtQuery {
+				require.False(t, iterative.closed)
+			} else if tc.queryErr == nil && tc.rule.Database == "dbOne" {
+				require.True(t, iterative.closed)
+				require.Equal(t, tc.expectedConsumed, iterative.table.consumed)
+			}
+			if tc.expectThrottle {
+				require.ErrorIs(t, err, alert.ErrTooManyRequests)
+			}
 			if tc.expectError {
 				require.Error(t, err)
 			} else {
@@ -277,37 +203,6 @@ func TestQuery(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newRows(t *testing.T, values []string) *kusto.MockRows {
-	t.Helper()
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "columnOne", Type: types.String},
-	})
-	require.NoError(t, err)
-	for _, val := range values {
-		err = rows.Row(value.Values{value.String{Value: val, Valid: true}})
-		require.NoError(t, err)
-	}
-	return rows
-}
-
-func newRowsWithError(t *testing.T, values []string, rowError error) *kusto.MockRows {
-	t.Helper()
-
-	rows, err := kusto.NewMockRows(table.Columns{
-		{Name: "columnOne", Type: types.String},
-	})
-	require.NoError(t, err)
-	for _, val := range values {
-		err = rows.Row(value.Values{value.String{Value: val, Valid: true}})
-		require.NoError(t, err)
-	}
-	// Add error to the stream
-	err = rows.Error(rowError)
-	require.NoError(t, err)
-	return rows
 }
 
 func TestFindCaseInsensitiveMatch(t *testing.T) {
@@ -318,19 +213,15 @@ func TestFindCaseInsensitiveMatch(t *testing.T) {
 		},
 	}
 
-	// Different casing
 	match := client.FindCaseInsensitiveMatch("cluster_state")
 	require.Equal(t, "Cluster_State", match)
 
-	// Different casing
 	match = client.FindCaseInsensitiveMatch("CLUSTER_STATE")
 	require.Equal(t, "Cluster_State", match)
 
-	// No match
 	match = client.FindCaseInsensitiveMatch("unknown")
 	require.Empty(t, match)
 
-	// Metrics with different case
 	match = client.FindCaseInsensitiveMatch("metrics")
 	require.Equal(t, "Metrics", match)
 }
@@ -348,12 +239,12 @@ func TestQuery_UnknownDB_EnhancedError(t *testing.T) {
 	ctx := context.Background()
 	queryContext := &engine.QueryContext{
 		Rule: &rules.Rule{
-			Database: "cluster_state", // Wrong case
+			Database: "cluster_state",
 		},
-		Stmt: kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd("query"),
+		Stmt: kql.New("").AddUnsafe("query"),
 	}
 
-	err, _ := client.Query(ctx, queryContext, func(context.Context, string, *engine.QueryContext, *table.Row) error {
+	err, _ := client.Query(ctx, queryContext, func(context.Context, string, *engine.QueryContext, azquery.Row) error {
 		return nil
 	})
 
@@ -365,8 +256,99 @@ func TestQuery_UnknownDB_EnhancedError(t *testing.T) {
 	require.Equal(t, "Cluster_State", unknownDBErr.CaseInsensitiveMatch)
 	require.Equal(t, []string{"Cluster_State", "Metrics"}, unknownDBErr.AvailableDatabases)
 
-	// Check error message contains helpful info
 	errMsg := err.Error()
 	require.Contains(t, errMsg, `did you mean "Cluster_State"?`)
 	require.Contains(t, errMsg, "--kusto-endpoint")
+}
+
+type fakeDataset struct {
+	azquery.BaseDataset
+	tables []azquery.Table
+}
+
+func newFakeDataset(values []string) azqueryv1.Dataset {
+	base := azquery.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	table := newFakeTable(base, values)
+	return &fakeV1Dataset{fakeDataset: fakeDataset{BaseDataset: base, tables: []azquery.Table{table}}}
+}
+
+func (d *fakeDataset) Tables() []azquery.Table { return d.tables }
+
+type fakeV1Dataset struct{ fakeDataset }
+
+func (d *fakeV1Dataset) Index() []azqueryv1.TableIndexRow  { return nil }
+func (d *fakeV1Dataset) Status() []azqueryv1.QueryStatus   { return nil }
+func (d *fakeV1Dataset) Info() []azqueryv1.QueryProperties { return nil }
+
+type fakeIterativeDataset struct {
+	azquery.BaseDataset
+	table  *fakeIterativeTable
+	closed bool
+}
+
+func newFakeIterativeDataset(values []string, rowErr error) *fakeIterativeDataset {
+	base := azquery.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	return &fakeIterativeDataset{BaseDataset: base, table: newFakeIterativeTable(base, values, rowErr)}
+}
+
+func (d *fakeIterativeDataset) Tables() <-chan azquery.TableResult {
+	out := make(chan azquery.TableResult, 1)
+	out <- azquery.TableResultSuccess(d.table)
+	close(out)
+	return out
+}
+
+func (d *fakeIterativeDataset) ToDataset() (azquery.Dataset, error) { return nil, nil }
+
+func (d *fakeIterativeDataset) Close() error {
+	d.closed = true
+	return nil
+}
+
+type fakeIterativeTable struct {
+	azquery.BaseTable
+	rows     []azquery.Row
+	rowErr   error
+	consumed int
+}
+
+func newFakeIterativeTable(base azquery.BaseDataset, values []string, rowErr error) *fakeIterativeTable {
+	table := &fakeIterativeTable{}
+	table.BaseTable = azquery.NewBaseTable(base, 0, "", "QueryResult", "QueryResult", []azquery.Column{azquery.NewColumn(0, "columnOne", aztypes.String)})
+	for i, val := range values {
+		table.rows = append(table.rows, azquery.NewRow(table, i, azvalue.Values{azvalue.NewString(val)}))
+	}
+	table.rowErr = rowErr
+	return table
+}
+
+func (t *fakeIterativeTable) Rows() <-chan azquery.RowResult {
+	out := make(chan azquery.RowResult)
+	go func() {
+		defer close(out)
+		for _, row := range t.rows {
+			t.consumed++
+			out <- azquery.RowResultSuccess(row)
+		}
+		if t.rowErr != nil {
+			out <- azquery.RowResultError(t.rowErr)
+		}
+	}()
+	return out
+}
+
+func (t *fakeIterativeTable) ToTable() (azquery.Table, error) {
+	return azquery.NewTable(t.BaseTable, t.rows), nil
+}
+
+func newFakeTable(base azquery.BaseDataset, values []string) azquery.Table {
+	baseTable, ok := base.(azquery.BaseTable)
+	if !ok {
+		baseTable = azquery.NewBaseTable(base, 0, "", "QueryResult", "QueryResult", []azquery.Column{azquery.NewColumn(0, "columnOne", aztypes.String)})
+	}
+	rows := make([]azquery.Row, 0, len(values))
+	for i, val := range values {
+		rows = append(rows, azquery.NewRow(baseTable, i, azvalue.Values{azvalue.NewString(val)}))
+	}
+	return azquery.NewTable(baseTable, rows)
 }

--- a/alerter/rules/store.go
+++ b/alerter/rules/store.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Azure/adx-mon/pkg/celutil"
 	"github.com/Azure/adx-mon/pkg/logger"
 
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/unsafe"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 
 	// //nolint:godot // comment does not end with a sentence // temporarily disabling code
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,7 +97,7 @@ func toRule(r alertrulev1.AlertRule, region string) (*Rule, error) {
 	// declaration because then Kusto will say it's an invalid query.
 	rule.IsMgmtQuery = strings.HasPrefix(r.Spec.Query, ".")
 
-	stmt := kusto.NewStmt(``, kusto.UnsafeStmt(unsafe.Stmt{Add: true, SuppressWarning: true})).UnsafeAdd(r.Spec.Query)
+	stmt := kql.New("").AddUnsafe(r.Spec.Query)
 
 	rule.Stmt = stmt
 	return rule, nil
@@ -175,7 +175,7 @@ type Rule struct {
 	IsMgmtQuery bool
 
 	// Stmt specifies the underlayEtcdPeersQuery to execute.
-	Stmt kusto.Stmt
+	Stmt azkustodata.Statement
 
 	// LastQueryTime from the AlertRule status, used for smart scheduling
 	LastQueryTime time.Time

--- a/alerter/service.go
+++ b/alerter/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/adx-mon/alerter/multikustoclient"
 	"github.com/Azure/adx-mon/metrics"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -68,11 +67,7 @@ type Alerter struct {
 	alertHandler http.Handler
 }
 
-type KustoClient interface {
-	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
-	Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error)
-	Endpoint() string
-}
+type KustoClient interface{ Endpoint() string }
 
 type lintClientFactory func(opts *AlerterOpts) (engine.Client, error)
 


### PR DESCRIPTION
This migrates the alerter query engine to use the updated azkustodata library. Ingestor was migrated several months ago.

A primary benefit of the upgrade is better cleanup with partial reads - this library version better propagates result closure to the http layer to prevent partially-read bodies from getting a connection fully stuck.