### PR TITLE
Wrap alerter queries during context construction

### DIFF
--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -14,7 +14,7 @@ type QueryContext struct {
 	Rule      *rules.Rule
 	Query     string
 	Stmt      azkustodata.Statement
-	Params    *kql.Parameters
+	Options   []azkustodata.QueryOption
 	Region    string
 	StartTime time.Time
 	EndTime   time.Time
@@ -38,19 +38,31 @@ func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*Query
 
 func (q *QueryContext) wrapStmt() error {
 	q.Query = q.Rule.Query
-	q.Stmt = q.Rule.Stmt
+	q.Stmt = kql.New("").AddUnsafe(q.Rule.Query)
 
 	if q.Rule.IsMgmtQuery {
 		return nil
 	}
 
+	stmt, params, inlinedQuery, err := q.wrapQuery()
+	if err != nil {
+		return err
+	}
+
+	q.Query = inlinedQuery
+	q.Stmt = stmt
+	q.Options = []azkustodata.QueryOption{azkustodata.QueryParameters(params)}
+
+	return nil
+}
+
+func (q *QueryContext) wrapQuery() (azkustodata.Statement, *kql.Parameters, string, error) {
 	query := fmt.Sprintf(`
 let _startTime = _adxmonStartTime;
 let _endTime = _adxmonEndTime;
 let _region = _adxmonRegion;
 %s
 `, strings.TrimSpace(q.Rule.Query))
-
 	stmt := kql.New("").AddUnsafe(query)
 	queryParams := []queryParam{
 		{name: "_adxmonStartTime", value: q.StartTime},
@@ -69,14 +81,10 @@ let _region = _adxmonRegion;
 			params.AddDateTime(param.name, v)
 			literal = fmt.Sprintf("datetime(%s)", v.Format("2006-01-02T15:04:05.999999Z"))
 		default:
-			return fmt.Errorf("unsupported query parameter %s type %T", param.name, v)
+			return nil, nil, "", fmt.Errorf("unsupported query parameter %s type %T", param.name, v)
 		}
 		query = strings.ReplaceAll(query, param.name, literal)
 	}
 
-	q.Query = query
-	q.Params = params
-	q.Stmt = stmt
-
-	return nil
+	return stmt, params, query, nil
 }

--- a/alerter/engine/context_test.go
+++ b/alerter/engine/context_test.go
@@ -1,10 +1,11 @@
 package engine
 
 import (
-	"github.com/Azure/adx-mon/alerter/rules"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/Azure/adx-mon/alerter/rules"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewQueryContext_MgmtQuery(t *testing.T) {
@@ -34,4 +35,22 @@ func TestNewQueryContext_QueryWrapped(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tt.exp, qc.Query)
 	}
+}
+
+func TestQueryContext_ConstructsWrappedQuery(t *testing.T) {
+	r := &rules.Rule{Query: "Foo | where Timestamp between (_startTime .. _endTime)", Interval: time.Hour}
+	qc, err := NewQueryContext(r, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "region")
+	require.NoError(t, err)
+
+	require.Len(t, qc.Options, 1)
+	require.Equal(t, "\nlet _startTime = _adxmonStartTime;\nlet _endTime = _adxmonEndTime;\nlet _region = _adxmonRegion;\nFoo | where Timestamp between (_startTime .. _endTime)\n", qc.Stmt.String())
+}
+
+func TestQueryContext_ConstructsMgmtQuery(t *testing.T) {
+	r := &rules.Rule{IsMgmtQuery: true, Query: ".show tables"}
+	qc, err := NewQueryContext(r, time.Now(), "region")
+	require.NoError(t, err)
+
+	require.Empty(t, qc.Options)
+	require.Equal(t, ".show tables", qc.Stmt.String())
 }

--- a/alerter/multikustoclient/client.go
+++ b/alerter/multikustoclient/client.go
@@ -60,27 +60,20 @@ func (c multiKustoClient) Query(ctx context.Context, qc *engine.QueryContext, fn
 	}
 
 	if qc.Rule.IsMgmtQuery {
-		ds, err := client.Mgmt(ctx, qc.Rule.Database, qc.Stmt, queryOptions(qc)...)
+		ds, err := client.Mgmt(ctx, qc.Rule.Database, qc.Stmt, qc.Options...)
 		if err != nil {
 			return fmt.Errorf("failed to execute management kusto query=%s/%s: %w", qc.Rule.Namespace, qc.Rule.Name, err), 0
 		}
 		return c.handleDatasetRows(ctx, client.Endpoint(), qc, ds, fn)
 	}
 
-	ds, err := client.IterativeQuery(ctx, qc.Rule.Database, qc.Stmt, queryOptions(qc)...)
+	ds, err := client.IterativeQuery(ctx, qc.Rule.Database, qc.Stmt, qc.Options...)
 	if err != nil {
 		return fmt.Errorf("failed to execute kusto query=%s/%s: %w, %s", qc.Rule.Namespace, qc.Rule.Name, err, qc.Stmt), 0
 	}
 	defer ds.Close()
 
 	return c.handleIterativeRows(ctx, client.Endpoint(), qc, ds, fn)
-}
-
-func queryOptions(qc *engine.QueryContext) []azkustodata.QueryOption {
-	if qc.Params == nil {
-		return nil
-	}
-	return []azkustodata.QueryOption{azkustodata.QueryParameters(qc.Params)}
 }
 
 // handleIterativeRows processes the rows from an iterative dataset and calls the provided function for each row.

--- a/alerter/multikustoclient/client_test.go
+++ b/alerter/multikustoclient/client_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Azure/adx-mon/alerter/alert"
 	"github.com/Azure/adx-mon/alerter/engine"
 	"github.com/Azure/adx-mon/alerter/rules"
 	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
 	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
-	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	azqueryv1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
@@ -21,18 +21,26 @@ import (
 type fakeQueryClient struct {
 	nextQueryDataset azquery.IterativeDataset
 	nextQueryErr     error
+	lastQuery        azkustodata.Statement
+	lastQueryOptions []azkustodata.QueryOption
 
 	nextMgmtDataset azqueryv1.Dataset
 	nextMgmtErr     error
+	lastMgmt        azkustodata.Statement
+	lastMgmtOptions []azkustodata.QueryOption
 
 	endpoint string
 }
 
 func (f *fakeQueryClient) IterativeQuery(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error) {
+	f.lastQuery = query
+	f.lastQueryOptions = options
 	return f.nextQueryDataset, f.nextQueryErr
 }
 
 func (f *fakeQueryClient) Mgmt(ctx context.Context, db string, query azkustodata.Statement, options ...azkustodata.QueryOption) (azqueryv1.Dataset, error) {
+	f.lastMgmt = query
+	f.lastMgmtOptions = options
 	return f.nextMgmtDataset, f.nextMgmtErr
 }
 
@@ -173,10 +181,8 @@ func TestQuery(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			queryContext := &engine.QueryContext{
-				Rule: tc.rule,
-				Stmt: kql.New("").AddUnsafe("query"),
-			}
+			queryContext, err := engine.NewQueryContext(tc.rule, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "eastus")
+			require.NoError(t, err)
 
 			callbackCounter := 0
 			callback := func(context.Context, string, *engine.QueryContext, azquery.Row) error {
@@ -184,7 +190,7 @@ func TestQuery(t *testing.T) {
 				return tc.callbackErr
 			}
 
-			err, _ := multiKustoClient.Query(ctx, queryContext, callback)
+			err, _ = multiKustoClient.Query(ctx, queryContext, callback)
 
 			require.Equal(t, tc.expectedSent, callbackCounter)
 			if tc.rule.IsMgmtQuery {
@@ -226,6 +232,28 @@ func TestFindCaseInsensitiveMatch(t *testing.T) {
 	require.Equal(t, "Metrics", match)
 }
 
+func TestQuery_UsesConstructedWrappedQuery(t *testing.T) {
+	client := &fakeQueryClient{endpoint: "endpoint", nextQueryDataset: newFakeIterativeDataset(nil, nil)}
+	multiKustoClient := multiKustoClient{
+		clients:          map[string]QueryClient{"dbOne": client},
+		maxNotifications: 5,
+	}
+	queryContext, err := engine.NewQueryContext(&rules.Rule{
+		Database: "dbOne",
+		Interval: time.Hour,
+		Query:    "Table | where Region == _region",
+	}, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "eastus")
+	require.NoError(t, err)
+
+	err, _ = multiKustoClient.Query(context.Background(), queryContext, func(context.Context, string, *engine.QueryContext, azquery.Row) error {
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "\nlet _startTime = _adxmonStartTime;\nlet _endTime = _adxmonEndTime;\nlet _region = _adxmonRegion;\nTable | where Region == _region\n", client.lastQuery.String())
+	require.Len(t, client.lastQueryOptions, 1)
+}
+
 func TestQuery_UnknownDB_EnhancedError(t *testing.T) {
 	client := multiKustoClient{
 		clients: map[string]QueryClient{
@@ -237,14 +265,10 @@ func TestQuery_UnknownDB_EnhancedError(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	queryContext := &engine.QueryContext{
-		Rule: &rules.Rule{
-			Database: "cluster_state",
-		},
-		Stmt: kql.New("").AddUnsafe("query"),
-	}
+	queryContext, err := engine.NewQueryContext(&rules.Rule{Database: "cluster_state"}, time.Now(), "eastus")
+	require.NoError(t, err)
 
-	err, _ := client.Query(ctx, queryContext, func(context.Context, string, *engine.QueryContext, azquery.Row) error {
+	err, _ = client.Query(ctx, queryContext, func(context.Context, string, *engine.QueryContext, azquery.Row) error {
 		return nil
 	})
 

--- a/alerter/rules/store.go
+++ b/alerter/rules/store.go
@@ -11,9 +11,6 @@ import (
 	"github.com/Azure/adx-mon/pkg/celutil"
 	"github.com/Azure/adx-mon/pkg/logger"
 
-	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
-	"github.com/Azure/azure-kusto-go/azkustodata/kql"
-
 	// //nolint:godot // comment does not end with a sentence // temporarily disabling code
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -97,9 +94,6 @@ func toRule(r alertrulev1.AlertRule, region string) (*Rule, error) {
 	// declaration because then Kusto will say it's an invalid query.
 	rule.IsMgmtQuery = strings.HasPrefix(r.Spec.Query, ".")
 
-	stmt := kql.New("").AddUnsafe(r.Spec.Query)
-
-	rule.Stmt = stmt
 	return rule, nil
 }
 
@@ -173,9 +167,6 @@ type Rule struct {
 	// Management queries (starts with a dot) have to call a different
 	// query API in the Kusto Go SDK.
 	IsMgmtQuery bool
-
-	// Stmt specifies the underlayEtcdPeersQuery to execute.
-	Stmt azkustodata.Statement
 
 	// LastQueryTime from the AlertRule status, used for smart scheduling
 	LastQueryTime time.Time


### PR DESCRIPTION
## Summary
- build alerter Kusto statements and query options when QueryContext is constructed
- remove deferred query parameter wrapping from the multi-Kusto client path
- remove stale rule-level statement construction

## Testing
- go test ./alerter/...