### PR TITLE
refactor(adxexporter): migrate adxexporter to azkustodata

### DIFF
--- a/adxexporter/kusto.go
+++ b/adxexporter/kusto.go
@@ -3,6 +3,7 @@ package adxexporter
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
 	"k8s.io/utils/clock"
 )
 
@@ -20,8 +22,8 @@ type KustoExecutor interface {
 	Database() string
 	// Endpoint returns the Kusto cluster endpoint
 	Endpoint() string
-	// Query executes a KQL query and returns the results
-	Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error)
+	// IterativeQuery executes a KQL query and streams the results
+	IterativeQuery(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error)
 	// Mgmt executes a Kusto management command (dot-command)
 	Mgmt(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error)
 }
@@ -63,8 +65,8 @@ func (k *KustoClient) Endpoint() string {
 	return k.endpoint
 }
 
-func (k *KustoClient) Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
-	return k.client.Query(ctx, k.database, query, options...)
+func (k *KustoClient) IterativeQuery(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error) {
+	return k.client.IterativeQuery(ctx, k.database, query, options...)
 }
 
 // Mgmt executes a Kusto management command (dot-command) against the configured database
@@ -120,7 +122,7 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 	stmt := kql.New("").AddUnsafe(processedQuery)
 
 	// Execute the query
-	iter, err := qe.kustoClient.Query(tCtx, stmt)
+	dataset, err := qe.kustoClient.IterativeQuery(tCtx, stmt)
 	if err != nil {
 		return &QueryResult{
 			Error:    fmt.Errorf("failed to execute query: %w", err),
@@ -129,7 +131,10 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 	}
 
 	// Convert results to rows
-	rows, err := qe.datasetToRows(iter)
+	rows, err := qe.iterativeDatasetToRows(dataset)
+	if closeErr := dataset.Close(); err == nil && closeErr != nil {
+		err = fmt.Errorf("failed to close query result: %w", closeErr)
+	}
 
 	return &QueryResult{
 		Rows:     rows,
@@ -138,36 +143,78 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 	}, nil
 }
 
-// datasetToRows converts a Kusto query dataset to a slice of row maps.
-func (qe *QueryExecutor) datasetToRows(ds azquery.Dataset) ([]map[string]interface{}, error) {
+// iterativeDatasetToRows converts a streamed Kusto query dataset to a slice of row maps.
+func (qe *QueryExecutor) iterativeDatasetToRows(ds azquery.IterativeDataset) ([]map[string]interface{}, error) {
 	var rows []map[string]interface{}
-	limit := qe.maxRows
 
-	for _, table := range ds.Tables() {
-		if !table.IsPrimaryResult() {
-			continue
+	for tableResult := range ds.Tables() {
+		if err := tableResult.Err(); err != nil {
+			return rows, err
 		}
+		table := tableResult.Table()
+		primary := table.IsPrimaryResult()
 
-		for _, row := range table.Rows() {
-			if limit > 0 && len(rows) >= limit {
-				return rows, fmt.Errorf("query result exceeded maximum row limit (%d)", limit)
+		for rowResult := range table.Rows() {
+			if err := rowResult.Err(); err != nil {
+				return rows, err
+			}
+			if !primary {
+				continue
+			}
+			if qe.maxRows > 0 && len(rows) >= qe.maxRows {
+				return rows, fmt.Errorf("query result exceeded maximum row limit (%d)", qe.maxRows)
 			}
 
 			// Convert row to map.
-			rowMap := make(map[string]interface{})
+			row := rowResult.Row()
 			columns := row.Columns()
 			values := row.Values()
+			rowMap := make(map[string]interface{}, len(columns))
 			for i, col := range columns {
 				if i < len(values) {
-					rowMap[col.Name()] = values[i]
+					rowMap[col.Name()] = materializeKustoValue(values[i])
 				}
 			}
 			rows = append(rows, rowMap)
 		}
 
-		// Only process the primary result table; exclude metadata tables.
-		break
+		if primary {
+			return rows, nil
+		}
 	}
 
 	return rows, nil
+}
+
+// materializeKustoValue converts azkustodata value wrappers to plain Go scalars.
+func materializeKustoValue(kustoValue azvalue.Kusto) interface{} {
+	if isNilValue(kustoValue) {
+		return nil
+	}
+
+	rawValue := kustoValue.GetValue()
+	if isNilValue(rawValue) {
+		return nil
+	}
+
+	value := reflect.ValueOf(rawValue)
+	if value.Kind() == reflect.Ptr {
+		return value.Elem().Interface()
+	}
+
+	return rawValue
+}
+
+func isNilValue(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
 }

--- a/adxexporter/kusto.go
+++ b/adxexporter/kusto.go
@@ -129,16 +129,19 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 			Duration: qe.clock.Since(start),
 		}, nil
 	}
+	defer dataset.Close()
 
 	// Convert results to rows
 	rows, err := qe.iterativeDatasetToRows(dataset)
-	if closeErr := dataset.Close(); err == nil && closeErr != nil {
-		err = fmt.Errorf("failed to close query result: %w", closeErr)
+	if err != nil {
+		return &QueryResult{
+			Error:    fmt.Errorf("failed to read query results: %w", err),
+			Duration: qe.clock.Since(start),
+		}, nil
 	}
 
 	return &QueryResult{
 		Rows:     rows,
-		Error:    err,
 		Duration: qe.clock.Since(start),
 	}, nil
 }
@@ -152,14 +155,13 @@ func (qe *QueryExecutor) iterativeDatasetToRows(ds azquery.IterativeDataset) ([]
 			return rows, err
 		}
 		table := tableResult.Table()
-		primary := table.IsPrimaryResult()
+		if !table.IsPrimaryResult() {
+			continue
+		}
 
 		for rowResult := range table.Rows() {
 			if err := rowResult.Err(); err != nil {
 				return rows, err
-			}
-			if !primary {
-				continue
 			}
 			if qe.maxRows > 0 && len(rows) >= qe.maxRows {
 				return rows, fmt.Errorf("query result exceeded maximum row limit (%d)", qe.maxRows)
@@ -178,9 +180,7 @@ func (qe *QueryExecutor) iterativeDatasetToRows(ds azquery.IterativeDataset) ([]
 			rows = append(rows, rowMap)
 		}
 
-		if primary {
-			return rows, nil
-		}
+		return rows, nil
 	}
 
 	return rows, nil

--- a/adxexporter/kusto.go
+++ b/adxexporter/kusto.go
@@ -3,13 +3,13 @@ package adxexporter
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
 	"github.com/Azure/adx-mon/pkg/kustoutil"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/kql"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	"k8s.io/utils/clock"
 )
 
@@ -21,14 +21,14 @@ type KustoExecutor interface {
 	// Endpoint returns the Kusto cluster endpoint
 	Endpoint() string
 	// Query executes a KQL query and returns the results
-	Query(ctx context.Context, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error)
+	Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error)
 	// Mgmt executes a Kusto management command (dot-command)
-	Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	Mgmt(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error)
 }
 
 // KustoClient wraps the Azure Kusto Go client to implement KustoExecutor
 type KustoClient struct {
-	client   *kusto.Client
+	client   *azkustodata.Client
 	database string
 	endpoint string
 }
@@ -37,13 +37,13 @@ const DefaultQueryExecutorMaxRows = 50000
 
 // NewKustoClient creates a new KustoClient with the given endpoint and database
 func NewKustoClient(endpoint, database string) (*KustoClient, error) {
-	kcsb := kusto.NewConnectionStringBuilder(endpoint)
+	kcsb := azkustodata.NewConnectionStringBuilder(endpoint)
 
 	if strings.HasPrefix(endpoint, "https://") {
 		kcsb.WithDefaultAzureCredential()
 	}
 
-	client, err := kusto.New(kcsb)
+	client, err := azkustodata.New(kcsb)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kusto client: %w", err)
 	}
@@ -63,12 +63,12 @@ func (k *KustoClient) Endpoint() string {
 	return k.endpoint
 }
 
-func (k *KustoClient) Query(ctx context.Context, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error) {
+func (k *KustoClient) Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
 	return k.client.Query(ctx, k.database, query, options...)
 }
 
 // Mgmt executes a Kusto management command (dot-command) against the configured database
-func (k *KustoClient) Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+func (k *KustoClient) Mgmt(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
 	return k.client.Mgmt(ctx, k.database, query, options...)
 }
 
@@ -127,10 +127,9 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 			Duration: qe.clock.Since(start),
 		}, nil
 	}
-	defer iter.Stop()
 
 	// Convert results to rows
-	rows, err := qe.iteratorToRows(iter)
+	rows, err := qe.datasetToRows(iter)
 
 	return &QueryResult{
 		Rows:     rows,
@@ -139,37 +138,35 @@ func (qe *QueryExecutor) ExecuteQuery(ctx context.Context, queryBody string, sta
 	}, nil
 }
 
-// iteratorToRows converts a Kusto RowIterator to a slice of maps
-func (qe *QueryExecutor) iteratorToRows(iter *kusto.RowIterator) ([]map[string]interface{}, error) {
+// datasetToRows converts a Kusto query dataset to a slice of row maps.
+func (qe *QueryExecutor) datasetToRows(ds azquery.Dataset) ([]map[string]interface{}, error) {
 	var rows []map[string]interface{}
 	limit := qe.maxRows
 
-	for {
-		row, errInline, errFinal := iter.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
-			// Log inline error but continue processing
+	for _, table := range ds.Tables() {
+		if !table.IsPrimaryResult() {
 			continue
 		}
-		if errFinal != nil {
-			return rows, fmt.Errorf("failed to read query results: %w", errFinal)
-		}
 
-		if limit > 0 && len(rows) >= limit {
-			return rows, fmt.Errorf("query result exceeded maximum row limit (%d)", limit)
-		}
-
-		// Convert row to map
-		rowMap := make(map[string]interface{})
-		columns := row.ColumnNames()
-		for i, colName := range columns {
-			if i < len(row.Values) {
-				rowMap[colName] = row.Values[i]
+		for _, row := range table.Rows() {
+			if limit > 0 && len(rows) >= limit {
+				return rows, fmt.Errorf("query result exceeded maximum row limit (%d)", limit)
 			}
+
+			// Convert row to map.
+			rowMap := make(map[string]interface{})
+			columns := row.Columns()
+			values := row.Values()
+			for i, col := range columns {
+				if i < len(values) {
+					rowMap[col.Name()] = values[i]
+				}
+			}
+			rows = append(rows, rowMap)
 		}
-		rows = append(rows, rowMap)
+
+		// Only process the primary result table; exclude metadata tables.
+		break
 	}
 
 	return rows, nil

--- a/adxexporter/kusto_test.go
+++ b/adxexporter/kusto_test.go
@@ -3,15 +3,15 @@ package adxexporter
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/clock"
 )
@@ -62,7 +62,7 @@ type MockKustoExecutor struct {
 	database string
 	endpoint string
 	queries  []string
-	results  []*kusto.RowIterator
+	results  []azquery.Dataset
 	errors   []error
 	callIdx  int
 }
@@ -73,7 +73,7 @@ func NewMockKustoExecutor(t *testing.T, database, endpoint string) *MockKustoExe
 		database: database,
 		endpoint: endpoint,
 		queries:  make([]string, 0),
-		results:  make([]*kusto.RowIterator, 0),
+		results:  make([]azquery.Dataset, 0),
 		errors:   make([]error, 0),
 	}
 }
@@ -86,7 +86,7 @@ func (m *MockKustoExecutor) Endpoint() string {
 	return m.endpoint
 }
 
-func (m *MockKustoExecutor) Query(ctx context.Context, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error) {
+func (m *MockKustoExecutor) Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
 	m.queries = append(m.queries, query.String())
 
 	if m.callIdx < len(m.errors) && m.errors[m.callIdx] != nil {
@@ -101,16 +101,15 @@ func (m *MockKustoExecutor) Query(ctx context.Context, query kusto.Statement, op
 		return result, nil
 	}
 
-	// Return empty iterator if no specific result configured
-	return createEmptyMockRowIterator(), nil
+	// Return empty dataset if no specific result configured.
+	return createMockDataset(nil), nil
 }
 
 // Mgmt implements the management command execution for the mock executor.
 // For current tests, no behavior changes are needed, so it mirrors Query by
-// recording the statement and returning configured results or an empty iterator.
-func (m *MockKustoExecutor) Mgmt(ctx context.Context, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+// recording the statement and returning configured results or an empty dataset.
+func (m *MockKustoExecutor) Mgmt(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
 	// Reuse Query behavior to avoid duplicating test plumbing
-	// Cast MgmtOption to no-op and delegate to Query-like path
 	m.queries = append(m.queries, query.String())
 
 	if m.callIdx < len(m.errors) && m.errors[m.callIdx] != nil {
@@ -125,7 +124,7 @@ func (m *MockKustoExecutor) Mgmt(ctx context.Context, query kusto.Statement, opt
 		return result, nil
 	}
 
-	return createEmptyMockRowIterator(), nil
+	return createMockDataset(nil), nil
 }
 
 func (m *MockKustoExecutor) SetNextError(err error) {
@@ -134,8 +133,7 @@ func (m *MockKustoExecutor) SetNextError(err error) {
 
 func (m *MockKustoExecutor) SetNextResult(t *testing.T, rows [][]interface{}) {
 	t.Helper()
-	iter := createMockRowIterator(t, rows)
-	m.results = append(m.results, iter)
+	m.results = append(m.results, createMockDataset(rows))
 }
 
 func (m *MockKustoExecutor) GetQueries() []string {
@@ -144,108 +142,83 @@ func (m *MockKustoExecutor) GetQueries() []string {
 
 func (m *MockKustoExecutor) Reset() {
 	m.queries = make([]string, 0)
-	m.results = make([]*kusto.RowIterator, 0)
+	m.results = make([]azquery.Dataset, 0)
 	m.errors = make([]error, 0)
 	m.callIdx = 0
 }
 
-// createMockRowIterator creates a mock RowIterator for testing with actual data
-func createMockRowIterator(t *testing.T, rows [][]interface{}) *kusto.RowIterator {
-	t.Helper()
-	iter := &kusto.RowIterator{}
+func createMockDataset(rows [][]interface{}) azquery.Dataset {
+	return createDatasetWithColumns([]string{"metric_name", "value", "timestamp"}, rows)
+}
 
-	// If no rows provided, return empty iterator
-	if len(rows) == 0 {
-		// Create empty mock rows to avoid nil pointer issues
-		mockRows, err := kusto.NewMockRows(table.Columns{})
-		require.NoError(t, err, "Failed to create empty mock rows")
-
-		// Work-around for Azure Kusto SDK's test environment check.
-		// The SDK's RowIterator.Mock() method explicitly checks if it's running in a test
-		// by calling isTest() which looks for the "test.v" flag (set by `go test`).
-		// If not found, Mock() panics with "cannot call Mock outside a test".
-		// We ensure the flag exists to bypass this safety check.
-		if flag.Lookup("test.v") == nil {
-			flag.String("test.v", "", "")
-			err := flag.CommandLine.Set("test.v", "true")
-			require.NoError(t, err, "Failed to set test.v flag")
-		}
-		err = iter.Mock(mockRows)
-		require.NoError(t, err, "Failed to mock empty iterator")
-		return iter
+func createDatasetWithColumns(columnNames []string, rows [][]interface{}) azquery.Dataset {
+	base := azquery.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	columns := make([]azquery.Column, 0, len(columnNames))
+	for i, name := range columnNames {
+		columns = append(columns, azquery.NewColumn(i, name, inferColumnType(rows, i)))
 	}
+	baseTable := azquery.NewBaseTable(base, 0, "", "QueryResult", "QueryResult", columns)
 
-	// Create columns based on the first row structure
-	// For simplicity, assume first row has: metric_name, value, timestamp
-	columns := table.Columns{
-		{Name: "metric_name", Type: types.String},
-		{Name: "value", Type: types.Real},
-		{Name: "timestamp", Type: types.DateTime},
-	}
-
-	mockRows, err := kusto.NewMockRows(columns)
-	require.NoError(t, err, "Failed to create mock rows")
-
-	// Add each row to the mock
-	for _, rowData := range rows {
-		var values value.Values
+	queryRows := make([]azquery.Row, 0, len(rows))
+	for i, rowData := range rows {
+		vals := make(azvalue.Values, 0, len(rowData))
 		for _, col := range rowData {
 			switch v := col.(type) {
 			case string:
-				values = append(values, value.String{Value: v, Valid: true})
+				vals = append(vals, azvalue.NewString(v))
 			case float64:
-				values = append(values, value.Real{Value: v, Valid: true})
+				vals = append(vals, azvalue.NewReal(v))
 			case time.Time:
-				values = append(values, value.DateTime{Value: v, Valid: true})
+				vals = append(vals, azvalue.NewDateTime(v))
 			default:
-				// Convert to string as fallback
-				values = append(values, value.String{Value: fmt.Sprintf("%v", v), Valid: true})
+				vals = append(vals, azvalue.NewString(fmt.Sprintf("%v", v)))
 			}
 		}
-		mockRows.Row(values)
+		queryRows = append(queryRows, azquery.NewRow(baseTable, i, vals))
 	}
 
-	// Work-around for Azure Kusto SDK's test environment check.
-	// The SDK's RowIterator.Mock() method explicitly checks if it's running in a test
-	// by calling isTest() which looks for the "test.v" flag (set by `go test`).
-	// If not found, Mock() panics with "cannot call Mock outside a test".
-	// We ensure the flag exists to bypass this safety check.
-	if flag.Lookup("test.v") == nil {
-		flag.String("test.v", "", "")
-		err := flag.CommandLine.Set("test.v", "true")
-		require.NoError(t, err, "Failed to set test.v flag")
-	}
-	err = iter.Mock(mockRows)
-	require.NoError(t, err, "Failed to mock iterator")
-	return iter
+	table := azquery.NewTable(baseTable, queryRows)
+	return &mockDataset{base: base, tables: []azquery.Table{table}}
 }
 
-// createEmptyMockRowIterator creates an empty mock RowIterator without requiring *testing.T
-// This is used internally by MockKustoExecutor when no specific result is configured
-func createEmptyMockRowIterator() *kusto.RowIterator {
-	iter := &kusto.RowIterator{}
+func inferColumnType(rows [][]interface{}, idx int) aztypes.Column {
+	for _, row := range rows {
+		if idx >= len(row) {
+			continue
+		}
 
-	// Create empty mock rows to avoid nil pointer issues
-	mockRows, err := kusto.NewMockRows(table.Columns{})
-	if err != nil {
-		panic(fmt.Sprintf("Failed to create empty mock rows: %v", err))
-	}
-
-	// Work-around for Azure Kusto SDK's test environment check.
-	// The SDK's RowIterator.Mock() method explicitly checks if it's running in a test
-	// by calling isTest() which looks for the "test.v" flag (set by `go test`).
-	// If not found, Mock() panics with "cannot call Mock outside a test".
-	// We ensure the flag exists to bypass this safety check.
-	if flag.Lookup("test.v") == nil {
-		flag.String("test.v", "", "")
-		if err := flag.CommandLine.Set("test.v", "true"); err != nil {
-			panic(err)
+		switch row[idx].(type) {
+		case string:
+			return aztypes.String
+		case float64:
+			return aztypes.Real
+		case time.Time:
+			return aztypes.DateTime
 		}
 	}
-	if err := iter.Mock(mockRows); err != nil {
-		panic(fmt.Sprintf("Failed to mock empty iterator: %v", err))
-	}
-	return iter
+
+	return aztypes.String
+}
+
+type mockDataset struct {
+	base   azquery.BaseDataset
+	tables []azquery.Table
+}
+
+func (d *mockDataset) Context() context.Context {
+	return d.base.Context()
+}
+
+func (d *mockDataset) Op() azerrors.Op {
+	return d.base.Op()
+}
+
+func (d *mockDataset) PrimaryResultKind() string {
+	return d.base.PrimaryResultKind()
+}
+
+func (d *mockDataset) Tables() []azquery.Table {
+	return d.tables
 }
 
 func TestQueryExecutor_ExecuteQuery(t *testing.T) {
@@ -263,15 +236,13 @@ func TestQueryExecutor_ExecuteQuery(t *testing.T) {
 	t.Run("query construction and execution call", func(t *testing.T) {
 		mockClient.Reset()
 
-		// For successful case, we just want to verify the query gets constructed correctly
-		// We'll mock an error to avoid the RowIterator processing issues
-		mockClient.SetNextError(errors.New("mock error to bypass iterator"))
+		mockClient.SetNextResult(t, nil)
 
 		result, err := executor.ExecuteQuery(ctx, queryBody, startTime, endTime, clusterLabels)
 
-		require.NoError(t, err) // No error from the function itself
+		require.NoError(t, err)
 		require.NotNil(t, result)
-		require.Error(t, result.Error) // The mock error we set
+		require.NoError(t, result.Error)
 		require.Greater(t, result.Duration, time.Duration(0))
 
 		// Verify the query was called with proper substitutions

--- a/adxexporter/kusto_test.go
+++ b/adxexporter/kusto_test.go
@@ -12,6 +12,8 @@ import (
 	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
 	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/clock"
 )
@@ -59,12 +61,13 @@ func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
 
 // MockKustoExecutor implements KustoExecutor for testing
 type MockKustoExecutor struct {
-	database string
-	endpoint string
-	queries  []string
-	results  []azquery.Dataset
-	errors   []error
-	callIdx  int
+	database      string
+	endpoint      string
+	queries       []string
+	results       []azquery.Dataset
+	errors        []error
+	callIdx       int
+	lastIterative *mockIterativeDataset
 }
 
 func NewMockKustoExecutor(t *testing.T, database, endpoint string) *MockKustoExecutor {
@@ -86,32 +89,25 @@ func (m *MockKustoExecutor) Endpoint() string {
 	return m.endpoint
 }
 
-func (m *MockKustoExecutor) Query(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
+func (m *MockKustoExecutor) IterativeQuery(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.IterativeDataset, error) {
 	m.queries = append(m.queries, query.String())
 
-	if m.callIdx < len(m.errors) && m.errors[m.callIdx] != nil {
-		err := m.errors[m.callIdx]
-		m.callIdx++
+	result, err := m.nextResult()
+	if err != nil {
 		return nil, err
 	}
-
-	if m.callIdx < len(m.results) {
-		result := m.results[m.callIdx]
-		m.callIdx++
-		return result, nil
-	}
-
-	// Return empty dataset if no specific result configured.
-	return createMockDataset(nil), nil
+	m.lastIterative = newMockIterativeDataset(result)
+	return m.lastIterative, nil
 }
 
 // Mgmt implements the management command execution for the mock executor.
-// For current tests, no behavior changes are needed, so it mirrors Query by
-// recording the statement and returning configured results or an empty dataset.
+// It records the statement and returns configured results or an empty dataset.
 func (m *MockKustoExecutor) Mgmt(ctx context.Context, query azkustodata.Statement, options ...azkustodata.QueryOption) (azquery.Dataset, error) {
-	// Reuse Query behavior to avoid duplicating test plumbing
 	m.queries = append(m.queries, query.String())
+	return m.nextResult()
+}
 
+func (m *MockKustoExecutor) nextResult() (azquery.Dataset, error) {
 	if m.callIdx < len(m.errors) && m.errors[m.callIdx] != nil {
 		err := m.errors[m.callIdx]
 		m.callIdx++
@@ -145,6 +141,7 @@ func (m *MockKustoExecutor) Reset() {
 	m.results = make([]azquery.Dataset, 0)
 	m.errors = make([]error, 0)
 	m.callIdx = 0
+	m.lastIterative = nil
 }
 
 func createMockDataset(rows [][]interface{}) azquery.Dataset {
@@ -166,6 +163,8 @@ func createDatasetWithColumns(columnNames []string, rows [][]interface{}) azquer
 			switch v := col.(type) {
 			case string:
 				vals = append(vals, azvalue.NewString(v))
+			case uuid.UUID:
+				vals = append(vals, azvalue.NewGUID(v))
 			case float64:
 				vals = append(vals, azvalue.NewReal(v))
 			case time.Time:
@@ -190,6 +189,8 @@ func inferColumnType(rows [][]interface{}, idx int) aztypes.Column {
 		switch row[idx].(type) {
 		case string:
 			return aztypes.String
+		case uuid.UUID:
+			return aztypes.GUID
 		case float64:
 			return aztypes.Real
 		case time.Time:
@@ -220,6 +221,63 @@ func (d *mockDataset) PrimaryResultKind() string {
 func (d *mockDataset) Tables() []azquery.Table {
 	return d.tables
 }
+
+type mockIterativeDataset struct {
+	base   azquery.Dataset
+	closed bool
+}
+
+func newMockIterativeDataset(dataset azquery.Dataset) *mockIterativeDataset {
+	return &mockIterativeDataset{base: dataset}
+}
+
+func (d *mockIterativeDataset) Context() context.Context  { return d.base.Context() }
+func (d *mockIterativeDataset) Op() azerrors.Op           { return d.base.Op() }
+func (d *mockIterativeDataset) PrimaryResultKind() string { return d.base.PrimaryResultKind() }
+
+func (d *mockIterativeDataset) Tables() <-chan azquery.TableResult {
+	tables := d.base.Tables()
+	results := make(chan azquery.TableResult, len(tables))
+	for _, table := range tables {
+		results <- azquery.TableResultSuccess(&mockIterativeTable{base: table})
+	}
+	close(results)
+	return results
+}
+
+func (d *mockIterativeDataset) ToDataset() (azquery.Dataset, error) { return d.base, nil }
+
+func (d *mockIterativeDataset) Close() error {
+	d.closed = true
+	return nil
+}
+
+type mockIterativeTable struct {
+	base azquery.Table
+}
+
+func (t *mockIterativeTable) Id() string                { return t.base.Id() }
+func (t *mockIterativeTable) Index() int64              { return t.base.Index() }
+func (t *mockIterativeTable) Name() string              { return t.base.Name() }
+func (t *mockIterativeTable) Columns() []azquery.Column { return t.base.Columns() }
+func (t *mockIterativeTable) Kind() string              { return t.base.Kind() }
+func (t *mockIterativeTable) ColumnByName(name string) azquery.Column {
+	return t.base.ColumnByName(name)
+}
+func (t *mockIterativeTable) Op() azerrors.Op       { return t.base.Op() }
+func (t *mockIterativeTable) IsPrimaryResult() bool { return t.base.IsPrimaryResult() }
+
+func (t *mockIterativeTable) Rows() <-chan azquery.RowResult {
+	rows := t.base.Rows()
+	results := make(chan azquery.RowResult, len(rows))
+	for _, row := range rows {
+		results <- azquery.RowResultSuccess(row)
+	}
+	close(results)
+	return results
+}
+
+func (t *mockIterativeTable) ToTable() (azquery.Table, error) { return t.base, nil }
 
 func TestQueryExecutor_ExecuteQuery(t *testing.T) {
 	mockClient := NewMockKustoExecutor(t, "TestDB", "https://test.kusto.windows.net")
@@ -293,6 +351,57 @@ func TestQueryExecutor_ExecuteQuery_MaxRowsLimit(t *testing.T) {
 	require.Error(t, result.Error)
 	require.Contains(t, result.Error.Error(), "maximum row limit")
 	require.Len(t, result.Rows, 1)
+	require.True(t, mockClient.lastIterative.closed)
+}
+
+func TestQueryExecutor_ExecuteQuery_MaterializesNativeValues(t *testing.T) {
+	mockClient := NewMockKustoExecutor(t, "TestDB", "https://test.kusto.windows.net")
+	executor := NewQueryExecutor(mockClient)
+	now := time.Date(2023, 1, 1, 14, 0, 0, 0, time.UTC)
+	mockClient.SetNextResult(t, [][]interface{}{{"metric_one", 1.5, now}})
+
+	result, err := executor.ExecuteQuery(context.Background(), "MyTable", now.Add(-time.Hour), now, nil)
+
+	require.NoError(t, err)
+	require.NoError(t, result.Error)
+	require.Equal(t, "metric_one", result.Rows[0]["metric_name"])
+	require.Equal(t, 1.5, result.Rows[0]["value"])
+	require.Equal(t, now, result.Rows[0]["timestamp"])
+}
+
+func TestMaterializeKustoValue(t *testing.T) {
+	now := time.Date(2023, 1, 1, 14, 0, 0, 0, time.UTC)
+	duration := 5 * time.Minute
+	id := uuid.MustParse("eeab2025-9cc6-411f-8ef5-9e5c6b720f22")
+	decimalValue := decimal.RequireFromString("123.45")
+	dynamicValue := []byte(`{"region":"west"}`)
+	var typedNilReal *azvalue.Real
+
+	tests := []struct {
+		name  string
+		value azvalue.Kusto
+		want  interface{}
+	}{
+		{name: "string", value: azvalue.NewString("metric_one"), want: "metric_one"},
+		{name: "bool", value: azvalue.NewBool(true), want: true},
+		{name: "int", value: azvalue.NewInt(42), want: int32(42)},
+		{name: "long", value: azvalue.NewLong(42), want: int64(42)},
+		{name: "real", value: azvalue.NewReal(1.5), want: 1.5},
+		{name: "datetime", value: azvalue.NewDateTime(now), want: now},
+		{name: "timespan", value: azvalue.NewTimespan(duration), want: duration},
+		{name: "decimal", value: azvalue.NewDecimal(decimalValue), want: decimalValue},
+		{name: "guid", value: azvalue.NewGUID(id), want: id},
+		{name: "dynamic", value: azvalue.NewDynamic(dynamicValue), want: dynamicValue},
+		{name: "null pointer value", value: azvalue.NewNullReal(), want: nil},
+		{name: "null slice value", value: azvalue.NewNullDynamic(), want: nil},
+		{name: "typed nil wrapper", value: typedNilReal, want: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, materializeKustoValue(test.value))
+		})
+	}
 }
 
 func TestNewKustoClient(t *testing.T) {

--- a/adxexporter/kusto_test.go
+++ b/adxexporter/kusto_test.go
@@ -68,6 +68,8 @@ type MockKustoExecutor struct {
 	errors        []error
 	callIdx       int
 	lastIterative *mockIterativeDataset
+	tableErr      error
+	rowErr        error
 }
 
 func NewMockKustoExecutor(t *testing.T, database, endpoint string) *MockKustoExecutor {
@@ -97,6 +99,8 @@ func (m *MockKustoExecutor) IterativeQuery(ctx context.Context, query azkustodat
 		return nil, err
 	}
 	m.lastIterative = newMockIterativeDataset(result)
+	m.lastIterative.tableErr = m.tableErr
+	m.lastIterative.rowErr = m.rowErr
 	return m.lastIterative, nil
 }
 
@@ -127,6 +131,14 @@ func (m *MockKustoExecutor) SetNextError(err error) {
 	m.errors = append(m.errors, err)
 }
 
+func (m *MockKustoExecutor) SetTableError(err error) {
+	m.tableErr = err
+}
+
+func (m *MockKustoExecutor) SetRowError(err error) {
+	m.rowErr = err
+}
+
 func (m *MockKustoExecutor) SetNextResult(t *testing.T, rows [][]interface{}) {
 	t.Helper()
 	m.results = append(m.results, createMockDataset(rows))
@@ -142,6 +154,8 @@ func (m *MockKustoExecutor) Reset() {
 	m.errors = make([]error, 0)
 	m.callIdx = 0
 	m.lastIterative = nil
+	m.tableErr = nil
+	m.rowErr = nil
 }
 
 func createMockDataset(rows [][]interface{}) azquery.Dataset {
@@ -223,8 +237,10 @@ func (d *mockDataset) Tables() []azquery.Table {
 }
 
 type mockIterativeDataset struct {
-	base   azquery.Dataset
-	closed bool
+	base     azquery.Dataset
+	closed   bool
+	tableErr error
+	rowErr   error
 }
 
 func newMockIterativeDataset(dataset azquery.Dataset) *mockIterativeDataset {
@@ -237,9 +253,14 @@ func (d *mockIterativeDataset) PrimaryResultKind() string { return d.base.Primar
 
 func (d *mockIterativeDataset) Tables() <-chan azquery.TableResult {
 	tables := d.base.Tables()
-	results := make(chan azquery.TableResult, len(tables))
+	results := make(chan azquery.TableResult, len(tables)+1)
+	if d.tableErr != nil {
+		results <- azquery.TableResultError(d.tableErr)
+		close(results)
+		return results
+	}
 	for _, table := range tables {
-		results <- azquery.TableResultSuccess(&mockIterativeTable{base: table})
+		results <- azquery.TableResultSuccess(&mockIterativeTable{base: table, rowErr: d.rowErr})
 	}
 	close(results)
 	return results
@@ -253,7 +274,8 @@ func (d *mockIterativeDataset) Close() error {
 }
 
 type mockIterativeTable struct {
-	base azquery.Table
+	base   azquery.Table
+	rowErr error
 }
 
 func (t *mockIterativeTable) Id() string                { return t.base.Id() }
@@ -269,9 +291,12 @@ func (t *mockIterativeTable) IsPrimaryResult() bool { return t.base.IsPrimaryRes
 
 func (t *mockIterativeTable) Rows() <-chan azquery.RowResult {
 	rows := t.base.Rows()
-	results := make(chan azquery.RowResult, len(rows))
+	results := make(chan azquery.RowResult, len(rows)+1)
 	for _, row := range rows {
 		results <- azquery.RowResultSuccess(row)
+	}
+	if t.rowErr != nil {
+		results <- azquery.RowResultError(t.rowErr)
 	}
 	close(results)
 	return results
@@ -327,6 +352,37 @@ MyTable | summarize avg_value = avg(Value) by ServiceName`
 		require.Contains(t, result.Error.Error(), "failed to execute query")
 		require.Contains(t, result.Error.Error(), "connection failed")
 	})
+
+	t.Run("streamed table error", func(t *testing.T) {
+		mockClient.Reset()
+		streamErr := errors.New("table stream failed")
+		mockClient.SetTableError(streamErr)
+
+		result, err := executor.ExecuteQuery(ctx, queryBody, startTime, endTime, clusterLabels)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.ErrorIs(t, result.Error, streamErr)
+		require.Contains(t, result.Error.Error(), "failed to read query results")
+		require.Empty(t, result.Rows)
+		require.True(t, mockClient.lastIterative.closed)
+	})
+
+	t.Run("streamed row error", func(t *testing.T) {
+		mockClient.Reset()
+		streamErr := errors.New("row stream failed")
+		mockClient.SetNextResult(t, [][]interface{}{{"metric_one", 1.0, startTime}})
+		mockClient.SetRowError(streamErr)
+
+		result, err := executor.ExecuteQuery(ctx, queryBody, startTime, endTime, clusterLabels)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.ErrorIs(t, result.Error, streamErr)
+		require.Contains(t, result.Error.Error(), "failed to read query results")
+		require.Empty(t, result.Rows)
+		require.True(t, mockClient.lastIterative.closed)
+	})
 }
 
 func TestQueryExecutor_ExecuteQuery_MaxRowsLimit(t *testing.T) {
@@ -350,7 +406,7 @@ func TestQueryExecutor_ExecuteQuery_MaxRowsLimit(t *testing.T) {
 	require.NotNil(t, result)
 	require.Error(t, result.Error)
 	require.Contains(t, result.Error.Error(), "maximum row limit")
-	require.Len(t, result.Rows, 1)
+	require.Empty(t, result.Rows)
 	require.True(t, mockClient.lastIterative.closed)
 }
 

--- a/adxexporter/summaryrule.go
+++ b/adxexporter/summaryrule.go
@@ -409,7 +409,7 @@ func (r *SummaryRuleReconciler) getOperation(ctx context.Context, database strin
 		for _, row := range table.Rows() {
 			var status AsyncOperationStatus
 			if err := row.ToStruct(&status); err != nil {
-				return nil, fmt.Errorf("failed to parse operation %s: %v", operationId, err)
+				return nil, fmt.Errorf("failed to parse operation %s: %w", operationId, err)
 			}
 			if status.State != "" {
 				return &status, nil

--- a/adxexporter/summaryrule.go
+++ b/adxexporter/summaryrule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+	aztypes "github.com/Azure/azure-kusto-go/azkustodata/types"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +40,7 @@ type SummaryRuleReconciler struct {
 	ClusterLabels map[string]string
 	KustoClusters map[string]string // database name -> endpoint URL
 
-	KustoExecutors map[string]KustoExecutor // per-database Kusto clients supporting Query and Mgmt
+	KustoExecutors map[string]KustoExecutor // per-database Kusto clients supporting iterative queries and management commands
 	Clock          clock.Clock
 }
 
@@ -237,7 +238,7 @@ func (r *SummaryRuleReconciler) adoptIfDesired(ctx context.Context, rule *adxmon
 // initializeQueryExecutors creates per-database executors for SummaryRule processing.
 func (r *SummaryRuleReconciler) initializeQueryExecutors() error {
 	for database, endpoint := range r.KustoClusters {
-		// Reuse the shared Kusto client capable of both Query and Mgmt
+		// Reuse the shared Kusto client for iterative queries and management commands.
 		kustoClient, err := NewKustoClient(endpoint, database)
 		if err != nil {
 			return err
@@ -336,24 +337,39 @@ func operationIDFromResult(ds azquery.Dataset) (string, error) {
 		if !table.IsPrimaryResult() {
 			continue
 		}
-		for _, row := range table.Rows() {
-			if opID, err := row.StringByName("OperationId"); err == nil {
-				return opID, nil
-			}
-
-			values := row.Values()
-			if len(values) == 0 {
-				return "", fmt.Errorf("operation result row has no values")
-			}
-			if len(values) > 1 {
-				return "", fmt.Errorf("unexpected number of values in row without OperationId column: %d", len(values))
-			}
-
-			return values[0].String(), nil
+		rows := table.Rows()
+		if len(rows) != 1 {
+			return "", fmt.Errorf("expected one operation result row, got %d", len(rows))
 		}
-		break
+		row := rows[0]
+		if column := table.ColumnByName("OperationId"); column != nil {
+			if column.Type() != aztypes.String && column.Type() != aztypes.GUID {
+				return "", fmt.Errorf("operation id has unsupported type %s", column.Type())
+			}
+
+			value, err := row.ValueByColumn(column)
+			if err != nil {
+				return "", fmt.Errorf("failed to read operation id: %w", err)
+			}
+			opID := value.String()
+			if opID == "" {
+				return "", fmt.Errorf("operation id is empty")
+			}
+			return opID, nil
+		}
+
+		values := row.Values()
+		if len(values) != 1 {
+			return "", fmt.Errorf("expected one value in row without OperationId column, got %d", len(values))
+		}
+
+		opID := values[0].String()
+		if opID == "" {
+			return "", fmt.Errorf("operation id is empty")
+		}
+		return opID, nil
 	}
-	return "", nil
+	return "", fmt.Errorf("operation id not found in result set")
 }
 
 // AsyncOperationStatus mirrors the schema returned by .show operations

--- a/adxexporter/summaryrule.go
+++ b/adxexporter/summaryrule.go
@@ -3,7 +3,6 @@ package adxexporter
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
@@ -11,8 +10,8 @@ import (
 	"github.com/Azure/adx-mon/pkg/crd/summaryrule/backfill"
 	"github.com/Azure/adx-mon/pkg/kustoutil"
 	"github.com/Azure/adx-mon/pkg/logger"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/kql"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	azquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -329,24 +328,30 @@ func (r *SummaryRuleReconciler) updateSummaryRuleStatus(rule *adxmonv1.SummaryRu
 	}
 }
 
-// operationIDFromResult extracts a single string cell (operation id) from the RowIterator
-func operationIDFromResult(iter *kusto.RowIterator) (string, error) {
-	defer iter.Stop()
-	for {
-		row, errInline, errFinal := iter.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
+// operationIDFromResult extracts an operation id from the primary result table.
+// It prefers the OperationId column when present, falling back to the first value
+// for compatibility with single-cell responses.
+func operationIDFromResult(ds azquery.Dataset) (string, error) {
+	for _, table := range ds.Tables() {
+		if !table.IsPrimaryResult() {
 			continue
 		}
-		if errFinal != nil {
-			return "", fmt.Errorf("failed to retrieve operation ID: %v", errFinal)
+		for _, row := range table.Rows() {
+			if opID, err := row.StringByName("OperationId"); err == nil {
+				return opID, nil
+			}
+
+			values := row.Values()
+			if len(values) == 0 {
+				return "", fmt.Errorf("operation result row has no values")
+			}
+			if len(values) > 1 {
+				return "", fmt.Errorf("unexpected number of values in row without OperationId column: %d", len(values))
+			}
+
+			return values[0].String(), nil
 		}
-		if len(row.Values) != 1 {
-			return "", fmt.Errorf("unexpected number of values in row: %d", len(row.Values))
-		}
-		return row.Values[0].String(), nil
+		break
 	}
 	return "", nil
 }
@@ -381,27 +386,20 @@ func (r *SummaryRuleReconciler) getOperation(ctx context.Context, database strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve operation %s: %w", operationId, err)
 	}
-	defer rows.Stop()
-
-	for {
-		row, errInline, errFinal := rows.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
+	for _, table := range rows.Tables() {
+		if !table.IsPrimaryResult() {
 			continue
 		}
-		if errFinal != nil {
-			return nil, fmt.Errorf("failed to retrieve operation %s: %v", operationId, errFinal)
+		for _, row := range table.Rows() {
+			var status AsyncOperationStatus
+			if err := row.ToStruct(&status); err != nil {
+				return nil, fmt.Errorf("failed to parse operation %s: %v", operationId, err)
+			}
+			if status.State != "" {
+				return &status, nil
+			}
 		}
-
-		var status AsyncOperationStatus
-		if err := row.ToStruct(&status); err != nil {
-			return nil, fmt.Errorf("failed to parse operation %s: %v", operationId, err)
-		}
-		if status.State != "" {
-			return &status, nil
-		}
+		break
 	}
 	return nil, nil
 }

--- a/adxexporter/summaryrule_test.go
+++ b/adxexporter/summaryrule_test.go
@@ -2,7 +2,6 @@ package adxexporter
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"strings"
@@ -11,11 +10,7 @@ import (
 
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/pkg/kustoutil"
-	"github.com/Azure/azure-kusto-go/kusto"
-	kustoerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
-	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
+	azkustoerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,43 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-// ensureTestVFlagSetT sets the -test.v flag required for Azure Kusto SDK mock diagnostics.
-func ensureTestVFlagSetT(t *testing.T) {
-	t.Helper()
-	if flag.Lookup("test.v") == nil {
-		flag.String("test.v", "", "")
-		err := flag.CommandLine.Set("test.v", "true")
-		require.NoError(t, err)
-	}
-}
-
-// buildMockRows constructs a kusto.MockRows and populates it with provided rows.
-func buildMockRows(t *testing.T, cols table.Columns, rows []value.Values) *kusto.MockRows {
-	t.Helper()
-	mockRows, err := kusto.NewMockRows(cols)
-	require.NoError(t, err)
-	for _, r := range rows {
-		require.NoError(t, mockRows.Row(r))
-	}
-	return mockRows
-}
-
-// buildIteratorFromMockRows creates a RowIterator from pre-built mock rows.
-func buildIteratorFromMockRows(t *testing.T, mockRows *kusto.MockRows) *kusto.RowIterator {
-	t.Helper()
-	ensureTestVFlagSetT(t)
-	iter := &kusto.RowIterator{}
-	require.NoError(t, iter.Mock(mockRows))
-	return iter
-}
-
-// createRowIteratorFromMockRows is a convenience wrapper combining buildMockRows + buildIteratorFromMockRows.
-// Kept for backwards compatibility with existing tests while providing finer-grained helpers for new cases.
-func createRowIteratorFromMockRows(t *testing.T, cols table.Columns, rows []value.Values) *kusto.RowIterator {
-	t.Helper()
-	return buildIteratorFromMockRows(t, buildMockRows(t, cols, rows))
-}
 
 func newFakeClientWithRule(t *testing.T, rule *adxmonv1.SummaryRule) client.Client {
 	t.Helper()
@@ -84,8 +42,6 @@ func newBaseReconciler(t *testing.T, c client.Client, mock *MockKustoExecutor, c
 }
 
 func TestSummaryRule_SubmissionSuccess(t *testing.T) {
-	ensureTestVFlagSetT(t)
-
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}},
 		Spec: adxmonv1.SummaryRuleSpec{
@@ -99,25 +55,12 @@ func TestSummaryRule_SubmissionSuccess(t *testing.T) {
 
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 	// First Mgmt: submission returns operation id as a single-cell row
-	opCols := table.Columns{{Name: "OperationId", Type: types.String}}
-	opRows := []value.Values{{value.String{Value: "operation-id-123", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, opCols, opRows))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"operation-id-123"}}))
 	// Second Mgmt (getOperation): return InProgress, ShouldRetry=0
-	cols := table.Columns{
-		{Name: "LastUpdatedOn", Type: types.DateTime},
-		{Name: "OperationId", Type: types.String},
-		{Name: "State", Type: types.String},
-		{Name: "ShouldRetry", Type: types.Real},
-		{Name: "Status", Type: types.String},
-	}
-	rows := []value.Values{{
-		value.DateTime{Value: time.Now(), Valid: true},
-		value.String{Value: "operation-id-123", Valid: true},
-		value.String{Value: "InProgress", Valid: true},
-		value.Real{Value: 0, Valid: true},
-		value.String{Value: "", Valid: true},
-	}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rows))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{time.Now(), "operation-id-123", "InProgress", float64(0), ""}},
+	))
 
 	r := newBaseReconciler(t, c, mock, time.Now())
 
@@ -138,8 +81,6 @@ func TestSummaryRule_SubmissionSuccess(t *testing.T) {
 }
 
 func TestSummaryRule_SubmissionFailure(t *testing.T) {
-	ensureTestVFlagSetT(t)
-
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-fail", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}},
 		Spec:       adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"},
@@ -169,8 +110,6 @@ func TestSummaryRule_SubmissionFailure(t *testing.T) {
 }
 
 func TestSummaryRule_CompletedFailedRemovesAndSetsStatus(t *testing.T) {
-	ensureTestVFlagSetT(t)
-
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-failed-op", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}},
@@ -186,15 +125,10 @@ func TestSummaryRule_CompletedFailedRemovesAndSetsStatus(t *testing.T) {
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 
 	// getOperation returns Failed
-	cols := table.Columns{{Name: "LastUpdatedOn", Type: types.DateTime}, {Name: "OperationId", Type: types.String}, {Name: "State", Type: types.String}, {Name: "ShouldRetry", Type: types.Real}, {Name: "Status", Type: types.String}}
-	rows := []value.Values{{
-		value.DateTime{Value: now, Valid: true},
-		value.String{Value: "failed-op-1", Valid: true},
-		value.String{Value: "Failed", Valid: true},
-		value.Real{Value: 0, Valid: true},
-		value.String{Value: "boom", Valid: true},
-	}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rows))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{now, "failed-op-1", "Failed", float64(0), "boom"}},
+	))
 
 	r := newBaseReconciler(t, c, mock, now)
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
@@ -209,8 +143,6 @@ func TestSummaryRule_CompletedFailedRemovesAndSetsStatus(t *testing.T) {
 }
 
 func TestSummaryRule_RetryOperation(t *testing.T) {
-	ensureTestVFlagSetT(t)
-
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-retry", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}},
@@ -228,19 +160,12 @@ func TestSummaryRule_RetryOperation(t *testing.T) {
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 
 	// First Mgmt: getOperation -> ShouldRetry=1
-	cols := table.Columns{{Name: "LastUpdatedOn", Type: types.DateTime}, {Name: "OperationId", Type: types.String}, {Name: "State", Type: types.String}, {Name: "ShouldRetry", Type: types.Real}, {Name: "Status", Type: types.String}}
-	rows := []value.Values{{
-		value.DateTime{Value: now, Valid: true},
-		value.String{Value: "retry-op-1", Valid: true},
-		value.String{Value: "InProgress", Valid: true},
-		value.Real{Value: 1, Valid: true},
-		value.String{Value: "", Valid: true},
-	}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rows))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{now, "retry-op-1", "InProgress", float64(1), ""}},
+	))
 	// Second Mgmt: resubmission returns new operation id (single-cell)
-	op2Cols := table.Columns{{Name: "OperationId", Type: types.String}}
-	op2Rows := []value.Values{{value.String{Value: "new-op-2", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, op2Cols, op2Rows))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"new-op-2"}}))
 
 	r := newBaseReconciler(t, c, mock, now)
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
@@ -254,7 +179,6 @@ func TestSummaryRule_RetryOperation(t *testing.T) {
 }
 
 func TestSummaryRule_CriteriaAndDatabaseGating(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now()
 	// Rule for other DB should be skipped
 	ruleOtherDB := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-skip-db"}, Spec: adxmonv1.SummaryRuleSpec{Database: "otherdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
@@ -273,7 +197,6 @@ func TestSummaryRule_CriteriaAndDatabaseGating(t *testing.T) {
 }
 
 func TestSummaryRule_NoImmediateRetryAfterFailure(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now()
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-no-retry", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
 	c := newFakeClientWithRule(t, rule)
@@ -301,7 +224,6 @@ func TestSummaryRule_NoImmediateRetryAfterFailure(t *testing.T) {
 }
 
 func TestSummaryRule_BacklogTimestampForwardProgressOnly(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC().Truncate(time.Hour)
 	// Prepare a rule with last exec at now and a backlog op that would not be forward progress
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-forward", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
@@ -313,9 +235,7 @@ func TestSummaryRule_BacklogTimestampForwardProgressOnly(t *testing.T) {
 	c := newFakeClientWithRule(t, rule)
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 	// Simulate successful submit of backlog
-	opCols := table.Columns{{Name: "OperationId", Type: types.String}}
-	opRows := []value.Values{{value.String{Value: "backlog-op-1", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, opCols, opRows))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"backlog-op-1"}}))
 	r := newBaseReconciler(t, c, mock, now)
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
@@ -330,7 +250,6 @@ func TestSummaryRule_BacklogTimestampForwardProgressOnly(t *testing.T) {
 }
 
 func TestSummaryRule_MixedAsyncStates(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-mixed", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
 	// Seed multiple ops
@@ -340,16 +259,17 @@ func TestSummaryRule_MixedAsyncStates(t *testing.T) {
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 
 	// getOperation for completed-op
-	cols := table.Columns{{Name: "LastUpdatedOn", Type: types.DateTime}, {Name: "OperationId", Type: types.String}, {Name: "State", Type: types.String}, {Name: "ShouldRetry", Type: types.Real}, {Name: "Status", Type: types.String}}
-	rowsCompleted := []value.Values{{value.DateTime{Value: now, Valid: true}, value.String{Value: "completed-op", Valid: true}, value.String{Value: "Completed", Valid: true}, value.Real{Value: 0, Valid: true}, value.String{Value: "", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rowsCompleted))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{now, "completed-op", "Completed", float64(0), ""}},
+	))
 	// getOperation for retry-op (ShouldRetry=1)
-	rowsRetry := []value.Values{{value.DateTime{Value: now, Valid: true}, value.String{Value: "retry-op", Valid: true}, value.String{Value: "InProgress", Valid: true}, value.Real{Value: 1, Valid: true}, value.String{Value: "", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rowsRetry))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{now, "retry-op", "InProgress", float64(1), ""}},
+	))
 	// resubmission new id
-	opCols := table.Columns{{Name: "OperationId", Type: types.String}}
-	opRows := []value.Values{{value.String{Value: "retry-op-new", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, opCols, opRows))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"retry-op-new"}}))
 
 	r := newBaseReconciler(t, c, mock, now)
 	// Prevent fresh submission by persisting LastExecutionTime in status
@@ -368,7 +288,6 @@ func TestSummaryRule_MixedAsyncStates(t *testing.T) {
 }
 
 func TestSummaryRule_GetOperationFailureRetainsRecentOps(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-retain", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
 	// Seed with one recent op id
@@ -390,17 +309,16 @@ func TestSummaryRule_GetOperationFailureRetainsRecentOps(t *testing.T) {
 }
 
 func TestSummaryRule_KustoErrorParsingOnFailure(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-err-msg", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
 	c := newFakeClientWithRule(t, rule)
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 	// Create a Kusto HttpError with an @message payload and wrap it
 	body := `{"error":{"@message": "function is invalid"}}`
-	kerr := kustoerrors.HTTP(kustoerrors.OpMgmt, "bad request", 400, io.NopCloser(strings.NewReader(body)), "")
+	kerr := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "bad request", 400, io.NopCloser(strings.NewReader(body)), "")
 	wrapped := fmt.Errorf("exec failed: %w", kerr)
 	mock.errors = append(mock.errors, wrapped)
-	// Also fail backlog resubmission during same reconcile to avoid unintended empty iterator path
+	// Also fail backlog resubmission during same reconcile to avoid an extra dataset path
 	mock.errors = append(mock.errors, wrapped)
 	r := newBaseReconciler(t, c, mock, now)
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
@@ -414,7 +332,6 @@ func TestSummaryRule_KustoErrorParsingOnFailure(t *testing.T) {
 }
 
 func TestSummaryRule_ExporterSkipsWhenOwnerIngestorOrMissing(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now()
 
 	// Case 1: owner=ingestor -> exporter should skip
@@ -452,7 +369,6 @@ func TestSummaryRule_ExporterSkipsWhenOwnerIngestorOrMissing(t *testing.T) {
 }
 
 func TestSummaryRule_ExporterAdoptsWhenDesiredAndSafe(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{
@@ -482,7 +398,6 @@ func TestSummaryRule_ExporterAdoptsWhenDesiredAndSafe(t *testing.T) {
 }
 
 func TestSummaryRule_ExporterDoesNotAdoptWhenInsideWindow(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{
@@ -513,7 +428,6 @@ func TestSummaryRule_ExporterDoesNotAdoptWhenInsideWindow(t *testing.T) {
 }
 
 func TestSummaryRule_ExporterAutoAdoptsMissingAnnotation(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	rule := &adxmonv1.SummaryRule{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-auto-adopt"}, // no annotations -> implicit ingestor owner
@@ -537,31 +451,33 @@ func TestSummaryRule_ExporterAutoAdoptsMissingAnnotation(t *testing.T) {
 }
 
 func TestSummaryRule_OneTickBoundary_NoDoubleProcessing(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	// Window boundaries should subtract OneTick for inclusive end, preventing overlap with next window
 	start := time.Date(2025, 8, 13, 10, 0, 0, 0, time.UTC)
 	rule := &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "sr-onetick", Annotations: map[string]string{adxmonv1.SummaryRuleOwnerAnnotation: adxmonv1.SummaryRuleOwnerADXExporter}}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb", Table: "T", Interval: metav1.Duration{Duration: time.Hour}, Body: "Body"}}
 	c := newFakeClientWithRule(t, rule)
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 	// First submission returns op id and then getOperation for that id
-	opCols := table.Columns{{Name: "OperationId", Type: types.String}}
-	op1 := []value.Values{{value.String{Value: "op-1", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, opCols, op1))
-	statusCols := table.Columns{{Name: "LastUpdatedOn", Type: types.DateTime}, {Name: "OperationId", Type: types.String}, {Name: "State", Type: types.String}, {Name: "ShouldRetry", Type: types.Real}, {Name: "Status", Type: types.String}}
-	inprog := []value.Values{{value.DateTime{Value: start, Valid: true}, value.String{Value: "op-1", Valid: true}, value.String{Value: "InProgress", Valid: true}, value.Real{Value: 0, Valid: true}, value.String{Value: "", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, statusCols, inprog))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"op-1"}}))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{start, "op-1", "InProgress", float64(0), ""}},
+	))
 	r := newBaseReconciler(t, c, mock, start)
 	// Run reconcile to submit first window [10:00, 11:00-1tick]
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
 	require.NoError(t, err)
 	// Advance clock by exactly one interval and submit next window; provide results for submission and both getOperation calls
-	op2 := []value.Values{{value.String{Value: "op-2", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, opCols, op2))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"op-2"}}))
 	// getOperation for op-1 again
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, statusCols, inprog))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{start, "op-1", "InProgress", float64(0), ""}},
+	))
 	// getOperation for op-2
-	inprog2 := []value.Values{{value.DateTime{Value: start.Add(time.Hour), Valid: true}, value.String{Value: "op-2", Valid: true}, value.String{Value: "InProgress", Valid: true}, value.Real{Value: 0, Valid: true}, value.String{Value: "", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, statusCols, inprog2))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{start.Add(time.Hour), "op-2", "InProgress", float64(0), ""}},
+	))
 	r.Clock.(*klock.FakeClock).SetTime(start.Add(time.Hour))
 	_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(rule)})
 	require.NoError(t, err)
@@ -577,16 +493,16 @@ func TestSummaryRule_OneTickBoundary_NoDoubleProcessing(t *testing.T) {
 }
 
 func TestSummaryRule_getOperation_Parsing(t *testing.T) {
-	ensureTestVFlagSetT(t)
 	now := time.Now().UTC()
 	c := newFakeClientWithRule(t, &adxmonv1.SummaryRule{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "dummy"}, Spec: adxmonv1.SummaryRuleSpec{Database: "testdb"}})
 	mock := NewMockKustoExecutor(t, "testdb", "https://test")
 	r := newBaseReconciler(t, c, mock, now)
 
 	// Configure a valid status row
-	cols := table.Columns{{Name: "LastUpdatedOn", Type: types.DateTime}, {Name: "OperationId", Type: types.String}, {Name: "State", Type: types.String}, {Name: "ShouldRetry", Type: types.Real}, {Name: "Status", Type: types.String}}
-	rows := []value.Values{{value.DateTime{Value: now, Valid: true}, value.String{Value: "op-x", Valid: true}, value.String{Value: "Completed", Valid: true}, value.Real{Value: 0, Valid: true}, value.String{Value: "", Valid: true}}}
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, rows))
+	mock.results = append(mock.results, createDatasetWithColumns(
+		[]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"},
+		[][]interface{}{{now, "op-x", "Completed", float64(0), ""}},
+	))
 	st, err := r.getOperation(context.Background(), "testdb", "op-x")
 	require.NoError(t, err)
 	require.NotNil(t, st)
@@ -595,7 +511,7 @@ func TestSummaryRule_getOperation_Parsing(t *testing.T) {
 	require.Equal(t, float64(0), st.ShouldRetry)
 
 	// Now configure empty result and expect nil
-	mock.results = append(mock.results, createRowIteratorFromMockRows(t, cols, nil))
+	mock.results = append(mock.results, createDatasetWithColumns([]string{"LastUpdatedOn", "OperationId", "State", "ShouldRetry", "Status"}, nil))
 	st, err = r.getOperation(context.Background(), "testdb", "not-found")
 	require.NoError(t, err)
 	require.Nil(t, st)

--- a/adxexporter/summaryrule_test.go
+++ b/adxexporter/summaryrule_test.go
@@ -11,6 +11,7 @@ import (
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/pkg/kustoutil"
 	azkustoerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -515,4 +516,39 @@ func TestSummaryRule_getOperation_Parsing(t *testing.T) {
 	st, err = r.getOperation(context.Background(), "testdb", "not-found")
 	require.NoError(t, err)
 	require.Nil(t, st)
+}
+
+func TestOperationIDFromResult_RequiresOperationID(t *testing.T) {
+	t.Run("missing row", func(t *testing.T) {
+		_, err := operationIDFromResult(createDatasetWithColumns([]string{"OperationId"}, nil))
+		require.EqualError(t, err, "expected one operation result row, got 0")
+	})
+
+	t.Run("multiple rows", func(t *testing.T) {
+		_, err := operationIDFromResult(createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{"op-1"}, {"op-2"}}))
+		require.EqualError(t, err, "expected one operation result row, got 2")
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		_, err := operationIDFromResult(createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{""}}))
+		require.EqualError(t, err, "operation id is empty")
+	})
+
+	t.Run("named GUID", func(t *testing.T) {
+		id := uuid.MustParse("eeab2025-9cc6-411f-8ef5-9e5c6b720f22")
+		opID, err := operationIDFromResult(createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{id}}))
+		require.NoError(t, err)
+		require.Equal(t, id.String(), opID)
+	})
+
+	t.Run("unnamed single cell", func(t *testing.T) {
+		opID, err := operationIDFromResult(createDatasetWithColumns([]string{"Result"}, [][]interface{}{{"op-1"}}))
+		require.NoError(t, err)
+		require.Equal(t, "op-1", opID)
+	})
+
+	t.Run("named unsupported type", func(t *testing.T) {
+		_, err := operationIDFromResult(createDatasetWithColumns([]string{"OperationId"}, [][]interface{}{{1.5}}))
+		require.EqualError(t, err, "operation id has unsupported type real")
+	})
 }


### PR DESCRIPTION
Migrated adxexporter from legacy Kusto client to azkustodata, modernizing the exporter’s ADX integration with safer query handling, cleaner result parsing, and a simpler azkustodata-based client interface.