### PR TITLE
refactor(transform): remove legacy Kusto value wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-adxexporter:
 build: build-alerter build-ingestor build-collector build-operator build-adxexporter
 .PHONY: build
 
-image: image-ingestor image-alerter image-collector image-operator
+image: image-ingestor image-alerter image-collector image-operator image-adxexporter
 .PHONY: image
 
 image-ingestor:
@@ -54,6 +54,10 @@ image-operator:
 	docker build --no-cache --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_TIME=$(BUILD_TIME) -t ghcr.io/azure/adx-mon/operator:latest -f build/images/Dockerfile.operator .
 .PHONY: image-operator
 
+image-adxexporter:
+	docker build --no-cache --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_TIME=$(BUILD_TIME) -t ghcr.io/azure/adx-mon/adxexporter:latest -f build/images/Dockerfile.adxexporter .
+.PHONY: image-adxexporter
+
 image-operator-dev:
 .PHONY: image-operator-dev
 
@@ -62,6 +66,7 @@ push:
 	docker push ghcr.io/azure/adx-mon/ingestor:latest
 	docker push ghcr.io/azure/adx-mon/collector:latest
 	docker push ghcr.io/azure/adx-mon/operator:latest
+	docker push ghcr.io/azure/adx-mon/adxexporter:latest
 .PHONY: push
 
 clean:

--- a/adxexporter/kusto_test.go
+++ b/adxexporter/kusto_test.go
@@ -175,6 +175,8 @@ func createDatasetWithColumns(columnNames []string, rows [][]interface{}) azquer
 		vals := make(azvalue.Values, 0, len(rowData))
 		for _, col := range rowData {
 			switch v := col.(type) {
+			case azvalue.Kusto:
+				vals = append(vals, v)
 			case string:
 				vals = append(vals, azvalue.NewString(v))
 			case uuid.UUID:
@@ -200,7 +202,9 @@ func inferColumnType(rows [][]interface{}, idx int) aztypes.Column {
 			continue
 		}
 
-		switch row[idx].(type) {
+		switch value := row[idx].(type) {
+		case azvalue.Kusto:
+			return value.GetType()
 		case string:
 			return aztypes.String
 		case uuid.UUID:

--- a/adxexporter/metricsexporter_test.go
+++ b/adxexporter/metricsexporter_test.go
@@ -11,6 +11,7 @@ import (
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/metrics/v1"
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
+	azvalue "github.com/Azure/azure-kusto-go/azkustodata/value"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -954,6 +955,76 @@ func TestTransformAndRegisterMetrics(t *testing.T) {
 	// Execute transformation and registration
 	err = reconciler.transformAndRegisterMetrics(context.Background(), me, rows)
 	require.NoError(t, err)
+}
+
+func TestKustoQueryValuesTransformAndPushToOTLP(t *testing.T) {
+	requestChan := make(chan *v1.ExportMetricsServiceRequest, 1)
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		request := &v1.ExportMetricsServiceRequest{}
+		require.NoError(t, proto.Unmarshal(body, request))
+		requestChan <- request
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	timestamp := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	mockClient := NewMockKustoExecutor(t, "Metrics", "https://test.kusto.windows.net")
+	mockClient.results = append(mockClient.results, createDatasetWithColumns(
+		[]string{"metric_name", "value", "timestamp", "region"},
+		[][]interface{}{{
+			azvalue.NewString("request_count"),
+			azvalue.NewReal(42.5),
+			azvalue.NewDateTime(timestamp),
+			azvalue.NewString("west"),
+		}},
+	))
+
+	result, err := NewQueryExecutor(mockClient).ExecuteQuery(
+		context.Background(),
+		"print metric_name, value, timestamp, region",
+		timestamp.Add(-time.Minute),
+		timestamp,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, result.Error)
+
+	reconciler := &MetricsExporterReconciler{OTLPEndpoint: mockServer.URL}
+	require.NoError(t, reconciler.initOtlpExporter())
+	metricsExporter := &adxmonv1.MetricsExporter{
+		Spec: adxmonv1.MetricsExporterSpec{
+			Transform: adxmonv1.TransformConfig{
+				MetricNameColumn: "metric_name",
+				ValueColumns:     []string{"value"},
+				TimestampColumn:  "timestamp",
+				LabelColumns:     []string{"region"},
+			},
+		},
+	}
+	require.NoError(t, reconciler.transformAndRegisterMetrics(context.Background(), metricsExporter, result.Rows))
+
+	select {
+	case request := <-requestChan:
+		require.Len(t, request.ResourceMetrics, 1)
+		require.Len(t, request.ResourceMetrics[0].ScopeMetrics, 1)
+		metrics := request.ResourceMetrics[0].ScopeMetrics[0].Metrics
+		require.Len(t, metrics, 1)
+		require.Equal(t, "request_count_value", metrics[0].Name)
+
+		dataPoints := metrics[0].GetGauge().GetDataPoints()
+		require.Len(t, dataPoints, 1)
+		require.Equal(t, 42.5, dataPoints[0].GetAsDouble())
+		require.Equal(t, uint64(timestamp.UnixNano()), dataPoints[0].TimeUnixNano)
+		require.Len(t, dataPoints[0].Attributes, 1)
+		require.Equal(t, "region", dataPoints[0].Attributes[0].Key)
+		require.Equal(t, "west", dataPoints[0].Attributes[0].Value.GetStringValue())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OTLP request")
+	}
 }
 
 func TestTransformAndRegisterMetrics_DefaultMetricName(t *testing.T) {

--- a/build/images/Dockerfile.adxexporter
+++ b/build/images/Dockerfile.adxexporter
@@ -1,0 +1,20 @@
+FROM golang:1.26 AS builder
+ARG TARGETOS TARGETARCH VERSION GIT_COMMIT BUILD_TIME
+
+ADD . /code
+WORKDIR /code
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+-ldflags=" \
+-X 'github.com/Azure/adx-mon/pkg/version.Version=${VERSION}' \
+-X 'github.com/Azure/adx-mon/pkg/version.GitCommit=${GIT_COMMIT}' \
+-X 'github.com/Azure/adx-mon/pkg/version.BuildTime=${BUILD_TIME}' \
+" -o ./bin/adxexporter ./cmd/adxexporter
+
+FROM mcr.microsoft.com/azurelinux/distroless/base:3.0
+
+LABEL org.opencontainers.image.source=https://github.com/Azure/adx-mon
+
+COPY --from=builder /code/bin /
+
+ENTRYPOINT ["/adxexporter"]

--- a/pkg/testutils/adxexporter/adxexporter.go
+++ b/pkg/testutils/adxexporter/adxexporter.go
@@ -1,0 +1,91 @@
+//go:build !disableDocker
+
+package adxexporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/adx-mon/pkg/testutils"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/k3s"
+)
+
+const (
+	DefaultImage = "adxexporter"
+	DefaultTag   = "latest"
+)
+
+type ADXExporterContainer struct {
+	testcontainers.Container
+}
+
+func Run(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*ADXExporterContainer, error) {
+	var relative string
+	for iter := range 4 {
+		relative = strings.Repeat("../", iter)
+		if _, err := os.Stat(filepath.Join(relative, "build/images/Dockerfile.adxexporter")); err == nil {
+			break
+		}
+	}
+
+	req := testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Repo:       DefaultImage,
+			Tag:        DefaultTag,
+			Context:    relative,
+			Dockerfile: "build/images/Dockerfile.adxexporter",
+			KeepImage:  true,
+		},
+	}
+
+	genericContainerReq := testcontainers.GenericContainerRequest{ContainerRequest: req}
+	for _, opt := range opts {
+		if err := opt.Customize(&genericContainerReq); err != nil {
+			return nil, err
+		}
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	var exporter *ADXExporterContainer
+	if container != nil {
+		exporter = &ADXExporterContainer{Container: container}
+	}
+	if err != nil {
+		return exporter, fmt.Errorf("generic container: %w", err)
+	}
+
+	return exporter, nil
+}
+
+func WithCluster(ctx context.Context, cluster *k3s.K3sContainer) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.LifecycleHooks = append(req.LifecycleHooks, testcontainers.ContainerLifecycleHooks{
+			PreCreates: []testcontainers.ContainerRequestHook{
+				func(ctx context.Context, req testcontainers.ContainerRequest) error {
+					if err := cluster.LoadImages(ctx, DefaultImage+":"+DefaultTag); err != nil {
+						return fmt.Errorf("failed to load image: %w", err)
+					}
+
+					rootDir, err := testutils.GetGitRootDir()
+					if err != nil {
+						return fmt.Errorf("failed to get git root dir: %w", err)
+					}
+
+					localPath := filepath.Join(rootDir, "pkg/testutils/adxexporter/k8s.yaml")
+					remotePath := filepath.Join(testutils.K3sManifests, "adxexporter.yaml")
+					if err := cluster.CopyFileToContainer(ctx, localPath, remotePath, 0644); err != nil {
+						return fmt.Errorf("failed to copy manifest: %w", err)
+					}
+
+					return nil
+				},
+			},
+		})
+
+		return nil
+	}
+}

--- a/pkg/testutils/adxexporter/k8s.yaml
+++ b/pkg/testutils/adxexporter/k8s.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adx-mon
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: adxexporter
+  namespace: adx-mon
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: adx-mon:adxexporter
+rules:
+  - apiGroups: ["adx-mon.azure.com"]
+    resources: ["metricsexporters", "summaryrules"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["adx-mon.azure.com"]
+    resources: ["metricsexporters/status", "summaryrules/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: adx-mon:adxexporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: adx-mon:adxexporter
+subjects:
+  - kind: ServiceAccount
+    name: adxexporter
+    namespace: adx-mon
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: adx-mon
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [debug]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: adx-mon
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: adx-mon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector:0.130.1
+          args: ["--config=/etc/otelcol/config.yaml"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          ports:
+            - containerPort: 4318
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adxexporter
+  namespace: adx-mon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: adxexporter
+  template:
+    metadata:
+      labels:
+        app: adxexporter
+    spec:
+      serviceAccountName: adxexporter
+      containers:
+        - name: adxexporter
+          image: adxexporter:latest
+          imagePullPolicy: Never
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          args:
+            - "--kusto-endpoints=Metrics=http://kustainer.default.svc.cluster.local:8080"
+            - "--otlp-endpoint=http://otel-collector.adx-mon.svc.cluster.local:4318/v1/metrics"
+          env:
+            - name: GODEBUG
+              value: http2client=0
+          ports:
+            - containerPort: 8081

--- a/pkg/testutils/collector/collector.go
+++ b/pkg/testutils/collector/collector.go
@@ -23,7 +23,6 @@ import (
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -155,7 +154,7 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 					})
 
 					// Wait for our manifests to be applied
-					restConfig, _, err := testutils.GetKubeConfig(ctx, k)
+					restConfig, ctrlCli, err := testutils.GetKubeConfig(ctx, k)
 					if err != nil {
 						return fmt.Errorf("failed to get kube config: %w", err)
 					}
@@ -163,11 +162,6 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 					clientset, err := kubernetes.NewForConfig(restConfig)
 					if err != nil {
 						return fmt.Errorf("failed to create clientset: %w", err)
-					}
-
-					ctrlCli, err := ctrlclient.New(restConfig, ctrlclient.Options{})
-					if err != nil {
-						return fmt.Errorf("failed to create controller client: %w", err)
 					}
 
 					err = kwait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {

--- a/pkg/testutils/ingestor/ingestor.go
+++ b/pkg/testutils/ingestor/ingestor.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -255,7 +254,7 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 						// We're keeping the existing volumeMount since it's already pointing to /mnt/data
 					}
 
-					restConfig, _, err := testutils.GetKubeConfig(ctx, k)
+					restConfig, ctrlCli, err := testutils.GetKubeConfig(ctx, k)
 					if err != nil {
 						return fmt.Errorf("failed to get kube config: %w", err)
 					}
@@ -263,11 +262,6 @@ func WithCluster(ctx context.Context, k *k3s.K3sContainer) testcontainers.Custom
 					clientset, err := kubernetes.NewForConfig(restConfig)
 					if err != nil {
 						return fmt.Errorf("failed to create clientset: %w", err)
-					}
-
-					ctrlCli, err := ctrlclient.New(restConfig, ctrlclient.Options{})
-					if err != nil {
-						return fmt.Errorf("failed to create controller client: %w", err)
 					}
 
 					err = kwait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Minute, true, func(ctx context.Context) (bool, error) {

--- a/pkg/testutils/integration_test.go
+++ b/pkg/testutils/integration_test.go
@@ -80,7 +80,7 @@ func StartCluster(ctx context.Context, t *testing.T) (kustoUrl string, k3sContai
 	testcontainers.CleanupContainer(t, kustoContainer)
 	require.NoError(t, err)
 
-	restConfig, _, err := testutils.GetKubeConfig(ctx, k3sContainer)
+	restConfig, k8sClient, err := testutils.GetKubeConfig(ctx, k3sContainer)
 	require.NoError(t, err)
 	require.NoError(t, kustoContainer.PortForward(ctx, restConfig))
 
@@ -154,6 +154,25 @@ func StartCluster(ctx context.Context, t *testing.T) (kustoUrl string, k3sContai
 		exporterContainer, err := testadxexporter.Run(ctx, testadxexporter.WithCluster(ctx, k3sContainer))
 		testcontainers.CleanupContainer(t, exporterContainer)
 		require.NoError(tt, err)
+	})
+
+	t.Run("Wait for Collector function", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			var function adxmonv1.Function
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "collector", Namespace: "adx-mon"}, &function); err != nil {
+				t.Logf("Failed to retrieve Collector Function: %v", err)
+				return false
+			}
+
+			condition := function.GetCondition()
+			if condition == nil || condition.Status != metav1.ConditionTrue || condition.ObservedGeneration != function.Generation {
+				if condition != nil {
+					t.Logf("Collector Function pending: status=%s reason=%s message=%s", condition.Status, condition.Reason, condition.Message)
+				}
+				return false
+			}
+			return true
+		}, 5*time.Minute, time.Second, "Collector Function did not reconcile")
 	})
 
 	return kustoUrl, k3sContainer

--- a/pkg/testutils/integration_test.go
+++ b/pkg/testutils/integration_test.go
@@ -13,6 +13,7 @@ import (
 
 	adxmonv1 "github.com/Azure/adx-mon/api/v1"
 	"github.com/Azure/adx-mon/pkg/testutils"
+	testadxexporter "github.com/Azure/adx-mon/pkg/testutils/adxexporter"
 	"github.com/Azure/adx-mon/pkg/testutils/alerter"
 	"github.com/Azure/adx-mon/pkg/testutils/collector"
 	"github.com/Azure/adx-mon/pkg/testutils/ingestor"
@@ -24,6 +25,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -56,6 +58,12 @@ func TestIntegration(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		VerifyAlerts(ctx, t, kustainerUrl, k3sContainer)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		VerifyMetricsExporter(ctx, t, k3sContainer)
 	}()
 
 	wg.Wait()
@@ -142,7 +150,98 @@ func StartCluster(ctx context.Context, t *testing.T) (kustoUrl string, k3sContai
 		require.NoError(tt, err)
 	})
 
+	t.Run("Build and install ADX Exporter", func(tt *testing.T) {
+		exporterContainer, err := testadxexporter.Run(ctx, testadxexporter.WithCluster(ctx, k3sContainer))
+		testcontainers.CleanupContainer(t, exporterContainer)
+		require.NoError(tt, err)
+	})
+
 	return kustoUrl, k3sContainer
+}
+
+func VerifyMetricsExporter(ctx context.Context, t *testing.T, k3sContainer *k3s.K3sContainer) {
+	t.Helper()
+
+	restConfig, k8sClient, err := testutils.GetKubeConfig(ctx, k3sContainer)
+	require.NoError(t, err)
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err)
+
+	rule := &adxmonv1.MetricsExporter{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MetricsExporter",
+			APIVersion: "adx-mon.azure.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kusto-values-e2e",
+			Namespace: "adx-mon",
+		},
+		Spec: adxmonv1.MetricsExporterSpec{
+			Database: "Metrics",
+			Body:     `print metric_name="e2e_request_count", value=real(42.5), timestamp=now(), region="west"`,
+			Interval: metav1.Duration{Duration: time.Minute},
+			Transform: adxmonv1.TransformConfig{
+				MetricNameColumn: "metric_name",
+				ValueColumns:     []string{"value"},
+				TimestampColumn:  "timestamp",
+				LabelColumns:     []string{"region"},
+			},
+		},
+	}
+
+	require.Eventually(t, func() bool {
+		if err := k8sClient.Create(ctx, rule.DeepCopy()); err != nil {
+			t.Logf("MetricsExporter CRD not ready: %v", err)
+			return false
+		}
+		return true
+	}, 5*time.Minute, time.Second)
+
+	require.Eventually(t, func() bool {
+		var current adxmonv1.MetricsExporter
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace}, &current); err != nil {
+			t.Logf("Failed to retrieve MetricsExporter: %v", err)
+			return false
+		}
+		condition := current.GetCondition()
+		return condition != nil && condition.Status == metav1.ConditionTrue
+	}, 5*time.Minute, time.Second, "MetricsExporter did not report a successful execution")
+
+	require.Eventually(t, func() bool {
+		found, err := podLogsContain(ctx, clientset, "adx-mon", "app=otel-collector", "otel-collector", "e2e_request_count_value")
+		if err != nil {
+			t.Logf("Failed to inspect OTel Collector logs: %v", err)
+		}
+		return found
+	}, 5*time.Minute, time.Second, "OTel Collector did not receive the exported metric")
+}
+
+func podLogsContain(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector, container, expected string) (bool, error) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return false, fmt.Errorf("list pods: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+
+		stream, err := clientset.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: container}).Stream(ctx)
+		if err != nil {
+			continue
+		}
+		body, readErr := io.ReadAll(stream)
+		stream.Close()
+		if readErr != nil {
+			return false, fmt.Errorf("read pod logs: %w", readErr)
+		}
+		if strings.Contains(string(body), expected) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func VerifyAlerts(ctx context.Context, t *testing.T, kustainerUrl string, k3sContainer *k3s.K3sContainer) {

--- a/pkg/testutils/integration_test.go
+++ b/pkg/testutils/integration_test.go
@@ -162,58 +162,60 @@ func StartCluster(ctx context.Context, t *testing.T) (kustoUrl string, k3sContai
 func VerifyMetricsExporter(ctx context.Context, t *testing.T, k3sContainer *k3s.K3sContainer) {
 	t.Helper()
 
-	restConfig, k8sClient, err := testutils.GetKubeConfig(ctx, k3sContainer)
-	require.NoError(t, err)
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	require.NoError(t, err)
+	t.Run("Verify Metrics Exporter", func(t *testing.T) {
+		restConfig, k8sClient, err := testutils.GetKubeConfig(ctx, k3sContainer)
+		require.NoError(t, err)
+		clientset, err := kubernetes.NewForConfig(restConfig)
+		require.NoError(t, err)
 
-	rule := &adxmonv1.MetricsExporter{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "MetricsExporter",
-			APIVersion: "adx-mon.azure.com/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kusto-values-e2e",
-			Namespace: "adx-mon",
-		},
-		Spec: adxmonv1.MetricsExporterSpec{
-			Database: "Metrics",
-			Body:     `print metric_name="e2e_request_count", value=real(42.5), timestamp=now(), region="west"`,
-			Interval: metav1.Duration{Duration: time.Minute},
-			Transform: adxmonv1.TransformConfig{
-				MetricNameColumn: "metric_name",
-				ValueColumns:     []string{"value"},
-				TimestampColumn:  "timestamp",
-				LabelColumns:     []string{"region"},
+		rule := &adxmonv1.MetricsExporter{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MetricsExporter",
+				APIVersion: "adx-mon.azure.com/v1",
 			},
-		},
-	}
-
-	require.Eventually(t, func() bool {
-		if err := k8sClient.Create(ctx, rule.DeepCopy()); err != nil {
-			t.Logf("MetricsExporter CRD not ready: %v", err)
-			return false
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kusto-values-e2e",
+				Namespace: "adx-mon",
+			},
+			Spec: adxmonv1.MetricsExporterSpec{
+				Database: "Metrics",
+				Body:     `print metric_name="e2e_request_count", value=real(42.5), timestamp=now(), region="west"`,
+				Interval: metav1.Duration{Duration: time.Minute},
+				Transform: adxmonv1.TransformConfig{
+					MetricNameColumn: "metric_name",
+					ValueColumns:     []string{"value"},
+					TimestampColumn:  "timestamp",
+					LabelColumns:     []string{"region"},
+				},
+			},
 		}
-		return true
-	}, 5*time.Minute, time.Second)
 
-	require.Eventually(t, func() bool {
-		var current adxmonv1.MetricsExporter
-		if err := k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace}, &current); err != nil {
-			t.Logf("Failed to retrieve MetricsExporter: %v", err)
-			return false
-		}
-		condition := current.GetCondition()
-		return condition != nil && condition.Status == metav1.ConditionTrue
-	}, 5*time.Minute, time.Second, "MetricsExporter did not report a successful execution")
+		require.Eventually(t, func() bool {
+			if err := k8sClient.Create(ctx, rule.DeepCopy()); err != nil {
+				t.Logf("MetricsExporter CRD not ready: %v", err)
+				return false
+			}
+			return true
+		}, 5*time.Minute, time.Second)
 
-	require.Eventually(t, func() bool {
-		found, err := podLogsContain(ctx, clientset, "adx-mon", "app=otel-collector", "otel-collector", "e2e_request_count_value")
-		if err != nil {
-			t.Logf("Failed to inspect OTel Collector logs: %v", err)
-		}
-		return found
-	}, 5*time.Minute, time.Second, "OTel Collector did not receive the exported metric")
+		require.Eventually(t, func() bool {
+			var current adxmonv1.MetricsExporter
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace}, &current); err != nil {
+				t.Logf("Failed to retrieve MetricsExporter: %v", err)
+				return false
+			}
+			condition := current.GetCondition()
+			return condition != nil && condition.Status == metav1.ConditionTrue
+		}, 5*time.Minute, time.Second, "MetricsExporter did not report a successful execution")
+
+		require.Eventually(t, func() bool {
+			found, err := podLogsContain(ctx, clientset, "adx-mon", "app=otel-collector", "otel-collector", "e2e_request_count_value")
+			if err != nil {
+				t.Logf("Failed to inspect OTel Collector logs: %v", err)
+			}
+			return found
+		}, 5*time.Minute, time.Second, "OTel Collector did not receive the exported metric")
+	})
 }
 
 func podLogsContain(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector, container, expected string) (bool, error) {

--- a/pkg/testutils/k8s.go
+++ b/pkg/testutils/k8s.go
@@ -10,6 +10,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -34,7 +35,7 @@ func WriteKubeConfig(ctx context.Context, k *k3s.K3sContainer, dir string) (stri
 }
 
 func GetKubeConfig(ctx context.Context, k *k3s.K3sContainer) (*rest.Config, ctrlclient.Client, error) {
-	scheme := clientgoscheme.Scheme
+	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		return nil, nil, fmt.Errorf("failed to add client-go scheme: %w", err)
 	}
@@ -53,7 +54,7 @@ func GetKubeConfig(ctx context.Context, k *k3s.K3sContainer) (*rest.Config, ctrl
 	}
 	restCfg.WarningHandler = rest.NoWarnings{}
 
-	ctrlCli, err := ctrlclient.New(restCfg, ctrlclient.Options{})
+	ctrlCli, err := ctrlclient.New(restCfg, ctrlclient.Options{Scheme: scheme})
 
 	return restCfg, ctrlCli, err
 }

--- a/transform/kusto_to_metrics.go
+++ b/transform/kusto_to_metrics.go
@@ -403,7 +403,7 @@ func (t *KustoToMetricsTransformer) extractLabels(row map[string]any) (map[strin
 		case string:
 			labels[labelColumn] = v
 		default:
-			// Lables must be string key:value pairs.
+			// Labels must be string key:value pairs.
 			return nil, fmt.Errorf("label column '%s' contains unsupported type %T", labelColumn, rawValue)
 		}
 	}

--- a/transform/kusto_to_metrics.go
+++ b/transform/kusto_to_metrics.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/adx-mon/pkg/logger"
 	"github.com/Azure/adx-mon/pkg/prompb"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -178,8 +177,8 @@ func constructMetricName(baseName, prefix, columnName string) (string, error) {
 	return result, nil
 }
 
-// Transform converts KQL query results to Prometheus metrics
-// Supports both single-value and multi-value column modes
+// Transform converts materialized KQL rows to Prometheus metrics.
+// Callers must convert Kusto SDK values and nulls to native Go values first.
 func (t *KustoToMetricsTransformer) Transform(results []map[string]any) ([]MetricData, error) {
 	if len(results) == 0 {
 		return []MetricData{}, nil
@@ -267,6 +266,9 @@ func (t *KustoToMetricsTransformer) extractMetricName(row map[string]any) (strin
 		if !exists {
 			return "", fmt.Errorf("metric name column '%s' not found in row", t.config.MetricNameColumn)
 		}
+		if rawValue == nil {
+			return "", fmt.Errorf("metric name column '%s' contains null value", t.config.MetricNameColumn)
+		}
 
 		switch v := rawValue.(type) {
 		case string:
@@ -274,14 +276,6 @@ func (t *KustoToMetricsTransformer) extractMetricName(row map[string]any) (strin
 				return "", fmt.Errorf("metric name column '%s' contains empty string", t.config.MetricNameColumn)
 			}
 			return v, nil
-		case value.String:
-			if !v.Valid {
-				return "", fmt.Errorf("metric name column '%s' contains null value", t.config.MetricNameColumn)
-			}
-			if v.Value == "" {
-				return "", fmt.Errorf("metric name column '%s' contains empty string", t.config.MetricNameColumn)
-			}
-			return v.Value, nil
 		default:
 			return "", fmt.Errorf("metric name column '%s' contains non-string value: %T", t.config.MetricNameColumn, rawValue)
 		}
@@ -336,21 +330,6 @@ func (t *KustoToMetricsTransformer) extractValueFromColumn(row map[string]any, c
 		return float64(v), nil
 	case int64:
 		return float64(v), nil
-	case value.Long:
-		if !v.Valid {
-			return 0, fmt.Errorf("value column '%s' contains null value", columnName)
-		}
-		return float64(v.Value), nil
-	case value.Real:
-		if !v.Valid {
-			return 0, fmt.Errorf("value column '%s' contains null value", columnName)
-		}
-		return v.Value, nil
-	case value.Int:
-		if !v.Valid {
-			return 0, fmt.Errorf("value column '%s' contains null value", columnName)
-		}
-		return float64(v.Value), nil
 	case string:
 		// Try to parse string as float
 		parsed, err := strconv.ParseFloat(v, 64)
@@ -401,11 +380,6 @@ func (t *KustoToMetricsTransformer) extractTimestamp(row map[string]any) (time.T
 			return time.Time{}, fmt.Errorf("timestamp column '%s' contains unparseable string value '%s': %w", t.config.TimestampColumn, v, err)
 		}
 		return parsed, nil
-	case value.DateTime:
-		if !v.Valid {
-			return time.Time{}, fmt.Errorf("timestamp column '%s' contains null value", t.config.TimestampColumn)
-		}
-		return v.Value, nil
 	default:
 		return time.Time{}, fmt.Errorf("timestamp column '%s' contains unsupported type %T", t.config.TimestampColumn, rawValue)
 	}
@@ -421,15 +395,13 @@ func (t *KustoToMetricsTransformer) extractLabels(row map[string]any) (map[strin
 			// Skip missing label columns instead of failing
 			continue
 		}
+		if rawValue == nil {
+			return nil, fmt.Errorf("label column '%s' contains null value", labelColumn)
+		}
 
 		switch v := rawValue.(type) {
 		case string:
 			labels[labelColumn] = v
-		case value.String:
-			if !v.Valid {
-				return nil, fmt.Errorf("label column '%s' contains invalid value: %T", labelColumn, rawValue)
-			}
-			labels[labelColumn] = v.Value
 		default:
 			// Lables must be string key:value pairs.
 			return nil, fmt.Errorf("label column '%s' contains unsupported type %T", labelColumn, rawValue)
@@ -545,21 +517,9 @@ func (t *KustoToMetricsTransformer) validateValueColumn(row map[string]any, colu
 	}
 
 	// Check if value is numeric type
-	switch v := rawValue.(type) {
+	switch rawValue.(type) {
 	case float64, float32, int, int32, int64, string:
 		// Valid numeric types (string will be validated during parsing)
-	case value.Long:
-		if !v.Valid {
-			return fmt.Errorf("value column '%s' contains null value", columnName)
-		}
-	case value.Real:
-		if !v.Valid {
-			return fmt.Errorf("value column '%s' contains null value", columnName)
-		}
-	case value.Int:
-		if !v.Valid {
-			return fmt.Errorf("value column '%s' contains null value", columnName)
-		}
 	case nil:
 		return fmt.Errorf("value column '%s' contains null value", columnName)
 	default:

--- a/transform/kusto_to_metrics_test.go
+++ b/transform/kusto_to_metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/pkg/prompb"
-	"github.com/Azure/azure-kusto-go/kusto/data/value"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
 )
@@ -123,6 +122,31 @@ func TestTransformWithTimestamp(t *testing.T) {
 	require.True(t, metric.Timestamp.Equal(testTime))
 }
 
+func TestTransformMaterializedKustoRow(t *testing.T) {
+	timestamp := time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC)
+	transformer := NewKustoToMetricsTransformer(TransformConfig{
+		MetricNameColumn: "metric_name",
+		ValueColumns:     []string{"value"},
+		TimestampColumn:  "timestamp",
+		LabelColumns:     []string{"host"},
+	}, noop.NewMeterProvider().Meter("test"))
+
+	metrics, err := transformer.Transform([]map[string]any{{
+		"metric_name": "cpu_usage",
+		"value":       float64(42.5),
+		"timestamp":   timestamp,
+		"host":        "server1",
+	}})
+
+	require.NoError(t, err)
+	require.Equal(t, []MetricData{{
+		Name:      "cpu_usage_value",
+		Value:     42.5,
+		Timestamp: timestamp,
+		Labels:    map[string]string{"host": "server1"},
+	}}, metrics)
+}
+
 func TestTransformValueTypes(t *testing.T) {
 	config := TransformConfig{
 		ValueColumns:      []string{"value"},
@@ -152,51 +176,6 @@ func TestTransformValueTypes(t *testing.T) {
 
 			metrics, err := transformer.Transform(results)
 			require.NoError(t, err)
-			require.Len(t, metrics, 1)
-			require.Equal(t, tc.expected, metrics[0].Value)
-		})
-	}
-}
-
-func TestTransformKustoValueTypes(t *testing.T) {
-	config := TransformConfig{
-		ValueColumns:      []string{"value"},
-		DefaultMetricName: "test_metric",
-	}
-	meter := noop.NewMeterProvider().Meter("test")
-	transformer := NewKustoToMetricsTransformer(config, meter)
-
-	testCases := []struct {
-		name     string
-		value    any
-		expected float64
-	}{
-		{"value.Long valid", value.Long{Value: 42, Valid: true}, 42.0},
-		{"value.Real valid", value.Real{Value: 42.5, Valid: true}, 42.5},
-		{"value.Int valid", value.Int{Value: 42, Valid: true}, 42.0},
-		{"value.Long invalid", value.Long{Value: 42, Valid: false}, 0.0},   // Should fail validation
-		{"value.Real invalid", value.Real{Value: 42.5, Valid: false}, 0.0}, // Should fail validation
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			results := []map[string]any{
-				{"value": tc.value},
-			}
-
-			// Test validation first
-			err := transformer.Validate(results)
-			if tc.name == "value.Long invalid" || tc.name == "value.Real invalid" {
-				// These should fail validation due to Valid=false
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "null value")
-				return
-			}
-			require.NoError(t, err, "Validation should pass for valid Kusto types")
-
-			// Test transformation
-			metrics, err := transformer.Transform(results)
-			require.NoError(t, err, "Transform should handle Kusto types")
 			require.Len(t, metrics, 1)
 			require.Equal(t, tc.expected, metrics[0].Value)
 		})
@@ -249,6 +228,7 @@ func TestTransformErrors(t *testing.T) {
 		config  TransformConfig
 		results []map[string]any
 		wantErr bool
+		errMsg  string
 	}{
 		{
 			name: "missing value column",
@@ -271,6 +251,7 @@ func TestTransformErrors(t *testing.T) {
 				{"value": nil},
 			},
 			wantErr: true,
+			errMsg:  "value column 'value' contains null value",
 		},
 		{
 			name: "no metric name config",
@@ -281,6 +262,44 @@ func TestTransformErrors(t *testing.T) {
 				{"value": 42.0},
 			},
 			wantErr: true,
+		},
+		{
+			name: "null metric name",
+			config: TransformConfig{
+				ValueColumns:     []string{"value"},
+				MetricNameColumn: "name",
+			},
+			results: []map[string]any{
+				{"value": 42.0, "name": nil},
+			},
+			wantErr: true,
+			errMsg:  "metric name column 'name' contains null value",
+		},
+		{
+			name: "null timestamp",
+			config: TransformConfig{
+				ValueColumns:      []string{"value"},
+				DefaultMetricName: "test",
+				TimestampColumn:   "timestamp",
+			},
+			results: []map[string]any{
+				{"value": 42.0, "timestamp": nil},
+			},
+			wantErr: true,
+			errMsg:  "timestamp column 'timestamp' contains null value",
+		},
+		{
+			name: "null label",
+			config: TransformConfig{
+				ValueColumns:      []string{"value"},
+				DefaultMetricName: "test",
+				LabelColumns:      []string{"host"},
+			},
+			results: []map[string]any{
+				{"value": 42.0, "host": nil},
+			},
+			wantErr: true,
+			errMsg:  "label column 'host' contains null value",
 		},
 		{
 			name: "missing metric name column",
@@ -323,6 +342,9 @@ func TestTransformErrors(t *testing.T) {
 			_, err := transformer.Transform(tc.results)
 			if tc.wantErr {
 				require.Error(t, err)
+				if tc.errMsg != "" {
+					require.ErrorContains(t, err, tc.errMsg)
+				}
 			} else {
 				require.NoError(t, err)
 			}
@@ -850,85 +872,32 @@ func TestTransformBackwardCompatibility(t *testing.T) {
 	})
 }
 
-func TestValidateKustoValueTypes(t *testing.T) {
+func TestValidateNativeValueTypes(t *testing.T) {
 	meter := noop.NewMeterProvider().Meter("test")
+	transformer := NewKustoToMetricsTransformer(TransformConfig{
+		ValueColumns:      []string{"value"},
+		DefaultMetricName: "test",
+	}, meter)
 
-	testCases := []struct {
+	tests := []struct {
 		name    string
-		config  TransformConfig
-		results []map[string]any
-		wantErr bool
-		errMsg  string
+		value   any
+		wantErr string
 	}{
-		{
-			name: "value.Long valid should pass validation",
-			config: TransformConfig{
-				ValueColumns:      []string{"value"},
-				DefaultMetricName: "test",
-			},
-			results: []map[string]any{
-				{"value": value.Long{Value: 42, Valid: true}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "value.Real valid should pass validation",
-			config: TransformConfig{
-				ValueColumns:      []string{"value"},
-				DefaultMetricName: "test",
-			},
-			results: []map[string]any{
-				{"value": value.Real{Value: 42.5, Valid: true}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "value.Int valid should pass validation",
-			config: TransformConfig{
-				ValueColumns:      []string{"value"},
-				DefaultMetricName: "test",
-			},
-			results: []map[string]any{
-				{"value": value.Int{Value: 42, Valid: true}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "value.Long invalid should fail validation",
-			config: TransformConfig{
-				ValueColumns:      []string{"value"},
-				DefaultMetricName: "test",
-			},
-			results: []map[string]any{
-				{"value": value.Long{Value: 42, Valid: false}},
-			},
-			wantErr: true,
-			errMsg:  "null value",
-		},
-		{
-			name: "value.Real invalid should fail validation",
-			config: TransformConfig{
-				ValueColumns:      []string{"value"},
-				DefaultMetricName: "test",
-			},
-			results: []map[string]any{
-				{"value": value.Real{Value: 42.5, Valid: false}},
-			},
-			wantErr: true,
-			errMsg:  "null value",
-		},
+		{name: "real", value: float64(42.5)},
+		{name: "int", value: int32(42)},
+		{name: "long", value: int64(42)},
+		{name: "null", value: nil, wantErr: "null value"},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			transformer := NewKustoToMetricsTransformer(tc.config, meter)
-			err := transformer.Validate(tc.results)
-			if tc.wantErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.errMsg)
-			} else {
-				require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := transformer.Validate([]map[string]any{{"value": test.value}})
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
 			}
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1609,21 +1578,6 @@ func TestExtractValues(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "extraction with Kusto value types",
-			row: map[string]any{
-				"LongValue": value.Long{Value: 12345, Valid: true},
-				"RealValue": value.Real{Value: 98.76, Valid: true},
-				"IntValue":  value.Int{Value: 999, Valid: true},
-			},
-			valueColumns: []string{"LongValue", "RealValue", "IntValue"},
-			expected: map[string]float64{
-				"LongValue": 12345.0,
-				"RealValue": 98.76,
-				"IntValue":  999.0,
-			},
-			wantErr: false,
-		},
-		{
 			name: "extraction with string numeric values",
 			row: map[string]any{
 				"StringInt":   "42",
@@ -1658,17 +1612,6 @@ func TestExtractValues(t *testing.T) {
 			expected:     nil,
 			wantErr:      true,
 			errMsg:       "value column 'NullColumn' contains null value",
-		},
-		{
-			name: "invalid Kusto value",
-			row: map[string]any{
-				"ValidColumn":  42.0,
-				"InvalidValue": value.Long{Value: 0, Valid: false},
-			},
-			valueColumns: []string{"ValidColumn", "InvalidValue"},
-			expected:     nil,
-			wantErr:      true,
-			errMsg:       "value column 'InvalidValue' contains null value",
 		},
 		{
 			name: "unparseable string value",
@@ -1755,13 +1698,6 @@ func TestExtractValueFromColumn(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:       "extract Kusto Long",
-			row:        map[string]any{"test_col": value.Long{Value: 12345, Valid: true}},
-			columnName: "test_col",
-			expected:   12345.0,
-			wantErr:    false,
-		},
-		{
 			name:       "extract string number",
 			row:        map[string]any{"test_col": "3.14159"},
 			columnName: "test_col",
@@ -1779,14 +1715,6 @@ func TestExtractValueFromColumn(t *testing.T) {
 		{
 			name:       "null value",
 			row:        map[string]any{"test_col": nil},
-			columnName: "test_col",
-			expected:   0,
-			wantErr:    true,
-			errMsg:     "value column 'test_col' contains null value",
-		},
-		{
-			name:       "invalid Kusto Real",
-			row:        map[string]any{"test_col": value.Real{Value: 0, Valid: false}},
 			columnName: "test_col",
 			expected:   0,
 			wantErr:    true,
@@ -1904,7 +1832,7 @@ func BenchmarkExtractValues(b *testing.B) {
 			map[string]any{
 				"col1": 42.0,
 				"col2": int(43),
-				"col3": value.Long{Value: 44, Valid: true},
+				"col3": int64(44),
 				"col4": "45.5",
 				"col5": float32(46.5),
 			},


### PR DESCRIPTION
Removes the transformer’s dependency on legacy wrappers and updates tests to use the native Go values produced by adxexporter.

The transformer intentionally does not accept `azkustodata` wrappers. SDK materialization is owned by adxexporter, keeping the transformer SDK-independent and ensuring wrapper leaks fail fast instead of duplicating conversion and null-handling logic.

Null behavior remains explicit through native nil, and existing support for numeric values, strings, timestamps, and labels is preserved.

**Depends on the ADX exporter migration being merged first.**