### PR TITLE
Add reusable alerter alert primitives

### DIFF
--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -26,10 +26,17 @@ type queryParam struct {
 }
 
 func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*QueryContext, error) {
+	if rule == nil {
+		return nil, fmt.Errorf("rule must not be nil")
+	}
 	return NewQueryContextForWindow(rule, endTime.Add(-rule.Interval), endTime, region)
 }
 
 func NewQueryContextForWindow(rule *rules.Rule, startTime, endTime time.Time, region string) (*QueryContext, error) {
+	if rule == nil {
+		return nil, fmt.Errorf("rule must not be nil")
+	}
+
 	qc := &QueryContext{
 		Rule:      rule,
 		Region:    region,

--- a/alerter/engine/context.go
+++ b/alerter/engine/context.go
@@ -26,10 +26,14 @@ type queryParam struct {
 }
 
 func NewQueryContext(rule *rules.Rule, endTime time.Time, region string) (*QueryContext, error) {
+	return NewQueryContextForWindow(rule, endTime.Add(-rule.Interval), endTime, region)
+}
+
+func NewQueryContextForWindow(rule *rules.Rule, startTime, endTime time.Time, region string) (*QueryContext, error) {
 	qc := &QueryContext{
 		Rule:      rule,
 		Region:    region,
-		StartTime: endTime.Add(-rule.Interval),
+		StartTime: startTime,
 		EndTime:   endTime,
 	}
 	err := qc.wrapStmt()

--- a/alerter/engine/context_test.go
+++ b/alerter/engine/context_test.go
@@ -60,6 +60,16 @@ func TestNewQueryContext_UsesRuleIntervalWindow(t *testing.T) {
 	require.Equal(t, "\nlet _startTime = datetime(2023-04-10T02:35:06Z);\nlet _endTime = datetime(2023-04-10T04:05:06Z);\nlet _region = \"region\";\nFoo | limit 1\n", qc.Query)
 }
 
+func TestNewQueryContext_NilRule(t *testing.T) {
+	_, err := NewQueryContext(nil, time.Now(), "region")
+	require.EqualError(t, err, "rule must not be nil")
+}
+
+func TestNewQueryContextForWindow_NilRule(t *testing.T) {
+	_, err := NewQueryContextForWindow(nil, time.Now(), time.Now(), "region")
+	require.EqualError(t, err, "rule must not be nil")
+}
+
 func TestQueryContext_ConstructsWrappedQuery(t *testing.T) {
 	r := &rules.Rule{Query: "Foo | where Timestamp between (_startTime .. _endTime)", Interval: time.Hour}
 	qc, err := NewQueryContext(r, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "region")

--- a/alerter/engine/context_test.go
+++ b/alerter/engine/context_test.go
@@ -37,6 +37,29 @@ func TestNewQueryContext_QueryWrapped(t *testing.T) {
 	}
 }
 
+func TestNewQueryContextForWindow_InjectsExactWindow(t *testing.T) {
+	startTime := time.Date(2023, 4, 10, 1, 2, 3, 0, time.UTC)
+	endTime := time.Date(2023, 4, 10, 4, 5, 6, 0, time.UTC)
+	r := &rules.Rule{Query: "Foo | limit 1", Interval: time.Hour}
+
+	qc, err := NewQueryContextForWindow(r, startTime, endTime, "region")
+	require.NoError(t, err)
+	require.Equal(t, startTime, qc.StartTime)
+	require.Equal(t, endTime, qc.EndTime)
+	require.Equal(t, "\nlet _startTime = datetime(2023-04-10T01:02:03Z);\nlet _endTime = datetime(2023-04-10T04:05:06Z);\nlet _region = \"region\";\nFoo | limit 1\n", qc.Query)
+}
+
+func TestNewQueryContext_UsesRuleIntervalWindow(t *testing.T) {
+	endTime := time.Date(2023, 4, 10, 4, 5, 6, 0, time.UTC)
+	r := &rules.Rule{Query: "Foo | limit 1", Interval: 90 * time.Minute}
+
+	qc, err := NewQueryContext(r, endTime, "region")
+	require.NoError(t, err)
+	require.Equal(t, endTime.Add(-r.Interval), qc.StartTime)
+	require.Equal(t, endTime, qc.EndTime)
+	require.Equal(t, "\nlet _startTime = datetime(2023-04-10T02:35:06Z);\nlet _endTime = datetime(2023-04-10T04:05:06Z);\nlet _region = \"region\";\nFoo | limit 1\n", qc.Query)
+}
+
 func TestQueryContext_ConstructsWrappedQuery(t *testing.T) {
 	r := &rules.Rule{Query: "Foo | where Timestamp between (_startTime .. _endTime)", Interval: time.Hour}
 	qc, err := NewQueryContext(r, time.Date(2023, 04, 10, 0, 0, 0, 0, time.UTC), "region")

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -167,6 +167,13 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 
 // ParseAlertResult converts and validates a query row without performing delivery enrichment or I/O.
 func ParseAlertResult(qc *QueryContext, row azquery.Row) (AlertResult, error) {
+	if qc == nil {
+		return AlertResult{}, fmt.Errorf("query context must not be nil")
+	}
+	if qc.Rule == nil {
+		return AlertResult{}, fmt.Errorf("query context rule must not be nil")
+	}
+
 	notification := Notification{
 		Severity:     math.MinInt64,
 		CustomFields: map[string]string{},

--- a/alerter/engine/executor.go
+++ b/alerter/engine/executor.go
@@ -124,44 +124,8 @@ func (e *Executor) Close() error {
 
 // HandlerFn converts rows of a query to Alerts.
 func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error {
-	res := Notification{
-		Severity:     math.MinInt64,
-		CustomFields: map[string]string{},
-	}
-
-	columns := row.Columns()
-	columnNames := make([]string, 0, len(columns))
-	for _, column := range columns {
-		columnNames = append(columnNames, column.Name())
-	}
-	if err := validateNotificationColumns(columnNames); err != nil {
-		return err
-	}
-
-	for i, value := range row.Values() {
-		switch strings.ToLower(columnNames[i]) {
-		case "title":
-			res.Title = value.String()
-		case "description":
-			res.Description = value.String()
-		case "severity":
-			v, err := e.asInt64(value)
-			if err != nil {
-				return &NotificationValidationError{err.Error()}
-			}
-			res.Severity = v
-		case "recipient":
-			res.Recipient = value.String()
-		case "summary":
-			res.Summary = value.String()
-		case "correlationid":
-			res.CorrelationID = value.String()
-		default:
-			res.CustomFields[columnNames[i]] = value.String()
-		}
-	}
-
-	if err := res.Validate(); err != nil {
+	res, err := ParseAlertResult(qc, row)
+	if err != nil {
 		return err
 	}
 
@@ -171,24 +135,13 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 		return fmt.Errorf("failed to create kusto deep link: %w", err)
 	}
 
-	if res.CorrelationID != "" && !strings.HasPrefix(res.CorrelationID, fmt.Sprintf("%s/%s://", qc.Rule.Namespace, qc.Rule.Name)) {
-		res.CorrelationID = fmt.Sprintf("%s/%s://%s", qc.Rule.Namespace, qc.Rule.Name, res.CorrelationID)
-	}
-
-	destination := qc.Rule.Destination
-	// The recipient query results field is deprecated.
-	if destination == "" {
-		logger.Warnf("Recipient query results field is deprecated. Please use the destination field in the rule instead for %s/%s.", qc.Rule.Namespace, qc.Rule.Name)
-		destination = res.Recipient
-	}
-
 	a := alert.Alert{
-		Destination:   destination,
+		Destination:   res.Destination,
 		Title:         res.Title,
 		Summary:       summary,
 		Description:   res.Description,
 		Severity:      clampInt64ToInt(res.Severity),
-		Source:        fmt.Sprintf("%s/%s", qc.Rule.Namespace, qc.Rule.Name),
+		Source:        res.Source,
 		CorrelationID: res.CorrelationID,
 		CustomFields:  res.CustomFields,
 	}
@@ -210,6 +163,83 @@ func (e *Executor) HandlerFn(ctx context.Context, endpoint string, qc *QueryCont
 	metrics.NotificationUnhealthy.WithLabelValues(qc.Rule.Namespace, qc.Rule.Name).Set(0)
 
 	return nil
+}
+
+// ParseAlertResult converts and validates a query row without performing delivery enrichment or I/O.
+func ParseAlertResult(qc *QueryContext, row azquery.Row) (AlertResult, error) {
+	notification := Notification{
+		Severity:     math.MinInt64,
+		CustomFields: map[string]string{},
+	}
+
+	columns := row.Columns()
+	values := row.Values()
+	if len(columns) != len(values) {
+		return AlertResult{}, &NotificationValidationError{fmt.Sprintf("query result row has %d columns and %d values", len(columns), len(values))}
+	}
+
+	columnNames := make([]string, 0, len(columns))
+	for _, column := range columns {
+		columnNames = append(columnNames, column.Name())
+	}
+	if err := validateNotificationColumns(columnNames); err != nil {
+		return AlertResult{}, err
+	}
+
+	for i, value := range values {
+		if value == nil {
+			return AlertResult{}, &NotificationValidationError{fmt.Sprintf("query result column %q has nil value", columnNames[i])}
+		}
+
+		switch strings.ToLower(columnNames[i]) {
+		case "title":
+			notification.Title = value.String()
+		case "description":
+			notification.Description = value.String()
+		case "severity":
+			v, err := asInt64(value)
+			if err != nil {
+				return AlertResult{}, &NotificationValidationError{err.Error()}
+			}
+			notification.Severity = v
+		case "recipient":
+			notification.Recipient = value.String()
+		case "summary":
+			notification.Summary = value.String()
+		case "correlationid":
+			notification.CorrelationID = value.String()
+		default:
+			notification.CustomFields[columnNames[i]] = value.String()
+		}
+	}
+
+	if err := notification.Validate(); err != nil {
+		return AlertResult{}, err
+	}
+
+	source := fmt.Sprintf("%s/%s", qc.Rule.Namespace, qc.Rule.Name)
+	correlationID := notification.CorrelationID
+	if correlationID != "" && !strings.HasPrefix(correlationID, source+"://") {
+		correlationID = fmt.Sprintf("%s://%s", source, correlationID)
+	}
+
+	destination := qc.Rule.Destination
+	if destination == "" {
+		// The recipient query results field is deprecated.
+		logger.Warnf("Recipient query results field is deprecated. Please use the destination field in the rule instead for %s/%s.", qc.Rule.Namespace, qc.Rule.Name)
+		destination = notification.Recipient
+	}
+
+	return AlertResult{
+		Destination:   destination,
+		Title:         notification.Title,
+		Summary:       notification.Summary,
+		Description:   notification.Description,
+		Severity:      notification.Severity,
+		Source:        source,
+		CorrelationID: correlationID,
+		CustomFields:  notification.CustomFields,
+	}, nil
 }
 
 func clampInt64ToInt(v int64) int {
@@ -240,7 +270,7 @@ func validateNotificationColumns(columns []string) error {
 	return nil
 }
 
-func (e *Executor) asInt64(value azvalue.Kusto) (int64, error) {
+func asInt64(value azvalue.Kusto) (int64, error) {
 	if value == nil {
 		return 0, fmt.Errorf("failed to convert severity to int: <nil>")
 	}

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -158,8 +159,6 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 }
 
 func TestExecutor_asInt64_Errors(t *testing.T) {
-	e := &Executor{}
-
 	for _, tt := range []struct {
 		desc  string
 		value azvalue.Kusto
@@ -202,10 +201,212 @@ func TestExecutor_asInt64_Errors(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, err := e.asInt64(tt.value)
+			_, err := asInt64(tt.value)
 			require.ErrorContains(t, err, tt.err)
 		})
 	}
+}
+
+func TestParseAlertResult(t *testing.T) {
+	qc := &QueryContext{
+		Rule: &rules.Rule{
+			Namespace: "rulesns",
+			Name:      "rulename",
+			Database:  "database",
+			Query:     "source | where Secret == true",
+		},
+		Query: "rendered query that must remain delivery-only",
+	}
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "TITLE", aztypes.String),
+			testColumn(1, "description", aztypes.String),
+			testColumn(2, "SeVeRiTy", aztypes.String),
+			testColumn(3, "RECIPIENT", aztypes.String),
+			testColumn(4, "Summary", aztypes.String),
+			testColumn(5, "correlationID", aztypes.String),
+			testColumn(6, "CustomField", aztypes.String),
+		},
+		azvalue.Values{
+			azvalue.NewString("Alert title"),
+			azvalue.NewString("Alert description"),
+			azvalue.NewString("3"),
+			azvalue.NewString("fallback destination"),
+			azvalue.NewString("Original summary"),
+			azvalue.NewString("entity"),
+			azvalue.NewString("custom value"),
+		},
+	)
+
+	got, err := ParseAlertResult(qc, row)
+	require.NoError(t, err)
+	require.Equal(t, AlertResult{
+		Destination:   "fallback destination",
+		Title:         "Alert title",
+		Summary:       "Original summary",
+		Description:   "Alert description",
+		Severity:      3,
+		Source:        "rulesns/rulename",
+		CorrelationID: "rulesns/rulename://entity",
+		CustomFields:  map[string]string{"CustomField": "custom value"},
+	}, got)
+
+	encoded, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), qc.Query)
+	require.NotContains(t, string(encoded), "query=")
+}
+
+func TestParseAlertResult_RuleDestinationTakesPrecedence(t *testing.T) {
+	qc := &QueryContext{Rule: &rules.Rule{Destination: "rule destination"}}
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "Title", aztypes.String),
+			testColumn(1, "Severity", aztypes.Long),
+			testColumn(2, "Recipient", aztypes.String),
+		},
+		azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("recipient")},
+	)
+
+	got, err := ParseAlertResult(qc, row)
+	require.NoError(t, err)
+	require.Equal(t, "rule destination", got.Destination)
+}
+
+func TestParseAlertResult_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		columns azquery.Columns
+		values  azvalue.Values
+		wantErr string
+	}{
+		{
+			name:    "missing title",
+			columns: azquery.Columns{testColumn(0, "Severity", aztypes.Long)},
+			values:  azvalue.Values{azvalue.NewLong(1)},
+			wantErr: "title must be between 1 and 512 chars",
+		},
+		{
+			name:    "missing severity",
+			columns: azquery.Columns{testColumn(0, "Title", aztypes.String)},
+			values:  azvalue.Values{azvalue.NewString("Title")},
+			wantErr: "severity must be specified",
+		},
+		{
+			name: "duplicate reserved field",
+			columns: azquery.Columns{
+				testColumn(0, "Title", aztypes.String),
+				testColumn(1, "Severity", aztypes.Long),
+				testColumn(2, "severity", aztypes.Long),
+			},
+			values:  azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewLong(2)},
+			wantErr: `query results include multiple columns for reserved alert field "Severity": Severity, severity`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseAlertResult(&QueryContext{Rule: &rules.Rule{}}, testRow(tt.columns, tt.values))
+			require.ErrorContains(t, err, tt.wantErr)
+			require.True(t, isUserError(err))
+		})
+	}
+}
+
+func TestParseAlertResult_MalformedRow(t *testing.T) {
+	tests := []struct {
+		name    string
+		columns azquery.Columns
+		values  azvalue.Values
+		wantErr string
+	}{
+		{
+			name: "extra value",
+			columns: azquery.Columns{
+				testColumn(0, "Title", aztypes.String),
+				testColumn(1, "Severity", aztypes.Long),
+			},
+			values:  azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), azvalue.NewString("extra")},
+			wantErr: "query result row has 2 columns and 3 values",
+		},
+		{
+			name: "missing value",
+			columns: azquery.Columns{
+				testColumn(0, "Title", aztypes.String),
+				testColumn(1, "Severity", aztypes.Long),
+			},
+			values:  azvalue.Values{azvalue.NewString("Title")},
+			wantErr: "query result row has 2 columns and 1 values",
+		},
+		{
+			name: "nil non-severity value",
+			columns: azquery.Columns{
+				testColumn(0, "Title", aztypes.String),
+				testColumn(1, "Severity", aztypes.Long),
+				testColumn(2, "Summary", aztypes.String),
+			},
+			values:  azvalue.Values{azvalue.NewString("Title"), azvalue.NewLong(1), nil},
+			wantErr: `query result column "Summary" has nil value`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseAlertResult(&QueryContext{Rule: &rules.Rule{}}, testRow(tt.columns, tt.values))
+			require.ErrorContains(t, err, tt.wantErr)
+			require.True(t, isUserError(err))
+		})
+	}
+}
+
+func TestExecutor_Handler_DeliversEnrichedAlert(t *testing.T) {
+	client := &fakeAlertClient{}
+	executor := &Executor{alertCli: client, alertAddr: "http://alert-service"}
+	qc := &QueryContext{
+		Rule: &rules.Rule{
+			Namespace:   "rulesns",
+			Name:        "rulename",
+			Database:    "database",
+			Destination: "rule destination",
+		},
+		Query: "Table | take 1",
+	}
+	row := testRow(
+		azquery.Columns{
+			testColumn(0, "Title", aztypes.String),
+			testColumn(1, "Summary", aztypes.String),
+			testColumn(2, "Description", aztypes.String),
+			testColumn(3, "Severity", aztypes.Long),
+			testColumn(4, "CorrelationId", aztypes.String),
+			testColumn(5, "Custom", aztypes.String),
+		},
+		azvalue.Values{
+			azvalue.NewString("Title"),
+			azvalue.NewString("Original summary"),
+			azvalue.NewString("Description"),
+			azvalue.NewLong(2),
+			azvalue.NewString("entity"),
+			azvalue.NewString("value"),
+		},
+	)
+
+	err := executor.HandlerFn(context.Background(), "https://cluster.kusto.windows.net", qc, row)
+	require.NoError(t, err)
+	wantSummary, err := KustoQueryLinks("Original summary", qc.Query, "https://cluster.kusto.windows.net", "database")
+	require.NoError(t, err)
+	require.Equal(t, "http://alert-service/alerts", client.endpoint)
+	require.Equal(t, alert.Alert{
+		Destination:   "rule destination",
+		Title:         "Title",
+		Summary:       wantSummary,
+		Description:   "Description",
+		Severity:      2,
+		Source:        "rulesns/rulename",
+		CorrelationID: "rulesns/rulename://entity",
+		CustomFields:  map[string]string{"Custom": "value"},
+	}, client.alert)
+	require.Contains(t, client.alert.Summary, qc.Query)
+	require.Contains(t, client.alert.Summary, "https://cluster.kusto.windows.net/database?query=")
 }
 
 func TestClampInt64ToInt(t *testing.T) {
@@ -475,10 +676,12 @@ func TestExecutor_syncWorkers_Changed(t *testing.T) {
 }
 
 type fakeAlertClient struct {
-	alert alert.Alert
+	endpoint string
+	alert    alert.Alert
 }
 
 func (f *fakeAlertClient) Create(ctx context.Context, endpoint string, alert alert.Alert) error {
+	f.endpoint = endpoint
 	f.alert = alert
 	return nil
 }

--- a/alerter/engine/executor_test.go
+++ b/alerter/engine/executor_test.go
@@ -158,7 +158,7 @@ func TestExecutor_Handler_Severity(t *testing.T) {
 	}
 }
 
-func TestExecutor_asInt64_Errors(t *testing.T) {
+func TestAsInt64_Errors(t *testing.T) {
 	for _, tt := range []struct {
 		desc  string
 		value azvalue.Kusto
@@ -271,6 +271,24 @@ func TestParseAlertResult_RuleDestinationTakesPrecedence(t *testing.T) {
 	got, err := ParseAlertResult(qc, row)
 	require.NoError(t, err)
 	require.Equal(t, "rule destination", got.Destination)
+}
+
+func TestParseAlertResult_InvalidQueryContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		qc      *QueryContext
+		wantErr string
+	}{
+		{name: "nil context", wantErr: "query context must not be nil"},
+		{name: "nil rule", qc: &QueryContext{}, wantErr: "query context rule must not be nil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseAlertResult(tt.qc, testRow(nil, nil))
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestParseAlertResult_Validation(t *testing.T) {

--- a/alerter/engine/types.go
+++ b/alerter/engine/types.go
@@ -4,6 +4,18 @@ import (
 	"math"
 )
 
+// AlertResult is the delivery-neutral result of converting an alert query row.
+type AlertResult struct {
+	Destination   string
+	Title         string
+	Summary       string
+	Description   string
+	Severity      int64
+	Source        string
+	CorrelationID string
+	CustomFields  map[string]string
+}
+
 type Notification struct {
 	// Title maps to the Title Notification field.
 	Title string `kusto:"Title"`


### PR DESCRIPTION
## Summary
- allow query contexts to use explicit start and end times
- extract alert query-row parsing into a reusable, delivery-neutral helper
- validate malformed rows and preserve existing alert delivery behavior

## Testing
- `go test ./alerter/engine`