### PR TITLE
refactor(testutils): migrate Kusto helpers to azkustodata

### DIFF
--- a/pkg/testutils/integration_test.go
+++ b/pkg/testutils/integration_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/Azure/adx-mon/pkg/testutils/collector"
 	"github.com/Azure/adx-mon/pkg/testutils/ingestor"
 	"github.com/Azure/adx-mon/pkg/testutils/kustainer"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/kql"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
@@ -172,42 +172,46 @@ func VerifyAlerts(ctx context.Context, t *testing.T, kustainerUrl string, k3sCon
 	})
 
 	t.Run("Verify alert rule triggers", func(t *testing.T) {
-		cb := kusto.NewConnectionStringBuilder(kustainerUrl)
-		client, err := kusto.New(cb)
+		client, err := azkustodata.New(azkustodata.NewConnectionStringBuilder(kustainerUrl))
 		require.NoError(t, err)
 		defer client.Close()
 
 		stmt := kql.New("AdxmonAlerterQueryHealth | where Labels['name'] == 'testalert' | where Value == 1 | count")
 		require.Eventually(t, func() bool {
-			rows, err := client.Query(ctx, "Metrics", stmt)
+			hasRows, err := queryHasRows(ctx, client, "Metrics", stmt)
 			if err != nil {
+				t.Logf("Failed to retrieve alert health: %v", err)
 				return false
 			}
-
-			for {
-				row, errInline, errFinal := rows.NextRowOrError()
-				if errFinal == io.EOF {
-					break
-				}
-				if errInline != nil {
-					t.Logf("Partial failure to retrieve tables: %v", errInline)
-					continue
-				}
-				if errFinal != nil {
-					t.Logf("Failed to retrieve tables: %v", errFinal)
-				}
-
-				var res KustoCountResult
-				if err := row.ToStruct(&res); err != nil {
-					t.Logf("Failed to convert row to struct: %v", err)
-					continue
-				}
-				return res.Count > 0
-			}
-
-			return false
+			return hasRows
 		}, 10*time.Minute, time.Second)
 	})
+}
+
+func queryHasRows(ctx context.Context, client *azkustodata.Client, database string, stmt azkustodata.Statement) (bool, error) {
+	dataset, err := client.Query(ctx, database, stmt)
+	if err != nil {
+		return false, err
+	}
+
+	for _, table := range dataset.Tables() {
+		if !table.IsPrimaryResult() {
+			continue
+		}
+
+		rows := table.Rows()
+		if len(rows) != 1 {
+			return false, fmt.Errorf("expected one count result row, got %d", len(rows))
+		}
+
+		var result KustoCountResult
+		if err := rows[0].ToStruct(&result); err != nil {
+			return false, fmt.Errorf("convert row count to struct: %w", err)
+		}
+		return result.Count > 0, nil
+	}
+
+	return false, fmt.Errorf("count result not found")
 }
 
 func TestDiskFull(t *testing.T) {

--- a/pkg/testutils/kql_verify.go
+++ b/pkg/testutils/kql_verify.go
@@ -3,11 +3,11 @@ package testutils
 import (
 	"context"
 	"fmt"
-	"io"
 	"testing"
 
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/kql"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	"github.com/Azure/azure-kusto-go/azkustodata/query"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,32 +16,67 @@ type TableSchema interface {
 	CslColumns() []string
 }
 
+func newKustoClient(t *testing.T, uri string) *azkustodata.Client {
+	t.Helper()
+
+	client, err := azkustodata.New(azkustodata.NewConnectionStringBuilder(uri))
+	require.NoError(t, err)
+	return client
+}
+
+func primaryResultRows(t *testing.T, dataset query.Dataset) []query.Row {
+	t.Helper()
+
+	for _, table := range dataset.Tables() {
+		if table.IsPrimaryResult() {
+			return table.Rows()
+		}
+	}
+
+	require.FailNow(t, "Kusto response did not contain a primary result table")
+	return nil
+}
+
+func forEachPrimaryResultRow(dataset query.IterativeDataset, visit func(query.Row) error) error {
+	foundPrimary := false
+	for tableResult := range dataset.Tables() {
+		if err := tableResult.Err(); err != nil {
+			return err
+		}
+
+		table := tableResult.Table()
+		if !table.IsPrimaryResult() {
+			continue
+		}
+		foundPrimary = true
+
+		for rowResult := range table.Rows() {
+			if err := rowResult.Err(); err != nil {
+				return err
+			}
+			if err := visit(rowResult.Row()); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !foundPrimary {
+		return fmt.Errorf("Kusto response did not contain a primary result table")
+	}
+	return nil
+}
+
 func TableExists(ctx context.Context, t *testing.T, database, table, uri string) bool {
 	t.Helper()
 
-	cb := kusto.NewConnectionStringBuilder(uri)
-	client, err := kusto.New(cb)
-	require.NoError(t, err)
+	client := newKustoClient(t, uri)
 	defer client.Close()
 
 	stmt := kql.New(".show tables")
-	rows, err := client.Mgmt(ctx, database, stmt)
+	dataset, err := client.Mgmt(ctx, database, stmt)
 	require.NoError(t, err)
-	defer rows.Stop()
 
-	for {
-		row, errInline, errFinal := rows.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
-			t.Logf("Partial failure to retrieve tables: %v", errInline)
-			continue
-		}
-		if errFinal != nil {
-			t.Errorf("Failed to retrieve tables: %v", errFinal)
-		}
-
+	for _, row := range primaryResultRows(t, dataset) {
 		var tbl Table
 		if err := row.ToStruct(&tbl); err != nil {
 			t.Errorf("Failed to convert row to struct: %v", err)
@@ -72,29 +107,14 @@ func FunctionExists(ctx context.Context, t *testing.T, database, function, uri s
 func GetFunction(ctx context.Context, t *testing.T, database, function, uri string) Function {
 	t.Helper()
 
-	cb := kusto.NewConnectionStringBuilder(uri)
-	client, err := kusto.New(cb)
-	require.NoError(t, err)
+	client := newKustoClient(t, uri)
 	defer client.Close()
 
 	stmt := kql.New(".show functions")
-	rows, err := client.Mgmt(ctx, database, stmt)
+	dataset, err := client.Mgmt(ctx, database, stmt)
 	require.NoError(t, err)
-	defer rows.Stop()
 
-	for {
-		row, errInline, errFinal := rows.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
-			t.Logf("Partial failure to retrieve functions: %v", errInline)
-			continue
-		}
-		if errFinal != nil {
-			t.Errorf("Failed to retrieve functions: %v", errFinal)
-		}
-
+	for _, row := range primaryResultRows(t, dataset) {
 		var fn Function
 		if err := row.ToStruct(&fn); err != nil {
 			t.Errorf("Failed to convert row to struct: %v", err)
@@ -119,38 +139,20 @@ type Function struct {
 func TableHasRows(ctx context.Context, t *testing.T, database, table, uri string) bool {
 	t.Helper()
 
-	cb := kusto.NewConnectionStringBuilder(uri)
-	client, err := kusto.New(cb)
-	require.NoError(t, err)
+	client := newKustoClient(t, uri)
 	defer client.Close()
 
-	query := kql.New("").AddUnsafe(table).AddLiteral(" | count")
-	rows, err := client.Query(ctx, database, query)
+	stmt := kql.New("").AddUnsafe(table).AddLiteral(" | count")
+	dataset, err := client.Query(ctx, database, stmt)
 	require.NoError(t, err)
-	defer rows.Stop()
 
-	for {
-		row, errInline, errFinal := rows.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
-			t.Logf("Partial failure to retrieve row count: %v", errInline)
-			continue
-		}
-		if errFinal != nil {
-			t.Errorf("Failed to retrieve row count: %v", errFinal)
-		}
+	rows := primaryResultRows(t, dataset)
+	require.Len(t, rows, 1, "Expected one row count result")
 
-		var count RowCount
-		if err := row.ToStruct(&count); err != nil {
-			t.Errorf("Failed to convert row to struct: %v", err)
-			continue
-		}
-		return count.Count > 0
-	}
+	var count RowCount
+	require.NoError(t, rows[0].ToStruct(&count), "Failed to convert row count to struct")
 
-	return false
+	return count.Count > 0
 }
 
 type RowCount struct {
@@ -160,37 +162,24 @@ type RowCount struct {
 func VerifyTableSchema(ctx context.Context, t *testing.T, database, table, uri string, expect TableSchema) {
 	t.Helper()
 
-	cb := kusto.NewConnectionStringBuilder(uri)
-	client, err := kusto.New(cb)
-	require.NoError(t, err)
+	client := newKustoClient(t, uri)
 	defer client.Close()
 
-	query := kql.New("").AddUnsafe(table).AddLiteral(" | getschema")
-	rows, err := client.Query(ctx, database, query)
+	stmt := kql.New("").AddUnsafe(table).AddLiteral(" | getschema")
+	dataset, err := client.IterativeQuery(ctx, database, stmt)
 	require.NoError(t, err)
-	defer rows.Stop()
+	defer dataset.Close()
 
 	var schema []*KqlSchema
-	for {
-		row, errInline, errFinal := rows.NextRowOrError()
-		if errFinal == io.EOF {
-			break
-		}
-		if errInline != nil {
-			t.Logf("Partial failure to retrieve schema: %v", errInline)
-			continue
-		}
-		if errFinal != nil {
-			t.Errorf("Failed to retrieve schema: %v", errFinal)
-		}
-
+	err = forEachPrimaryResultRow(dataset, func(row query.Row) error {
 		var s KqlSchema
 		if err := row.ToStruct(&s); err != nil {
-			t.Errorf("Failed to convert row to struct: %v", err)
-			continue
+			return fmt.Errorf("convert schema row to struct: %w", err)
 		}
 		schema = append(schema, &s)
-	}
+		return nil
+	})
+	require.NoError(t, err, "Failed to retrieve schema")
 
 	require.Equal(t, expect.TableName(), table)
 	require.Equal(t, cslSchemaFromKqlSchema(schema), expect.CslColumns())

--- a/pkg/testutils/kql_verify_internal_test.go
+++ b/pkg/testutils/kql_verify_internal_test.go
@@ -1,0 +1,147 @@
+package testutils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	azerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
+	"github.com/Azure/azure-kusto-go/azkustodata/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForEachPrimaryResultRow(t *testing.T) {
+	testErr := errors.New("test error")
+
+	tests := []struct {
+		name         string
+		dataset      query.IterativeDataset
+		visit        func(query.Row) error
+		expectedRows int
+		expectedErr  error
+		expectedText string
+	}{
+		{
+			name:         "visits rows",
+			dataset:      newTestIterativeDataset(primaryTestTable(query.RowResultSuccess(nil), query.RowResultSuccess(nil))),
+			visit:        func(query.Row) error { return nil },
+			expectedRows: 2,
+		},
+		{
+			name:         "skips non-primary tables",
+			dataset:      newTestIterativeDataset(nonPrimaryTestTable(query.RowResultSuccess(nil)), primaryTestTable(query.RowResultSuccess(nil))),
+			visit:        func(query.Row) error { return nil },
+			expectedRows: 1,
+		},
+		{
+			name:         "missing primary result table",
+			dataset:      newTestIterativeDataset(nonPrimaryTestTable(query.RowResultSuccess(nil))),
+			visit:        func(query.Row) error { return nil },
+			expectedText: "Kusto response did not contain a primary result table",
+		},
+		{
+			name:        "table error",
+			dataset:     newTestIterativeDataset(query.TableResultError(testErr)),
+			visit:       func(query.Row) error { return nil },
+			expectedErr: testErr,
+		},
+		{
+			name:        "row error",
+			dataset:     newTestIterativeDataset(primaryTestTable(query.RowResultError(testErr))),
+			visit:       func(query.Row) error { return nil },
+			expectedErr: testErr,
+		},
+		{
+			name:         "visitor error",
+			dataset:      newTestIterativeDataset(primaryTestTable(query.RowResultSuccess(nil))),
+			visit:        func(query.Row) error { return testErr },
+			expectedRows: 1,
+			expectedErr:  testErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			visited := 0
+			err := forEachPrimaryResultRow(test.dataset, func(row query.Row) error {
+				visited++
+				return test.visit(row)
+			})
+
+			require.Equal(t, test.expectedRows, visited)
+			if test.expectedText != "" {
+				require.EqualError(t, err, test.expectedText)
+				return
+			}
+			if test.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, test.expectedErr)
+		})
+	}
+}
+
+type testIterativeDataset struct {
+	query.BaseDataset
+	tableResults []query.TableResult
+}
+
+func newTestIterativeDataset(results ...query.TableResult) *testIterativeDataset {
+	return &testIterativeDataset{
+		BaseDataset:  query.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult"),
+		tableResults: results,
+	}
+}
+
+func primaryTestTable(rows ...query.RowResult) query.TableResult {
+	return newTestTableResult("QueryResult", rows)
+}
+
+func nonPrimaryTestTable(rows ...query.RowResult) query.TableResult {
+	return newTestTableResult("QueryProperties", rows)
+}
+
+func newTestTableResult(kind string, rows []query.RowResult) query.TableResult {
+	dataset := query.NewBaseDataset(context.Background(), azerrors.OpQuery, "QueryResult")
+	table := &testIterativeTable{
+		BaseTable: query.NewBaseTable(dataset, 0, "", kind, kind, nil),
+		rows:      rows,
+	}
+	return query.TableResultSuccess(table)
+}
+
+func (d *testIterativeDataset) Tables() <-chan query.TableResult {
+	results := make(chan query.TableResult, len(d.tableResults))
+	for _, result := range d.tableResults {
+		results <- result
+	}
+	close(results)
+	return results
+}
+
+func (d *testIterativeDataset) ToDataset() (query.Dataset, error) {
+	return nil, nil
+}
+
+func (d *testIterativeDataset) Close() error {
+	return nil
+}
+
+type testIterativeTable struct {
+	query.BaseTable
+	rows []query.RowResult
+}
+
+func (t *testIterativeTable) Rows() <-chan query.RowResult {
+	rows := make(chan query.RowResult, len(t.rows))
+	for _, row := range t.rows {
+		rows <- row
+	}
+	close(rows)
+	return rows
+}
+
+func (t *testIterativeTable) ToTable() (query.Table, error) {
+	return nil, nil
+}

--- a/pkg/testutils/kustainer/kustainer.go
+++ b/pkg/testutils/kustainer/kustainer.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/Azure/adx-mon/pkg/testutils"
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/kql"
+	azkustodata "github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	"github.com/moby/moby/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
@@ -347,8 +347,7 @@ func (c *KustainerContainer) ConnectionUrl() string {
 }
 
 func (c *KustainerContainer) CreateDatabase(ctx context.Context, dbName string) error {
-	cb := kusto.NewConnectionStringBuilder(c.endpoint)
-	client, err := kusto.New(cb)
+	client, err := azkustodata.New(azkustodata.NewConnectionStringBuilder(c.endpoint))
 	if err != nil {
 		return fmt.Errorf("new kusto client: %w", err)
 	}
@@ -406,8 +405,7 @@ func (p IngestionBatchingPolicy) String() string {
 }
 
 func (c *KustainerContainer) SetIngestionBatchingPolicy(ctx context.Context, dbName string, p IngestionBatchingPolicy) error {
-	cb := kusto.NewConnectionStringBuilder(c.endpoint)
-	client, err := kusto.New(cb)
+	client, err := azkustodata.New(azkustodata.NewConnectionStringBuilder(c.endpoint))
 	if err != nil {
 		return fmt.Errorf("new kusto client: %w", err)
 	}


### PR DESCRIPTION
Replace legacy Kusto clients in test and integration helpers with azkustodata