### PR TITLE
Retry Function reconciliation for missing dependencies

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -228,7 +228,7 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 			_, err := t.kustoCli.Mgmt(ctx, stmt)
 			if err != nil {
 				parsed := kustoutil.ParseError(err)
-				if !errors.Retry(err) {
+				if !errors.Retry(err) && !kustoutil.IsMissingEntityError(err) {
 					logger.Errorf("Permanent failure to create function %s.%s: %v", function.Spec.Database, function.Name, err)
 					function.SetReconcileCondition(metav1.ConditionFalse, "KustoExecutionFailed", parsed)
 					if err = t.updateKQLFunctionStatus(ctx, function, v1.PermanentFailure, err); err != nil {

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -678,6 +678,25 @@ func TestSyncFunctionsTaskKustoExecution(t *testing.T) {
 		require.Equal(t, v1.Failed, fn.Status.Status)
 		require.Contains(t, fn.Status.Error, "temporary failure")
 	})
+
+	t.Run("missing referenced table retries later", func(t *testing.T) {
+		store := &TestFunctionStore{funcs: []*v1.Function{newFunction()}}
+		exec := &TestStatementExecutor{database: "db"}
+		body := `{"error":{"code":"General_BadRequest","@permanent":true,"innererror":{"code":"SEM0100","@type":"Kusto.Data.Exceptions.SemanticException","@errorCode":"SEM0100","@errorMessage":"Failed to resolve table or column expression named 'MissingTable'"}}}`
+		exec.nextMgmtErr = kustoerrors.HTTP(kustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		task := NewSyncFunctionsTask(store, exec, nil)
+
+		require.NoError(t, task.Run(ctx))
+		require.Len(t, exec.stmts, 1)
+		fn := store.funcs[0]
+		require.Equal(t, v1.Failed, fn.Status.Status)
+		require.Zero(t, fn.Status.ObservedGeneration)
+		require.Equal(t, "KustoExecutionRetrying", apimeta.FindStatusCondition(fn.Status.Conditions, v1.FunctionReconciled).Reason)
+
+		require.NoError(t, task.Run(ctx))
+		require.Len(t, exec.stmts, 2)
+		require.Equal(t, v1.Success, store.funcs[0].Status.Status)
+	})
 }
 
 func TestSyncFunctionsTaskDeletionConditions(t *testing.T) {

--- a/pkg/kustoutil/errors.go
+++ b/pkg/kustoutil/errors.go
@@ -10,7 +10,8 @@ import (
 const (
 	// MaxErrorMessageLength defines the maximum length for error messages
 	// to prevent excessively long messages in status conditions
-	MaxErrorMessageLength = 256
+	MaxErrorMessageLength  = 256
+	missingEntityErrorCode = "SEM0100"
 )
 
 // ParseError extracts a clean error message from Kusto HttpError objects
@@ -23,18 +24,8 @@ func ParseError(err error) string {
 
 	errMsg := err.Error()
 
-	var azkustoErr *azkustoerrors.HttpError
-	if errors.As(err, &azkustoErr) {
-		if parsed, ok := extractRESTMessage(azkustoErr.UnmarshalREST()); ok {
-			errMsg = parsed
-		}
-	}
-
-	var legacyKustoErr *legacykustoerrors.HttpError
-	if errors.As(err, &legacyKustoErr) {
-		if parsed, ok := extractRESTMessage(legacyKustoErr.UnmarshalREST()); ok {
-			errMsg = parsed
-		}
+	if parsed, ok := extractRESTMessage(decodeRESTError(err)); ok {
+		errMsg = parsed
 	}
 
 	// Truncate if necessary
@@ -43,6 +34,48 @@ func ParseError(err error) string {
 	}
 
 	return errMsg
+}
+
+// IsMissingEntityError reports whether Kusto rejected a query because a referenced
+// table or column could not be resolved. These dependencies may be created later.
+func IsMissingEntityError(err error) bool {
+	return hasErrorCode(decodeRESTError(err), missingEntityErrorCode)
+}
+
+func decodeRESTError(err error) map[string]interface{} {
+	var azkustoErr *azkustoerrors.HttpError
+	if errors.As(err, &azkustoErr) {
+		return azkustoErr.UnmarshalREST()
+	}
+
+	var legacyKustoErr *legacykustoerrors.HttpError
+	if errors.As(err, &legacyKustoErr) {
+		return legacyKustoErr.UnmarshalREST()
+	}
+
+	return nil
+}
+
+func hasErrorCode(decoded map[string]interface{}, code string) bool {
+	current, ok := decoded["error"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	for {
+		if stringValueEquals(current, "code", code) || stringValueEquals(current, "@errorCode", code) {
+			return true
+		}
+		current, ok = current["innererror"].(map[string]interface{})
+		if !ok {
+			return false
+		}
+	}
+}
+
+func stringValueEquals(values map[string]interface{}, key, expected string) bool {
+	value, ok := values[key].(string)
+	return ok && value == expected
 }
 
 func extractRESTMessage(decoded map[string]interface{}) (string, bool) {

--- a/pkg/kustoutil/errors_test.go
+++ b/pkg/kustoutil/errors_test.go
@@ -167,6 +167,50 @@ func TestParseError(t *testing.T) {
 	})
 }
 
+func TestIsMissingEntityError(t *testing.T) {
+	missingEntityBody := `{
+		"error": {
+			"code": "General_BadRequest",
+			"@type": "Kusto.Data.Exceptions.KustoBadRequestException",
+			"@permanent": true,
+			"innererror": {
+				"code": "SEM0100",
+				"@type": "Kusto.Data.Exceptions.SemanticException",
+				"@errorCode": "SEM0100",
+				"@errorMessage": "'where' operator: Failed to resolve table or column expression named 'MissingTable'"
+			}
+		}
+	}`
+
+	t.Run("azkusto structured missing entity error", func(t *testing.T) {
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(missingEntityBody)), "")
+		require.True(t, IsMissingEntityError(fmt.Errorf("create function: %w", err)))
+	})
+
+	t.Run("legacy structured missing entity error", func(t *testing.T) {
+		err := kustoerrors.HTTP(kustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(missingEntityBody)), "")
+		require.True(t, IsMissingEntityError(err))
+	})
+
+	t.Run("other permanent kusto error", func(t *testing.T) {
+		body := `{"error":{"code":"General_BadRequest","@permanent":true,"innererror":{"code":"SYN0002","@errorCode":"SYN0002"}}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingEntityError(err))
+	})
+
+	t.Run("message without structured code", func(t *testing.T) {
+		body := `{"error":{"@message":"Semantic error SEM0100: Failed to resolve table MissingTable"}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingEntityError(err))
+	})
+
+	t.Run("non-string error codes", func(t *testing.T) {
+		body := `{"error":{"code":{"unexpected":"SEM0100"},"@errorCode":["SEM0100"],"innererror":{"code":100,"@errorCode":true}}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingEntityError(err))
+	})
+}
+
 // stringError is a simple error type for testing
 type stringError struct {
 	msg string


### PR DESCRIPTION
## Summary
- Treat structured Kusto `SEM0100` missing-table or missing-column errors as retryable during Function reconciliation.
- Preserve `observedGeneration` until reconciliation succeeds so later cycles can retry after dependencies appear.
- Keep syntax and other permanent Kusto errors classified as permanent.

I think this will help with the nightly e2e test flakiness as well as with issues folks observe with defining functions against tables that get created after bootstrap. This should allow the initial function application to fail, but retry gracefully once the destination table is created.