### PR TITLE
Correctly handle wrapped Kusto missing table errors

### DIFF
--- a/ingestor/adx/tasks.go
+++ b/ingestor/adx/tasks.go
@@ -228,7 +228,7 @@ func (t *SyncFunctionsTask) Run(ctx context.Context) error {
 			_, err := t.kustoCli.Mgmt(ctx, stmt)
 			if err != nil {
 				parsed := kustoutil.ParseError(err)
-				if !errors.Retry(err) && !kustoutil.IsMissingEntityError(err) {
+				if !errors.Retry(err) && !kustoutil.IsMissingTableError(err) {
 					logger.Errorf("Permanent failure to create function %s.%s: %v", function.Spec.Database, function.Name, err)
 					function.SetReconcileCondition(metav1.ConditionFalse, "KustoExecutionFailed", parsed)
 					if err = t.updateKQLFunctionStatus(ctx, function, v1.PermanentFailure, err); err != nil {

--- a/ingestor/adx/tasks_test.go
+++ b/ingestor/adx/tasks_test.go
@@ -682,7 +682,7 @@ func TestSyncFunctionsTaskKustoExecution(t *testing.T) {
 	t.Run("missing referenced table retries later", func(t *testing.T) {
 		store := &TestFunctionStore{funcs: []*v1.Function{newFunction()}}
 		exec := &TestStatementExecutor{database: "db"}
-		body := `{"error":{"code":"General_BadRequest","@permanent":true,"innererror":{"code":"SEM0100","@type":"Kusto.Data.Exceptions.SemanticException","@errorCode":"SEM0100","@errorMessage":"Failed to resolve table or column expression named 'MissingTable'"}}}`
+		body := `{"error":{"code":"General_BadRequest","message":"Request is invalid and cannot be executed.","@type":"Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException","@message":"The command script was aborted due to a failure in command number 1 (1-based). Command: '.create-or-alter function fn() { MissingTable | take 1 }'. Details: 'Request is invalid and cannot be processed: Semantic error: SEM0100: 'take' operator: Failed to resolve table or column expression named 'MissingTable''","@failureCode":400,"@permanent":true}}`
 		exec.nextMgmtErr = kustoerrors.HTTP(kustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
 		task := NewSyncFunctionsTask(store, exec, nil)
 

--- a/pkg/kustoutil/errors.go
+++ b/pkg/kustoutil/errors.go
@@ -2,6 +2,7 @@ package kustoutil
 
 import (
 	"errors"
+	"strings"
 
 	azkustoerrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
 	legacykustoerrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
@@ -12,7 +13,14 @@ const (
 	// to prevent excessively long messages in status conditions
 	MaxErrorMessageLength  = 256
 	missingEntityErrorCode = "SEM0100"
+	scriptAbortedErrorType = "Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException"
+	scriptDetailsSeparator = "'. Details: '"
 )
+
+var missingTableMessageSignatures = [...]string{
+	"Failed to resolve table expression named",
+	"Failed to resolve table or column expression named",
+}
 
 // ParseError extracts a clean error message from Kusto HttpError objects
 // and truncates the message to a maximum length for consistent error handling.
@@ -36,10 +44,10 @@ func ParseError(err error) string {
 	return errMsg
 }
 
-// IsMissingEntityError reports whether Kusto rejected a query because a referenced
-// table or column could not be resolved. These dependencies may be created later.
-func IsMissingEntityError(err error) bool {
-	return hasErrorCode(decodeRESTError(err), missingEntityErrorCode)
+// IsMissingTableError reports whether Kusto rejected a query because a referenced
+// table could not be resolved. The table may be created later.
+func IsMissingTableError(err error) bool {
+	return hasWrappedMissingTableError(decodeRESTError(err))
 }
 
 func decodeRESTError(err error) map[string]interface{} {
@@ -56,26 +64,37 @@ func decodeRESTError(err error) map[string]interface{} {
 	return nil
 }
 
-func hasErrorCode(decoded map[string]interface{}, code string) bool {
-	current, ok := decoded["error"].(map[string]interface{})
+func stringValueEquals(values map[string]interface{}, key, expected string) bool {
+	value, ok := values[key].(string)
+	return ok && value == expected
+}
+
+func hasWrappedMissingTableError(decoded map[string]interface{}) bool {
+	errMap, ok := decoded["error"].(map[string]interface{})
+	if !ok || !stringValueEquals(errMap, "@type", scriptAbortedErrorType) {
+		return false
+	}
+
+	message, ok := errMap["@message"].(string)
 	if !ok {
 		return false
 	}
 
-	for {
-		if stringValueEquals(current, "code", code) || stringValueEquals(current, "@errorCode", code) {
-			return true
-		}
-		current, ok = current["innererror"].(map[string]interface{})
-		if !ok {
-			return false
-		}
+	separator := strings.LastIndex(message, scriptDetailsSeparator)
+	if separator == -1 {
+		return false
 	}
+	details := message[separator+len(scriptDetailsSeparator):]
+	return strings.Contains(details, "Semantic error: "+missingEntityErrorCode+":") && isMissingTableMessage(details)
 }
 
-func stringValueEquals(values map[string]interface{}, key, expected string) bool {
-	value, ok := values[key].(string)
-	return ok && value == expected
+func isMissingTableMessage(message string) bool {
+	for _, signature := range missingTableMessageSignatures {
+		if strings.Contains(message, signature) {
+			return true
+		}
+	}
+	return false
 }
 
 func extractRESTMessage(decoded map[string]interface{}) (string, bool) {

--- a/pkg/kustoutil/errors_test.go
+++ b/pkg/kustoutil/errors_test.go
@@ -167,47 +167,62 @@ func TestParseError(t *testing.T) {
 	})
 }
 
-func TestIsMissingEntityError(t *testing.T) {
-	missingEntityBody := `{
+func TestIsMissingTableError(t *testing.T) {
+	wrappedMissingTableBody := `{
 		"error": {
 			"code": "General_BadRequest",
-			"@type": "Kusto.Data.Exceptions.KustoBadRequestException",
-			"@permanent": true,
-			"innererror": {
-				"code": "SEM0100",
-				"@type": "Kusto.Data.Exceptions.SemanticException",
-				"@errorCode": "SEM0100",
-				"@errorMessage": "'where' operator: Failed to resolve table or column expression named 'MissingTable'"
-			}
+			"message": "Request is invalid and cannot be executed.",
+			"@type": "Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException",
+			"@message": "The command script was aborted due to a failure in command number 1 (1-based). Command: '.create-or-alter function MissingEntityProbe() { MissingTable | take 1 }'. Details: 'Request is invalid and cannot be processed: Semantic error: SEM0100: 'take' operator: Failed to resolve table or column expression named 'MissingTable''",
+			"@failureCode": 400,
+			"@permanent": true
 		}
 	}`
 
-	t.Run("azkusto structured missing entity error", func(t *testing.T) {
-		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(missingEntityBody)), "")
-		require.True(t, IsMissingEntityError(fmt.Errorf("create function: %w", err)))
+	t.Run("azkusto wrapped missing table error", func(t *testing.T) {
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(wrappedMissingTableBody)), "")
+		require.True(t, IsMissingTableError(fmt.Errorf("create function: %w", err)))
 	})
 
-	t.Run("legacy structured missing entity error", func(t *testing.T) {
-		err := kustoerrors.HTTP(kustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(missingEntityBody)), "")
-		require.True(t, IsMissingEntityError(err))
+	t.Run("legacy wrapped missing table error", func(t *testing.T) {
+		err := kustoerrors.HTTP(kustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(wrappedMissingTableBody)), "")
+		require.True(t, IsMissingTableError(err))
 	})
 
 	t.Run("other permanent kusto error", func(t *testing.T) {
 		body := `{"error":{"code":"General_BadRequest","@permanent":true,"innererror":{"code":"SYN0002","@errorCode":"SYN0002"}}}`
 		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
-		require.False(t, IsMissingEntityError(err))
+		require.False(t, IsMissingTableError(err))
 	})
 
 	t.Run("message without structured code", func(t *testing.T) {
 		body := `{"error":{"@message":"Semantic error SEM0100: Failed to resolve table MissingTable"}}`
 		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
-		require.False(t, IsMissingEntityError(err))
+		require.False(t, IsMissingTableError(err))
+	})
+
+	t.Run("wrapped unresolved column", func(t *testing.T) {
+		body := `{"error":{"@type":"Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException","@message":"The command script was aborted due to a failure in command number 1 (1-based). Command: '.create function f() { MissingTable | project MissingColumn }'. Details: 'Request is invalid and cannot be processed: Semantic error: SEM0100: 'project' operator: Failed to resolve scalar expression named 'MissingColumn''"}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingTableError(err))
+	})
+
+	t.Run("wrapped unresolved function", func(t *testing.T) {
+		body := `{"error":{"@type":"Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException","@message":"The command script was aborted due to a failure in command number 1 (1-based). Command: '.create function f() { MissingFunction() }'. Details: 'Request is invalid and cannot be processed: Semantic error: SEM0100: 'take' operator: Failed to resolve tabular function named 'MissingFunction''"}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingTableError(err))
+	})
+
+	t.Run("signature in wrapped command text", func(t *testing.T) {
+		body := `{"error":{"@type":"Kusto.Common.Svc.Exceptions.AdminCommandExecuteScriptAbortedException","@message":"The command script was aborted due to a failure in command number 1 (1-based). Command: '.create function f() { print note=\"Semantic error: SEM0100: Failed to resolve table expression named\" }'. Details: 'Request is invalid due to another permanent error'"}}`
+		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
+		require.False(t, IsMissingTableError(err))
 	})
 
 	t.Run("non-string error codes", func(t *testing.T) {
 		body := `{"error":{"code":{"unexpected":"SEM0100"},"@errorCode":["SEM0100"],"innererror":{"code":100,"@errorCode":true}}}`
 		err := azkustoerrors.HTTP(azkustoerrors.OpMgmt, "BadRequest", 400, io.NopCloser(strings.NewReader(body)), "")
-		require.False(t, IsMissingEntityError(err))
+		require.False(t, IsMissingTableError(err))
 	})
 }
 


### PR DESCRIPTION
We were not correctly unwrapping errors from Kusto to determine if they were missing table errors, which we want to be considered transient.