### PR TITLE
Handle ingestion request timeouts

### DIFF
--- a/cmd/collector/config/config.go
+++ b/cmd/collector/config/config.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Azure/adx-mon/collector/logs/sources/tail/sourceparse"
 	"github.com/Azure/adx-mon/collector/logs/transforms"
@@ -19,6 +20,8 @@ var (
 	homedir         string
 	validColumnName = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 )
+
+const DefaultRequestTimeoutSeconds = 15
 
 func init() {
 	homedir = os.Getenv("HOME")
@@ -225,6 +228,7 @@ func (t *ScrapeTarget) Validate() error {
 type PrometheusRemoteWrite struct {
 	Database                 string `toml:"database" comment:"Database to store metrics in."`
 	Path                     string `toml:"path" comment:"The path to listen on for prometheus remote write requests.  Defaults to /receive."`
+	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for a remote write request. Defaults to 15."`
 	DisableMetricsForwarding *bool  `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
 
 	DefaultDropMetrics        *bool              `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`
@@ -239,6 +243,9 @@ type PrometheusRemoteWrite struct {
 }
 
 func (w *PrometheusRemoteWrite) Validate() error {
+	if _, err := w.RequestTimeout(); err != nil {
+		return err
+	}
 	if w.Path == "" {
 		return errors.New("prometheus-remote-write.path must be set")
 	}
@@ -278,15 +285,23 @@ func (w *PrometheusRemoteWrite) Validate() error {
 	return nil
 }
 
+func (w *PrometheusRemoteWrite) RequestTimeout() (time.Duration, error) {
+	return defaultRequestTimeout(w.RequestTimeoutSeconds, "prometheus-remote-write")
+}
+
 type OtelLog struct {
-	AddAttributes     map[string]string  `toml:"add-attributes" comment:"Key/value pairs of attributes to add to all logs."`
-	AddMetadataLabels *AddMetadataLabels `toml:"add-metadata-labels" comment:"Optional configuration for adding dynamic metadata as labels to logs received on this endpoint."`
-	LiftAttributes    []string           `toml:"lift-attributes" comment:"Attributes lifted from the Body and added to Attributes."`
-	Transforms        []*LogTransform    `toml:"transforms" comment:"Defines a list of transforms to apply to log lines."`
-	Exporters         []string           `toml:"exporters" comment:"List of exporter names to forward logs to."`
+	RequestTimeoutSeconds int                `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15."`
+	AddAttributes         map[string]string  `toml:"add-attributes" comment:"Key/value pairs of attributes to add to all logs."`
+	AddMetadataLabels     *AddMetadataLabels `toml:"add-metadata-labels" comment:"Optional configuration for adding dynamic metadata as labels to logs received on this endpoint."`
+	LiftAttributes        []string           `toml:"lift-attributes" comment:"Attributes lifted from the Body and added to Attributes."`
+	Transforms            []*LogTransform    `toml:"transforms" comment:"Defines a list of transforms to apply to log lines."`
+	Exporters             []string           `toml:"exporters" comment:"List of exporter names to forward logs to."`
 }
 
 func (w *OtelLog) Validate() error {
+	if _, err := w.RequestTimeout(); err != nil {
+		return err
+	}
 	for k, v := range w.AddAttributes {
 		if k == "" {
 			return errors.New("otel-log.add-attributes key must be set")
@@ -308,10 +323,15 @@ func (w *OtelLog) Validate() error {
 	return nil
 }
 
+func (w *OtelLog) RequestTimeout() (time.Duration, error) {
+	return defaultRequestTimeout(w.RequestTimeoutSeconds, "otel-log")
+}
+
 type OtelMetric struct {
 	Database                 string `toml:"database" comment:"Database to store metrics in."`
 	Path                     string `toml:"path" comment:"The path to listen on for OTLP/HTTP requests."`
 	GrpcPort                 int    `toml:"grpc-port" comment:"The port to listen on for OTLP/gRPC requests."`
+	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP metrics request. Defaults to 15."`
 	DisableMetricsForwarding *bool  `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
 
 	DefaultDropMetrics        *bool              `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`
@@ -326,6 +346,9 @@ type OtelMetric struct {
 }
 
 func (w *OtelMetric) Validate() error {
+	if _, err := w.RequestTimeout(); err != nil {
+		return err
+	}
 	if w.Database == "" {
 		return errors.New("otel-metric.database must be set")
 	}
@@ -369,6 +392,20 @@ func (w *OtelMetric) Validate() error {
 	}
 
 	return nil
+}
+
+func (w *OtelMetric) RequestTimeout() (time.Duration, error) {
+	return defaultRequestTimeout(w.RequestTimeoutSeconds, "otel-metric")
+}
+
+func defaultRequestTimeout(timeoutSeconds int, endpoint string) (time.Duration, error) {
+	if timeoutSeconds < 0 {
+		return 0, fmt.Errorf("%s.request-timeout-seconds must be greater than 0", endpoint)
+	}
+	if timeoutSeconds == 0 {
+		timeoutSeconds = DefaultRequestTimeoutSeconds
+	}
+	return time.Duration(timeoutSeconds) * time.Second, nil
 }
 
 type HostLog struct {

--- a/cmd/collector/config/config.go
+++ b/cmd/collector/config/config.go
@@ -21,7 +21,10 @@ var (
 	validColumnName = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 )
 
-const DefaultRequestTimeoutSeconds = 15
+const (
+	DefaultRequestTimeoutSeconds = 15
+	MaxRequestTimeoutSeconds     = 5 * 60
+)
 
 func init() {
 	homedir = os.Getenv("HOME")
@@ -228,7 +231,7 @@ func (t *ScrapeTarget) Validate() error {
 type PrometheusRemoteWrite struct {
 	Database                 string `toml:"database" comment:"Database to store metrics in."`
 	Path                     string `toml:"path" comment:"The path to listen on for prometheus remote write requests.  Defaults to /receive."`
-	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for a remote write request. Defaults to 15."`
+	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for a remote write request. Defaults to 15 and cannot exceed 300."`
 	DisableMetricsForwarding *bool  `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
 
 	DefaultDropMetrics        *bool              `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`
@@ -290,7 +293,7 @@ func (w *PrometheusRemoteWrite) RequestTimeout() (time.Duration, error) {
 }
 
 type OtelLog struct {
-	RequestTimeoutSeconds int                `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15."`
+	RequestTimeoutSeconds int                `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15 and cannot exceed 300."`
 	AddAttributes         map[string]string  `toml:"add-attributes" comment:"Key/value pairs of attributes to add to all logs."`
 	AddMetadataLabels     *AddMetadataLabels `toml:"add-metadata-labels" comment:"Optional configuration for adding dynamic metadata as labels to logs received on this endpoint."`
 	LiftAttributes        []string           `toml:"lift-attributes" comment:"Attributes lifted from the Body and added to Attributes."`
@@ -331,7 +334,7 @@ type OtelMetric struct {
 	Database                 string `toml:"database" comment:"Database to store metrics in."`
 	Path                     string `toml:"path" comment:"The path to listen on for OTLP/HTTP requests."`
 	GrpcPort                 int    `toml:"grpc-port" comment:"The port to listen on for OTLP/gRPC requests."`
-	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP metrics request. Defaults to 15."`
+	RequestTimeoutSeconds    int    `toml:"request-timeout-seconds,omitempty" comment:"Maximum duration in seconds for an OTLP metrics request. Defaults to 15 and cannot exceed 300."`
 	DisableMetricsForwarding *bool  `toml:"disable-metrics-forwarding" comment:"Disable metrics forwarding to endpoints."`
 
 	DefaultDropMetrics        *bool              `toml:"default-drop-metrics" comment:"Default to dropping all metrics.  Only metrics matching a keep rule will be kept."`
@@ -401,6 +404,9 @@ func (w *OtelMetric) RequestTimeout() (time.Duration, error) {
 func defaultRequestTimeout(timeoutSeconds int, endpoint string) (time.Duration, error) {
 	if timeoutSeconds < 0 {
 		return 0, fmt.Errorf("%s.request-timeout-seconds must be greater than 0", endpoint)
+	}
+	if timeoutSeconds > MaxRequestTimeoutSeconds {
+		return 0, fmt.Errorf("%s.request-timeout-seconds must not exceed %d", endpoint, MaxRequestTimeoutSeconds)
 	}
 	if timeoutSeconds == 0 {
 		timeoutSeconds = DefaultRequestTimeoutSeconds

--- a/cmd/collector/config/config_test.go
+++ b/cmd/collector/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -1257,6 +1258,39 @@ func TestConfig_Validate_PrometheusRemoteWrite(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEndpointRequestTimeouts(t *testing.T) {
+	prom := &PrometheusRemoteWrite{Database: "db", Path: "/receive"}
+	require.NoError(t, prom.Validate())
+	require.Zero(t, prom.RequestTimeoutSeconds)
+	promTimeout, err := prom.RequestTimeout()
+	require.NoError(t, err)
+	require.Equal(t, 15*time.Second, promTimeout)
+	prom.RequestTimeoutSeconds = 30
+	promTimeout, err = prom.RequestTimeout()
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, promTimeout)
+	prom.RequestTimeoutSeconds = -1
+	require.EqualError(t, prom.Validate(), "prometheus-remote-write.request-timeout-seconds must be greater than 0")
+
+	logs := &OtelLog{}
+	require.NoError(t, logs.Validate())
+	require.Zero(t, logs.RequestTimeoutSeconds)
+	logsTimeout, err := logs.RequestTimeout()
+	require.NoError(t, err)
+	require.Equal(t, 15*time.Second, logsTimeout)
+	logs.RequestTimeoutSeconds = -1
+	require.EqualError(t, logs.Validate(), "otel-log.request-timeout-seconds must be greater than 0")
+
+	metrics := &OtelMetric{Database: "db", Path: "/v1/metrics"}
+	require.NoError(t, metrics.Validate())
+	require.Zero(t, metrics.RequestTimeoutSeconds)
+	metricsTimeout, err := metrics.RequestTimeout()
+	require.NoError(t, err)
+	require.Equal(t, 15*time.Second, metricsTimeout)
+	metrics.RequestTimeoutSeconds = -1
+	require.EqualError(t, metrics.Validate(), "otel-metric.request-timeout-seconds must be greater than 0")
 }
 
 func TestConfig_Validate_HostLog(t *testing.T) {

--- a/cmd/collector/config/config_test.go
+++ b/cmd/collector/config/config_test.go
@@ -1271,6 +1271,10 @@ func TestEndpointRequestTimeouts(t *testing.T) {
 	promTimeout, err = prom.RequestTimeout()
 	require.NoError(t, err)
 	require.Equal(t, 30*time.Second, promTimeout)
+	prom.RequestTimeoutSeconds = MaxRequestTimeoutSeconds
+	require.NoError(t, prom.Validate())
+	prom.RequestTimeoutSeconds++
+	require.EqualError(t, prom.Validate(), "prometheus-remote-write.request-timeout-seconds must not exceed 300")
 	prom.RequestTimeoutSeconds = -1
 	require.EqualError(t, prom.Validate(), "prometheus-remote-write.request-timeout-seconds must be greater than 0")
 
@@ -1280,6 +1284,8 @@ func TestEndpointRequestTimeouts(t *testing.T) {
 	logsTimeout, err := logs.RequestTimeout()
 	require.NoError(t, err)
 	require.Equal(t, 15*time.Second, logsTimeout)
+	logs.RequestTimeoutSeconds = MaxRequestTimeoutSeconds + 1
+	require.EqualError(t, logs.Validate(), "otel-log.request-timeout-seconds must not exceed 300")
 	logs.RequestTimeoutSeconds = -1
 	require.EqualError(t, logs.Validate(), "otel-log.request-timeout-seconds must be greater than 0")
 
@@ -1289,6 +1295,8 @@ func TestEndpointRequestTimeouts(t *testing.T) {
 	metricsTimeout, err := metrics.RequestTimeout()
 	require.NoError(t, err)
 	require.Equal(t, 15*time.Second, metricsTimeout)
+	metrics.RequestTimeoutSeconds = MaxRequestTimeoutSeconds + 1
+	require.EqualError(t, metrics.Validate(), "otel-metric.request-timeout-seconds must not exceed 300")
 	metrics.RequestTimeoutSeconds = -1
 	require.EqualError(t, metrics.Validate(), "otel-metric.request-timeout-seconds must be greater than 0")
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -373,6 +373,10 @@ func realMain(ctx *cli.Context) error {
 	}
 
 	for _, v := range cfg.PrometheusRemoteWrite {
+		requestTimeout, err := v.RequestTimeout()
+		if err != nil {
+			return err
+		}
 		// Add this pods identity for all metrics received
 		addLabels := mergeMaps(cfg.AddLabels, map[string]string{
 			"adxmon_namespace": k8s.Instance.Namespace,
@@ -451,7 +455,8 @@ func realMain(ctx *cli.Context) error {
 		}
 
 		opts.PromMetricsHandlers = append(opts.PromMetricsHandlers, collector.PrometheusRemoteWriteHandlerOpts{
-			Path: v.Path,
+			Path:           v.Path,
+			RequestTimeout: requestTimeout,
 			MetricOpts: collector.MetricsHandlerOpts{
 				DynamicLabeler:           newMetricLabeler(kubeNode, cfg.AddMetadataLabels, v.AddMetadataLabels),
 				AddLabels:                addLabels,
@@ -467,6 +472,10 @@ func realMain(ctx *cli.Context) error {
 	}
 
 	for _, v := range cfg.OtelMetric {
+		requestTimeout, err := v.RequestTimeout()
+		if err != nil {
+			return err
+		}
 		// Add this pods identity for all metrics received
 		addLabels := mergeMaps(cfg.AddLabels, v.AddLabels, map[string]string{
 			"adxmon_namespace": k8s.Instance.Namespace,
@@ -545,8 +554,9 @@ func realMain(ctx *cli.Context) error {
 		}
 
 		opts.OtlpMetricsHandlers = append(opts.OtlpMetricsHandlers, collector.OtlpMetricsHandlerOpts{
-			Path:     v.Path,
-			GrpcPort: v.GrpcPort,
+			Path:           v.Path,
+			GrpcPort:       v.GrpcPort,
+			RequestTimeout: requestTimeout,
 			MetricOpts: collector.MetricsHandlerOpts{
 				DefaultDropMetrics:       defaultDropMetrics,
 				DynamicLabeler:           newMetricLabeler(kubeNode, cfg.AddMetadataLabels, v.AddMetadataLabels),
@@ -563,6 +573,10 @@ func realMain(ctx *cli.Context) error {
 
 	if cfg.OtelLog != nil {
 		v := cfg.OtelLog
+		requestTimeout, err := v.RequestTimeout()
+		if err != nil {
+			return err
+		}
 		addAttributes := mergeMaps(cfg.AddAttributes, v.AddAttributes)
 
 		createHttpFunc := func(store storage.Store, health *cluster.Health) (*logs.Service, *http.HttpHandler, error) {
@@ -615,6 +629,7 @@ func realMain(ctx *cli.Context) error {
 			httpHandler := &http.HttpHandler{
 				Path:    "/v1/logs",
 				Handler: logsSvc.Handler,
+				Timeout: requestTimeout,
 			}
 			return workerSvc, httpHandler, nil
 		}

--- a/collector/export/metric_otlp.go
+++ b/collector/export/metric_otlp.go
@@ -169,7 +169,7 @@ func (c *PromToOtlpExporter) Write(ctx context.Context, wr *prompb.WriteRequest)
 	if timeseriesCount == 0 {
 		return nil
 	}
-	return c.sendRequest(serialized, timeseriesCount)
+	return c.sendRequest(ctx, serialized, timeseriesCount)
 }
 
 func (c *PromToOtlpExporter) CloseIdleConnections() {
@@ -262,8 +262,8 @@ func (c *PromToOtlpExporter) promToOtlpRequest(wr *prompb.WriteRequest) ([]byte,
 	return serialized, count, err
 }
 
-func (c *PromToOtlpExporter) sendRequest(body []byte, count int64) error {
-	req, err := http.NewRequest("POST", c.destination, bytes.NewReader(body))
+func (c *PromToOtlpExporter) sendRequest(ctx context.Context, body []byte, count int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.destination, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("metric otlp forwarder request: %w", err)
 	}

--- a/collector/export/metric_otlp_test.go
+++ b/collector/export/metric_otlp_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
+	"time"
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/metrics/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
@@ -295,7 +296,7 @@ func TestSendRequest(t *testing.T) {
 			tc.exporter.destination = server.URL + "/v1/metrics"
 
 			body := []byte("test body")
-			err := tc.exporter.sendRequest(body, 20)
+			err := tc.exporter.sendRequest(context.Background(), body, 20)
 
 			if tc.expectedStatus == http.StatusOK {
 				require.NoError(t, err)
@@ -303,6 +304,42 @@ func TestSendRequest(t *testing.T) {
 				require.Error(t, err)
 			}
 		})
+	}
+}
+
+func TestPromToOtlpExporterWriteCancellation(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	}))
+	defer server.Close()
+	defer close(releaseRequest)
+
+	exporter := NewPromToOtlpExporter(PromToOtlpExporterOpts{
+		Transformer: &transform.RequestTransformer{},
+		Destination: server.URL,
+		Timeout:     time.Minute,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- exporter.Write(ctx, newWR())
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("outbound request did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("outbound request did not stop after context cancellation")
 	}
 }
 

--- a/collector/logs/engine/worker.go
+++ b/collector/logs/engine/worker.go
@@ -49,7 +49,7 @@ func (w *worker) processBatch(ctx context.Context, batch *types.LogBatch) {
 		if err != nil {
 			logger.Warnf("Failed to transform logs from source %s -> %s: %v", w.SourceName, transform.Name(), err)
 			metrics.LogsCollectorLogsDropped.WithLabelValues(w.SourceName, transform.Name()).Add(float64(len(batch.Logs)))
-			disposeBatch(batch)
+			types.DisposeLogBatch(batch)
 			return
 		}
 	}
@@ -69,7 +69,7 @@ func (w *worker) processBatch(ctx context.Context, batch *types.LogBatch) {
 	}
 
 	wg.Wait()
-	disposeBatch(batch)
+	types.DisposeLogBatch(batch)
 }
 
 func sendToSink(ctx context.Context, sink types.Sink, batch *types.LogBatch, sourceName string) {
@@ -80,11 +80,4 @@ func sendToSink(ctx context.Context, sink types.Sink, batch *types.LogBatch, sou
 		return
 	}
 	metrics.LogsCollectorLogsSent.WithLabelValues(sourceName, sink.Name()).Add(float64(len(batch.Logs)))
-}
-
-func disposeBatch(batch *types.LogBatch) {
-	for _, log := range batch.Logs {
-		types.LogPool.Put(log)
-	}
-	types.LogBatchPool.Put(batch)
 }

--- a/collector/logs/types/logs.go
+++ b/collector/logs/types/logs.go
@@ -280,4 +280,13 @@ func (l *LogBatch) Reset() {
 	l.Ack = noop
 }
 
+// DisposeLogBatch returns a batch and all of its logs to their pools.
+func DisposeLogBatch(batch *LogBatch) {
+	for _, log := range batch.Logs {
+		LogPool.Put(log)
+	}
+	batch.Reset()
+	LogBatchPool.Put(batch)
+}
+
 func noop() {}

--- a/collector/otlp/logs_transfer.go
+++ b/collector/otlp/logs_transfer.go
@@ -129,7 +129,15 @@ func (s *LogsService) Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		s.outputQueue <- logBatch
+		select {
+		case s.outputQueue <- logBatch:
+			// The worker owns the batch after it is enqueued.
+		case <-r.Context().Done():
+			// Context has timed out with the outputQueue not being able to consume. Dispose the logBatch.
+			types.DisposeLogBatch(logBatch)
+			// At this point, either the client has given up or the server timeout middleware will return an error back to the client.
+			return
+		}
 
 		// The logs have been committed by the OTLP endpoint
 		resp := &v1.ExportLogsServiceResponse{}

--- a/collector/otlp/logs_transfer_test.go
+++ b/collector/otlp/logs_transfer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	v1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/collector/logs/v1"
 	commonv1 "buf.build/gen/go/opentelemetry/opentelemetry/protocolbuffers/go/opentelemetry/proto/common/v1"
@@ -378,6 +379,43 @@ func TestLogsService_Overloaded(t *testing.T) {
 
 	keys := store.PrefixesByAge()
 	require.Equal(t, 0, len(keys))
+}
+
+func TestLogsService_HandlerReturnsWhenQueueFullAndRequestCanceled(t *testing.T) {
+	s := NewLogsService(LogsServiceOpts{
+		HealthChecker: fakeHealthChecker{true},
+	})
+	for range cap(s.outputQueue) {
+		s.outputQueue <- &types.LogBatch{}
+	}
+
+	var msg v1.ExportLogsServiceRequest
+	require.NoError(t, protojson.Unmarshal(rawlog, &msg))
+	body, err := proto.Marshal(&msg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/v1/logs", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Handler(httptest.NewRecorder(), req)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		// Release the current implementation so the test does not leak its goroutine.
+		<-s.outputQueue
+		<-done
+		t.Fatal("handler did not return after request cancellation")
+	}
+
+	require.Len(t, s.outputQueue, cap(s.outputQueue), "canceled batch was enqueued")
 }
 
 func TestLogsService_ErrorStatusResponses(t *testing.T) {

--- a/collector/service.go
+++ b/collector/service.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	stdhttp "net/http"
@@ -25,6 +26,7 @@ import (
 	"github.com/Azure/adx-mon/pkg/service"
 	"github.com/Azure/adx-mon/storage"
 	"github.com/Azure/adx-mon/transform"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -152,6 +154,8 @@ type OtlpMetricsHandlerOpts struct {
 	Path string
 	// Optional. GrpcPort is the port where the metrics OTLP/GRPC handler will listen.
 	GrpcPort int
+	// RequestTimeout is the maximum duration for an OTLP metrics request.
+	RequestTimeout time.Duration
 
 	MetricOpts MetricsHandlerOpts
 }
@@ -159,8 +163,28 @@ type OtlpMetricsHandlerOpts struct {
 type PrometheusRemoteWriteHandlerOpts struct {
 	// Path is the path where the handler will be registered.
 	Path string
+	// RequestTimeout is the maximum duration for a remote write request.
+	RequestTimeout time.Duration
 
 	MetricOpts MetricsHandlerOpts
+}
+
+func requestTimeoutInterceptor(timeout time.Duration) connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if timeout <= 0 {
+				return next(ctx, req)
+			}
+
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			response, err := next(ctx, req)
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, connect.NewError(connect.CodeDeadlineExceeded, ctx.Err())
+			}
+			return response, err
+		}
+	})
 }
 
 type MetricsHandlerOpts struct {
@@ -259,6 +283,7 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 		httpHandlers = append(httpHandlers, &http.HttpHandler{
 			Path:    handlerOpts.Path,
 			Handler: metricsProxySvc.HandleReceive,
+			Timeout: handlerOpts.RequestTimeout,
 		})
 	}
 
@@ -275,11 +300,15 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 			httpHandlers = append(httpHandlers, &http.HttpHandler{
 				Path:    handlerOpts.Path,
 				Handler: oltpMetricsService.Handler,
+				Timeout: handlerOpts.RequestTimeout,
 			})
 		}
 
 		if handlerOpts.GrpcPort > 0 {
-			path, handler := metricsv1connect.NewMetricsServiceHandler(oltpMetricsService)
+			path, handler := metricsv1connect.NewMetricsServiceHandler(
+				oltpMetricsService,
+				connect.WithInterceptors(requestTimeoutInterceptor(handlerOpts.RequestTimeout)),
+			)
 
 			grpcHandlers = append(grpcHandlers, &http.GRPCHandler{
 				Port:    handlerOpts.GrpcPort,
@@ -468,7 +497,7 @@ func (s *Service) Open(ctx context.Context) error {
 	}
 
 	for _, handler := range s.httpHandlers {
-		primaryHttp.RegisterHandlerFunc(handler.Path, handler.Handler)
+		primaryHttp.RegisterHandler(handler.Path, handler.WithTimeout())
 	}
 	s.httpServers = append(s.httpServers, primaryHttp)
 

--- a/collector/service.go
+++ b/collector/service.go
@@ -169,6 +169,23 @@ type PrometheusRemoteWriteHandlerOpts struct {
 	MetricOpts MetricsHandlerOpts
 }
 
+const httpWriteTimeoutGrace = time.Second
+
+func httpWriteTimeout(enablePprof bool, handlers []*http.HttpHandler) time.Duration {
+	writeTimeout := 30 * time.Second
+	if enablePprof {
+		writeTimeout = 60 * time.Second
+	}
+
+	for _, handler := range handlers {
+		if handler.Timeout > 0 {
+			writeTimeout = max(writeTimeout, handler.Timeout+httpWriteTimeoutGrace)
+		}
+	}
+
+	return writeTimeout
+}
+
 func requestTimeoutInterceptor(timeout time.Duration) connect.Interceptor {
 	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
@@ -478,7 +495,7 @@ func (s *Service) Open(ctx context.Context) error {
 
 	opts := &http.ServerOpts{
 		MaxConns:     s.opts.MaxConnections,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: httpWriteTimeout(s.opts.EnablePprof, s.httpHandlers),
 		Listener:     listener,
 	}
 
@@ -488,7 +505,6 @@ func (s *Service) Open(ctx context.Context) error {
 	primaryHttp.RegisterHandlerFunc("/readyz", s.HandleReady)
 	primaryHttp.RegisterHandlerFunc("/debug/store", s.HandleDebugStore)
 	if s.opts.EnablePprof {
-		opts.WriteTimeout = 60 * time.Second
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/", pprof.Index)
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/cmdline", pprof.Cmdline)
 		primaryHttp.RegisterHandlerFunc("/debug/pprof/profile", pprof.Profile)

--- a/collector/service.go
+++ b/collector/service.go
@@ -171,6 +171,13 @@ type PrometheusRemoteWriteHandlerOpts struct {
 
 const httpWriteTimeoutGrace = time.Second
 
+func requestWriteTimeout(baseline, requestTimeout time.Duration) time.Duration {
+	if requestTimeout > 0 {
+		return max(baseline, requestTimeout+httpWriteTimeoutGrace)
+	}
+	return baseline
+}
+
 func httpWriteTimeout(enablePprof bool, handlers []*http.HttpHandler) time.Duration {
 	writeTimeout := 30 * time.Second
 	if enablePprof {
@@ -178,9 +185,7 @@ func httpWriteTimeout(enablePprof bool, handlers []*http.HttpHandler) time.Durat
 	}
 
 	for _, handler := range handlers {
-		if handler.Timeout > 0 {
-			writeTimeout = max(writeTimeout, handler.Timeout+httpWriteTimeoutGrace)
-		}
+		writeTimeout = requestWriteTimeout(writeTimeout, handler.Timeout)
 	}
 
 	return writeTimeout
@@ -331,6 +336,7 @@ func NewService(opts *ServiceOpts) (*Service, error) {
 				Port:    handlerOpts.GrpcPort,
 				Path:    path,
 				Handler: handler,
+				Timeout: handlerOpts.RequestTimeout,
 			})
 		}
 	}
@@ -523,8 +529,9 @@ func (s *Service) Open(ctx context.Context) error {
 			return err
 		}
 		server := http.NewServer(&http.ServerOpts{
-			MaxConns: s.opts.MaxConnections,
-			Listener: listener,
+			MaxConns:     s.opts.MaxConnections,
+			WriteTimeout: requestWriteTimeout(30*time.Second, handler.Timeout),
+			Listener:     listener,
 		})
 		server.RegisterHandler(handler.Path, handler.Handler)
 		s.httpServers = append(s.httpServers, server)

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -2,18 +2,34 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/Azure/adx-mon/pkg/k8s"
 	"github.com/Azure/adx-mon/storage"
+	connect "github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func TestRequestTimeoutInterceptor(t *testing.T) {
+	interceptor := requestTimeoutInterceptor(10 * time.Millisecond)
+	wrapped := interceptor.WrapUnary(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	_, err := wrapped(context.Background(), nil)
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	require.Equal(t, connect.CodeDeadlineExceeded, connectErr.Code())
+}
 
 const MetricListenAddr = ":9090"
 

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -63,6 +63,11 @@ func TestHTTPWriteTimeout(t *testing.T) {
 	}
 }
 
+func TestRequestWriteTimeout(t *testing.T) {
+	require.Equal(t, 30*time.Second, requestWriteTimeout(30*time.Second, 15*time.Second))
+	require.Equal(t, 5*time.Minute+httpWriteTimeoutGrace, requestWriteTimeout(30*time.Second, 5*time.Minute))
+}
+
 const MetricListenAddr = ":9090"
 
 var serviceBackends = []struct {

--- a/collector/service_test.go
+++ b/collector/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/adx-mon/pkg/http"
 	"github.com/Azure/adx-mon/pkg/k8s"
 	"github.com/Azure/adx-mon/storage"
 	connect "github.com/bufbuild/connect-go"
@@ -29,6 +30,37 @@ func TestRequestTimeoutInterceptor(t *testing.T) {
 	var connectErr *connect.Error
 	require.True(t, errors.As(err, &connectErr))
 	require.Equal(t, connect.CodeDeadlineExceeded, connectErr.Code())
+}
+
+func TestHTTPWriteTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		enablePprof bool
+		handlers    []*http.HttpHandler
+		want        time.Duration
+	}{
+		{name: "default", want: 30 * time.Second},
+		{name: "pprof", enablePprof: true, want: 60 * time.Second},
+		{
+			name:     "short endpoint retains default",
+			handlers: []*http.HttpHandler{{Timeout: 15 * time.Second}},
+			want:     30 * time.Second,
+		},
+		{
+			name: "longest endpoint plus grace",
+			handlers: []*http.HttpHandler{
+				{Timeout: 45 * time.Second},
+				{Timeout: 5 * time.Minute},
+			},
+			want: 5*time.Minute + httpWriteTimeoutGrace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, httpWriteTimeout(tt.enablePprof, tt.handlers))
+		})
+	}
 }
 
 const MetricListenAddr = ":9090"

--- a/docs/config.md
+++ b/docs/config.md
@@ -199,6 +199,8 @@ Prometheus remote write accepts metrics from [Prometheus remote write protocol](
   database = 'Metrics'
   # The path to listen on for prometheus remote write requests.  Defaults to /receive.
   path = '/receive'
+  # Maximum duration in seconds for a remote write request. Defaults to 15.
+  request-timeout-seconds = 15
   # Regexes of metrics to drop.
   drop-metrics = [
     '^kube_pod_ips$',
@@ -240,6 +242,8 @@ The Otel log endpoint accepts [OTLP/HTTP](https://opentelemetry.io/docs/specs/ot
 ```toml
 # Defines an OpenTelemetry log endpoint. Accepts OTLP/HTTP.
 [otel-log]
+  # Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15.
+  request-timeout-seconds = 15
   # Attributes lifted from the Body and added to Attributes.
   lift-attributes = [
     'host'
@@ -275,6 +279,8 @@ The Otel metrics endpoint accepts [OTLP/HTTP and/or OTLP/gRPC](https://opentelem
   path = '/v1/otlpmetrics'
   # The port to listen on for OTLP/gRPC requests.
   grpc-port = 4317
+  # Maximum duration in seconds for an OTLP metrics request. Defaults to 15.
+  request-timeout-seconds = 15
   # Regexes of metrics to drop.
   drop-metrics = [
     '^kube_pod_ips$',

--- a/docs/config.md
+++ b/docs/config.md
@@ -199,7 +199,7 @@ Prometheus remote write accepts metrics from [Prometheus remote write protocol](
   database = 'Metrics'
   # The path to listen on for prometheus remote write requests.  Defaults to /receive.
   path = '/receive'
-  # Maximum duration in seconds for a remote write request. Defaults to 15.
+  # Maximum duration in seconds for a remote write request. Defaults to 15 and cannot exceed 300.
   request-timeout-seconds = 15
   # Regexes of metrics to drop.
   drop-metrics = [
@@ -242,7 +242,7 @@ The Otel log endpoint accepts [OTLP/HTTP](https://opentelemetry.io/docs/specs/ot
 ```toml
 # Defines an OpenTelemetry log endpoint. Accepts OTLP/HTTP.
 [otel-log]
-  # Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15.
+  # Maximum duration in seconds for an OTLP/HTTP logs request. Defaults to 15 and cannot exceed 300.
   request-timeout-seconds = 15
   # Attributes lifted from the Body and added to Attributes.
   lift-attributes = [
@@ -279,7 +279,7 @@ The Otel metrics endpoint accepts [OTLP/HTTP and/or OTLP/gRPC](https://opentelem
   path = '/v1/otlpmetrics'
   # The port to listen on for OTLP/gRPC requests.
   grpc-port = 4317
-  # Maximum duration in seconds for an OTLP metrics request. Defaults to 15.
+  # Maximum duration in seconds for an OTLP metrics request. Defaults to 15 and cannot exceed 300.
   request-timeout-seconds = 15
   # Regexes of metrics to drop.
   drop-metrics = [

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -30,6 +30,7 @@ type GRPCHandler struct {
 	Path    string
 	Handler http.Handler
 	Port    int
+	Timeout time.Duration
 }
 
 type ServerOpts struct {

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -16,6 +16,14 @@ import (
 type HttpHandler struct {
 	Path    string
 	Handler http.HandlerFunc
+	Timeout time.Duration
+}
+
+func (h *HttpHandler) WithTimeout() http.Handler {
+	if h.Timeout <= 0 {
+		return h.Handler
+	}
+	return http.TimeoutHandler(h.Handler, h.Timeout, "")
 }
 
 type GRPCHandler struct {

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
@@ -36,5 +37,26 @@ func TestNewHttpServer_Endpoints(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, tt.status, resp.StatusCode, tt.endpoint)
+	}
+}
+
+func TestHttpHandlerWithTimeout(t *testing.T) {
+	contextCanceled := make(chan struct{})
+	handler := (&HttpHandler{
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			close(contextCanceled)
+		},
+		Timeout: 10 * time.Millisecond,
+	}).WithTimeout()
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v1/logs", nil))
+
+	require.Equal(t, http.StatusServiceUnavailable, response.Code)
+	select {
+	case <-contextCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("handler context was not canceled after timeout")
 	}
 }

--- a/tools/docgen/config/config.go
+++ b/tools/docgen/config/config.go
@@ -214,8 +214,9 @@ func getContents() Contents {
 				Config: &config.Config{
 					PrometheusRemoteWrite: []*config.PrometheusRemoteWrite{
 						{
-							Database: "Metrics",
-							Path:     "/receive",
+							Database:              "Metrics",
+							Path:                  "/receive",
+							RequestTimeoutSeconds: config.DefaultRequestTimeoutSeconds,
 							AddLabels: map[string]string{
 								"cluster": "cluster1",
 							},
@@ -248,6 +249,7 @@ func getContents() Contents {
 				Description: "The Otel log endpoint accepts [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/) logs from an OpenTelemetry sender. By default, this listens under the path `/v1/logs`. This endpoint expects the Attributes or Body fields to contain the key-value pairs `kusto.database` and `kusto.table` to route logs to the appropriate ADX database and table.",
 				Config: &config.Config{
 					OtelLog: &config.OtelLog{
+						RequestTimeoutSeconds: config.DefaultRequestTimeoutSeconds,
 						AddAttributes: map[string]string{
 							"cluster": "cluster1",
 							"geo":     "eu",
@@ -272,9 +274,10 @@ func getContents() Contents {
 				Config: &config.Config{
 					OtelMetric: []*config.OtelMetric{
 						{
-							Database: "Metrics",
-							Path:     "/v1/otlpmetrics",
-							GrpcPort: 4317,
+							Database:              "Metrics",
+							Path:                  "/v1/otlpmetrics",
+							GrpcPort:              4317,
+							RequestTimeoutSeconds: config.DefaultRequestTimeoutSeconds,
 							AddLabels: map[string]string{
 								"cluster": "cluster1",
 							},


### PR DESCRIPTION
This prevents us from building up large backlogs of in-flight data during slow processing, preventing memory explosions and/or trying to spend a ton of time processing queued data even when the remote end has already cancelled their request.

Tracking cancellation within /v1/logs also prevents us from leaking our counts of active connections in cases where the client has given up.