### PR TITLE
Retry transient remote Kusto entity resolution failures

### DIFF
--- a/alerter/engine/worker.go
+++ b/alerter/engine/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +24,9 @@ import (
 )
 
 const (
-	maxQueryTime = 5 * time.Minute
+	maxQueryTime                       = 5 * time.Minute
+	queryErrorNotificationReserve      = 30 * time.Second
+	minRemoteEntityResolutionRetryTime = 30 * time.Second
 
 	evaluationOutcomeSuccess               = metrics.AlertRuleEvaluationOutcomeSuccess
 	evaluationOutcomeSetupError            = metrics.AlertRuleEvaluationOutcomeSetupError
@@ -31,6 +34,8 @@ const (
 	evaluationOutcomeServiceError          = metrics.AlertRuleEvaluationOutcomeServiceError
 	evaluationOutcomeNotificationThrottled = metrics.AlertRuleEvaluationOutcomeNotificationThrottled
 )
+
+var errInsufficientRemoteEntityResolutionRetryBudget = errors.New("insufficient time remaining for remote entity resolution retry")
 
 type worker struct {
 	mu     sync.Mutex
@@ -47,6 +52,7 @@ type worker struct {
 	handlerFn  func(ctx context.Context, endpoint string, qc *QueryContext, row azquery.Row) error
 	querySlots chan struct{}
 	ctrlCli    client.Client
+	queryTime  time.Duration
 
 	// criteria/expression evaluation cached at construction
 	matchAllowed bool
@@ -88,6 +94,7 @@ func NewWorker(cfg *WorkerConfig) *worker {
 		handlerFn:   cfg.HandlerFn,
 		querySlots:  querySlots,
 		ctrlCli:     cfg.CtrlClient,
+		queryTime:   maxQueryTime,
 	}
 	allowed, err := cfg.Rule.Matches(cfg.Tags)
 	w.matchAllowed = allowed
@@ -187,7 +194,7 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 	// Release the worker slot.
 	defer func() { <-e.querySlots }()
 
-	ctx, cancel := context.WithTimeout(ctx, maxQueryTime)
+	ctx, cancel := context.WithTimeout(ctx, e.queryTime)
 	defer cancel()
 
 	evaluation := newAlertRuleEvaluation(e.rule)
@@ -213,7 +220,7 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 		return err
 	}
 
-	err, evaluation.rows = e.kustoClient.Query(ctx, queryContext, wrappedHandler)
+	err, evaluation.rows = e.queryWithRetry(ctx, queryContext, wrappedHandler)
 	if err != nil {
 		// This failed because we sent too many notifications.
 		if errors.Is(err, alert.ErrTooManyRequests) {
@@ -236,13 +243,18 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 		// This failed because the query failed.
 		logger.Errorf("Failed to execute query=%s/%s on %s/%s: %s", e.rule.Namespace, e.rule.Name, e.kustoClient.Endpoint(e.rule.Database), e.rule.Database, err)
 
-		if !isUserError(err) {
+		retryExhausted := isRemoteEntityResolutionRetryExhausted(err)
+		if !retryExhausted && !isUserError(err) {
 			evaluation.outcome = evaluationOutcomeServiceError
 			metrics.QueryHealth.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(0)
 			e.updateAlertRuleStatus(ctx, evaluation, "Error", fmt.Sprintf("Query execution failed: %v", err))
 			return
 		}
-		evaluation.outcome = evaluationOutcomeUserError
+		if retryExhausted {
+			evaluation.outcome = evaluationOutcomeServiceError
+		} else {
+			evaluation.outcome = evaluationOutcomeUserError
+		}
 
 		// Store the original query error before it gets overwritten
 		originalQueryErr := err
@@ -274,9 +286,14 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 		} else {
 			metrics.NotificationUnhealthy.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(0)
 		}
-		// Query failed due to user error, so return the query to healthy.
-		metrics.QueryHealth.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(1)
-		e.updateAlertRuleStatus(ctx, evaluation, "Error", fmt.Sprintf("Query failed with user error: %v", originalQueryErr))
+		if retryExhausted {
+			metrics.QueryHealth.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(0)
+			e.updateAlertRuleStatus(ctx, evaluation, "Error", fmt.Sprintf("Query failed after remote entity resolution retry: %v", originalQueryErr))
+		} else {
+			// Query failed due to user error, so return the query to healthy.
+			metrics.QueryHealth.WithLabelValues(e.rule.Namespace, e.rule.Name).Set(1)
+			e.updateAlertRuleStatus(ctx, evaluation, "Error", fmt.Sprintf("Query failed with user error: %v", originalQueryErr))
+		}
 		return
 	}
 
@@ -287,6 +304,107 @@ func (e *worker) ExecuteQuery(ctx context.Context) {
 
 	// Update AlertRule status with execution information
 	e.updateAlertRuleStatus(ctx, evaluation, "Success", "")
+}
+
+func (e *worker) queryWithRetry(
+	ctx context.Context,
+	queryContext *QueryContext,
+	handler func(context.Context, string, *QueryContext, azquery.Row) error,
+) (error, int) {
+	queryCtx, cancel := queryExecutionContext(ctx)
+	defer cancel()
+
+	initialErr, rows := e.kustoClient.Query(queryCtx, queryContext, handler)
+	if !isTransientRemoteEntityResolutionError(initialErr) {
+		return initialErr, rows
+	}
+
+	if !hasRemoteEntityResolutionRetryBudget(queryCtx) {
+		logger.Warnf(
+			"Query %s/%s failed with a transient remote entity resolution error but has insufficient time remaining for a safe retry",
+			e.rule.Namespace,
+			e.rule.Name,
+		)
+		return &remoteEntityResolutionRetryError{
+			initialErr: initialErr,
+			retryErr:   errInsufficientRemoteEntityResolutionRetryBudget,
+		}, rows
+	}
+
+	logger.Warnf(
+		"Query %s/%s failed with a transient remote entity resolution error; retrying once",
+		e.rule.Namespace,
+		e.rule.Name,
+	)
+	retryErr, retryRows := e.kustoClient.Query(queryCtx, queryContext, handler)
+	if retryErr == nil {
+		return nil, retryRows
+	}
+
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return ctx.Err(), retryRows
+	}
+
+	return &remoteEntityResolutionRetryError{
+		initialErr: initialErr,
+		retryErr:   retryErr,
+	}, retryRows
+}
+
+func queryExecutionContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+
+	return context.WithDeadline(ctx, deadline.Add(-queryErrorNotificationReserve))
+}
+
+func hasRemoteEntityResolutionRetryBudget(ctx context.Context) bool {
+	deadline, ok := ctx.Deadline()
+	return !ok || time.Until(deadline) >= minRemoteEntityResolutionRetryTime
+}
+
+func isTransientRemoteEntityResolutionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var kerr *kerrors.HttpError
+	if !errors.As(err, &kerr) {
+		return false
+	}
+
+	lowerErr := strings.ToLower(kerr.Error())
+	if kerr.StatusCode != http.StatusBadRequest ||
+		!strings.Contains(lowerErr, "sem0056") ||
+		!strings.Contains(lowerErr, "resolving remote entities") ||
+		!strings.Contains(lowerErr, "failed to resolve name or pattern") {
+		return false
+	}
+
+	return !strings.Contains(lowerErr, "obo token is required for cross-cluster communication") &&
+		!strings.Contains(lowerErr, "is not authorized to") &&
+		!strings.Contains(lowerErr, "access denied") &&
+		!strings.Contains(lowerErr, "is not allowed by the callout policy")
+}
+
+type remoteEntityResolutionRetryError struct {
+	initialErr error
+	retryErr   error
+}
+
+func (e *remoteEntityResolutionRetryError) Error() string {
+	return fmt.Sprintf("remote entity resolution retry failed: initial error: %v; retry error: %v", e.initialErr, e.retryErr)
+}
+
+func (e *remoteEntityResolutionRetryError) Unwrap() error {
+	return e.retryErr
+}
+
+func isRemoteEntityResolutionRetryExhausted(err error) bool {
+	var retryErr *remoteEntityResolutionRetryError
+	return errors.As(err, &retryErr)
 }
 
 // updateAlertRuleStatus updates the AlertRule status with the execution information

--- a/alerter/engine/worker_test.go
+++ b/alerter/engine/worker_test.go
@@ -410,8 +410,12 @@ func TestWorker_ContextTimeout(t *testing.T) {
 }
 
 func TestWorker_RequestInvalid(t *testing.T) {
+	queryCalls := 0
 	kcli := &fakeKustoClient{
-		queryErr: kerrors.HTTP(kerrors.OpQuery, "Bad Request", http.StatusBadRequest, io.NopCloser(bytes.NewBufferString("query")), "Request is invalid and cannot be processed: Semantic error: SEM0001: Arithmetic expression cannot be carried-out between DateTime and StringBuffer"),
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
+			queryCalls++
+			return semanticError("SEM0001: Arithmetic expression cannot be carried-out between DateTime and StringBuffer"), 0
+		},
 	}
 
 	var createCalled bool
@@ -432,10 +436,197 @@ func TestWorker_RequestInvalid(t *testing.T) {
 	metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(QueryHealthHealthy)
 
 	w.ExecuteQuery(context.Background())
+	require.Equal(t, 1, queryCalls)
 	require.True(t, createCalled, "Create alert should be called")
 	gaugeValue := getGaugeValue(t, metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name))
 	// user caused error
 	require.Equal(t, QueryHealthHealthy, gaugeValue)
+}
+
+func TestWorker_RemoteEntityResolutionError_RetrySucceeds(t *testing.T) {
+	queryCalls := 0
+	var firstQueryContext *QueryContext
+	kcli := &fakeKustoClient{
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
+			queryCalls++
+			if queryCalls == 1 {
+				firstQueryContext = qc
+				return remoteEntityResolutionError(), 0
+			}
+			require.Same(t, firstQueryContext, qc)
+			return nil, 0
+		},
+	}
+
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			t.Fatal("Create alert should not be called after a successful retry")
+			return nil
+		},
+	}
+
+	rule := &rules.Rule{
+		Namespace: "namespace",
+		Name:      "name",
+	}
+	w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: alertCli})
+
+	metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(QueryHealthUnhealthy)
+	successCounter := metrics.AlertRuleEvaluationsTotal.WithLabelValues(evaluationOutcomeSuccess)
+	successCounterBefore := getCounterValue(t, successCounter)
+
+	w.ExecuteQuery(context.Background())
+
+	require.Equal(t, 2, queryCalls)
+	require.Equal(t, QueryHealthHealthy, getGaugeValue(t, metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name)))
+	require.Equal(t, successCounterBefore+1, getCounterValue(t, successCounter))
+}
+
+func TestWorker_RemoteEntityResolutionError_RetriesRemainFailLoud(t *testing.T) {
+	queryCalls := 0
+	kcli := &fakeKustoClient{
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
+			queryCalls++
+			return remoteEntityResolutionError(), 0
+		},
+	}
+
+	createCalls := 0
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			createCalls++
+			return nil
+		},
+	}
+
+	rule := &rules.Rule{
+		Namespace: "namespace",
+		Name:      "name",
+	}
+	w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: alertCli})
+	serviceErrorCounter := metrics.AlertRuleEvaluationsTotal.WithLabelValues(evaluationOutcomeServiceError)
+	serviceErrorCounterBefore := getCounterValue(t, serviceErrorCounter)
+
+	w.ExecuteQuery(context.Background())
+
+	require.Equal(t, 2, queryCalls)
+	require.Equal(t, 1, createCalls)
+	require.Equal(t, QueryHealthUnhealthy, getGaugeValue(t, metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name)))
+	require.Equal(t, serviceErrorCounterBefore+1, getCounterValue(t, serviceErrorCounter))
+}
+
+func TestWorker_RemoteEntityResolutionError_InsufficientRetryBudgetRemainsFailLoud(t *testing.T) {
+	queryCalls := 0
+	kcli := &fakeKustoClient{
+		queryFn: func(ctx context.Context, qc *QueryContext, fn func(context.Context, string, *QueryContext, azquery.Row) error) (error, int) {
+			queryCalls++
+			<-ctx.Done()
+			require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+			return remoteEntityResolutionError(), 0
+		},
+	}
+
+	createCalls := 0
+	alertCli := &fakeAlerter{
+		createFn: func(ctx context.Context, endpoint string, alert alert.Alert) error {
+			require.NoError(t, ctx.Err())
+			createCalls++
+			return nil
+		},
+	}
+
+	rule := &rules.Rule{
+		Namespace: "namespace",
+		Name:      "name",
+	}
+	w := NewWorker(&WorkerConfig{Rule: rule, Region: "eastus", KustoClient: kcli, AlertClient: alertCli})
+	w.queryTime = queryErrorNotificationReserve + 10*time.Millisecond
+	metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name).Set(QueryHealthHealthy)
+	serviceErrorCounter := metrics.AlertRuleEvaluationsTotal.WithLabelValues(evaluationOutcomeServiceError)
+	serviceErrorCounterBefore := getCounterValue(t, serviceErrorCounter)
+
+	w.ExecuteQuery(context.Background())
+
+	require.Equal(t, 1, queryCalls)
+	require.Equal(t, 1, createCalls)
+	require.Equal(t, QueryHealthUnhealthy, getGaugeValue(t, metrics.QueryHealth.WithLabelValues(rule.Namespace, rule.Name)))
+	require.Equal(t, serviceErrorCounterBefore+1, getCounterValue(t, serviceErrorCounter))
+}
+
+func TestTransientRemoteEntityResolutionError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{
+			name:      "production remote entity resolution payload",
+			err:       remoteEntityResolutionError(),
+			transient: true,
+		},
+		{
+			name:      "syntax error",
+			err:       semanticError("SEM0001: Arithmetic expression cannot be carried-out between DateTime and StringBuffer"),
+			transient: false,
+		},
+		{
+			name:      "local missing entity",
+			err:       semanticError("SEM0056: Failed to resolve name or pattern 'TypoedTable' in one or more scopes"),
+			transient: false,
+		},
+		{
+			name:      "remote authorization denial",
+			err:       remoteEntityResolutionErrorWithSuffix("Access denied"),
+			transient: false,
+		},
+		{
+			name:      "remote OBO requirement",
+			err:       remoteEntityResolutionErrorWithSuffix("OBO token is required for cross-cluster communication"),
+			transient: false,
+		},
+		{
+			name:      "remote callout policy denial",
+			err:       remoteEntityResolutionErrorWithSuffix("Caller is not allowed by the callout policy"),
+			transient: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.transient, isTransientRemoteEntityResolutionError(tt.err))
+		})
+	}
+}
+
+func TestHasRemoteEntityResolutionRetryBudget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), minRemoteEntityResolutionRetryTime)
+	defer cancel()
+
+	require.False(t, hasRemoteEntityResolutionRetryBudget(ctx))
+}
+
+func remoteEntityResolutionError() error {
+	return remoteEntityResolutionErrorWithSuffix("")
+}
+
+func remoteEntityResolutionErrorWithSuffix(suffix string) error {
+	message := "Request is invalid and cannot be processed: Semantic error: SEM0056: Errors occurred while resolving remote entities. Failed to resolve name or pattern 'ManagedClusterSnapshot' in one or more scopes"
+	if suffix != "" {
+		message += ". " + suffix
+	}
+
+	return semanticError(message)
+}
+
+func semanticError(message string) error {
+	body := fmt.Sprintf(`{"error":{"code":"General_BadRequest","message":%q,"@permanent":true,"innererror":{"code":"SEM0056","message":%q}}}`, message, message)
+	return fmt.Errorf("failed to execute kusto query: %w", kerrors.HTTP(
+		kerrors.OpQuery,
+		"Bad Request",
+		http.StatusBadRequest,
+		io.NopCloser(bytes.NewBufferString(body)),
+		"error from Kusto endpoint",
+	))
 }
 
 func TestWorker_UnknownDB(t *testing.T) {


### PR DESCRIPTION
## Why

Transient cross-cluster Kusto entity-resolution failures currently create query-error Sev3 incidents immediately. These SEM0056 failures can occur even when the remote table exists and resolves on the next request.

Handling this inside individual alert queries with an empty fallback would hide monitoring loss. The alerter should retry the narrowly identified transient failure while preserving fail-loud behavior.

## What changed

- Retry once for HTTP 400 SEM0056 errors that specifically report remote entity resolution and failed name or pattern resolution.
- Exclude known permanent OBO, authorization, access-denied, and callout-policy failures.
- Reuse the original query context so the retry evaluates the same alert window.
- Reserve 30 seconds for failure notification.
- If retry fails or cannot safely run, send the existing query-error alert and keep the query unhealthy with a service-error outcome.
- Preserve worker cancellation and notification-throttling behavior.