### PR TITLE
collector: add journal-path option to journal-target

### DIFF
--- a/cmd/collector/config/config.go
+++ b/cmd/collector/config/config.go
@@ -498,6 +498,7 @@ type JournalTarget struct {
 	Table         string   `toml:"table" comment:"Table to store logs in."`
 	Parsers       []string `toml:"parsers" comment:"Parsers to apply sequentially to the log line."`
 	JournalFields []string `toml:"journal-fields" comment:"Optional journal metadata fields http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html"`
+	JournalPath   string   `toml:"journal-path" comment:"Optional directory to read journal files from. When unset, the local system journal is opened, which only exposes the journal matching the current machine ID. Set this to read a journal belonging to another machine ID, such as a host journal bind-mounted into a container."`
 }
 
 func (j *JournalTarget) Validate() error {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -851,6 +851,7 @@ func realMain(ctx *cli.Context) error {
 						Table:          target.Table,
 						LogLineParsers: parsers,
 						JournalFields:  target.JournalFields,
+						JournalPath:    target.JournalPath,
 					})
 				}
 

--- a/collector/logs/sources/journal/cursor.go
+++ b/collector/logs/sources/journal/cursor.go
@@ -15,11 +15,18 @@ type journalcursor struct {
 	Cursor string `json:"cursor"`
 }
 
-func cursorPath(cursorDirectory string, filters []string, database string, table string) string {
+func cursorPath(cursorDirectory string, filters []string, database string, table string, journalPath string) string {
 	hasher := xxhash.New()
 	// filters are order dependent, so do not sort before creating the hash.
 	for _, filter := range filters {
 		hasher.Write([]byte(filter))
+	}
+	// Targets reading a non-default journal need their own cursor, or two targets
+	// agreeing on database, table and matches would share one cursor file and
+	// clobber each other. Mixed in only when set, so cursor paths for targets that
+	// read the default journal are unchanged and no re-ingestion is triggered.
+	if journalPath != "" {
+		hasher.Write([]byte("journal-path=" + journalPath))
 	}
 	filterHash := hasher.Sum64()
 	fileName := fmt.Sprintf("journal_%s_%s_%x.cursor", database, table, filterHash)

--- a/collector/logs/sources/journal/cursor_test.go
+++ b/collector/logs/sources/journal/cursor_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCursorPath(t *testing.T) {
 	t.Run("sanitizes", func(t *testing.T) {
-		cursorPath := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "database/20", "desttable")
+		cursorPath := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "database/20", "desttable", "")
 		require.NotEmpty(t, cursorPath)
 
 		require.Equal(t, "cursorDirectory", filepath.Dir(cursorPath), "no sub directories")
@@ -20,17 +20,17 @@ func TestCursorPath(t *testing.T) {
 	})
 
 	t.Run("consistent", func(t *testing.T) {
-		pathOne := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable")
-		pathTwo := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable")
+		pathOne := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable", "")
+		pathTwo := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable", "")
 		require.Equal(t, pathOne, pathTwo)
 
-		pathOne = cursorPath("cursorDirectory", nil, "destdatabase", "desttable")
-		pathTwo = cursorPath("cursorDirectory", nil, "destdatabase", "desttable")
+		pathOne = cursorPath("cursorDirectory", nil, "destdatabase", "desttable", "")
+		pathTwo = cursorPath("cursorDirectory", nil, "destdatabase", "desttable", "")
 		require.Equal(t, pathOne, pathTwo)
 	})
 
 	t.Run("no filter", func(t *testing.T) {
-		cPath := cursorPath("cursorDirectory", nil, "destdatabase", "desttable")
+		cPath := cursorPath("cursorDirectory", nil, "destdatabase", "desttable", "")
 		require.NotEmpty(t, cPath)
 
 		require.Equal(t, "cursorDirectory", filepath.Dir(cPath), "no sub directories")
@@ -39,23 +39,23 @@ func TestCursorPath(t *testing.T) {
 	})
 
 	t.Run("varies by filter,db,table", func(t *testing.T) {
-		controlPath := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable")
-		testPath := cursorPath("cursorDirectory", []string{"filter1", "filter3", "filter2"}, "destdatabase", "desttable")
+		controlPath := cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "desttable", "")
+		testPath := cursorPath("cursorDirectory", []string{"filter1", "filter3", "filter2"}, "destdatabase", "desttable", "")
 		require.NotEqual(t, controlPath, testPath)
 
-		testPath = cursorPath("cursorDirectory", []string{"filter2"}, "destdatabase", "desttable")
+		testPath = cursorPath("cursorDirectory", []string{"filter2"}, "destdatabase", "desttable", "")
 		require.NotEqual(t, controlPath, testPath)
 
 		// different order of filter
-		testPath = cursorPath("cursorDirectory", []string{"filter2", "filter1"}, "destdatabase", "desttable")
+		testPath = cursorPath("cursorDirectory", []string{"filter2", "filter1"}, "destdatabase", "desttable", "")
 		require.NotEqual(t, controlPath, testPath)
 
 		// different table
-		testPath = cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "secondtable")
+		testPath = cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "destdatabase", "secondtable", "")
 		require.NotEqual(t, controlPath, testPath)
 
 		// different db
-		testPath = cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "otherdatabase", "desttable")
+		testPath = cursorPath("cursorDirectory", []string{"filter1", "filter2"}, "otherdatabase", "desttable", "")
 		require.NotEqual(t, controlPath, testPath)
 	})
 }
@@ -134,5 +134,38 @@ func TestClean(t *testing.T) {
 		cleanCursor(cursorPath)
 		_, err := os.Stat(cursorPath)
 		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestCursorPathJournalPath(t *testing.T) {
+	matches := []string{"_TRANSPORT=kernel"}
+
+	t.Run("empty journal path preserves the legacy cursor name", func(t *testing.T) {
+		// Pinned rather than recomputed: the whole point is that targets reading
+		// the default journal keep the exact cursor file they had before
+		// journal-path existed, so an upgrade does not re-ingest from the head of
+		// the journal. Recomputing the hash here would pass even if the scheme
+		// changed underneath us.
+		require.Equal(t,
+			filepath.Join("cursorDirectory", "journal_destdatabase_desttable_43a88ce0d2e1e5de.cursor"),
+			cursorPath("cursorDirectory", matches, "destdatabase", "desttable", ""))
+	})
+
+	t.Run("a journal path yields a different cursor than the default journal", func(t *testing.T) {
+		def := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "")
+		withPath := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "/var/log/host-journal")
+		require.NotEqual(t, def, withPath)
+	})
+
+	t.Run("different journal paths yield different cursors", func(t *testing.T) {
+		one := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "/var/log/host-journal")
+		two := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "/var/log/other-journal")
+		require.NotEqual(t, one, two)
+	})
+
+	t.Run("the same journal path is stable", func(t *testing.T) {
+		one := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "/var/log/host-journal")
+		two := cursorPath("cursorDirectory", matches, "destdatabase", "desttable", "/var/log/host-journal")
+		require.Equal(t, one, two)
 	})
 }

--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -76,15 +76,7 @@ func (s *Source) Open(ctx context.Context) error {
 		batchQueue := make(chan *types.Log, 512)
 		outputQueue := make(chan *types.LogBatch, 1)
 
-		// Targets reading a non-default journal need their own cursor, or two
-		// targets that agree on database, table and matches would share one
-		// cursor file and clobber each other. Only mixed in when set, so cursor
-		// paths for existing configurations are unchanged.
-		cursorKey := target.Matches
-		if target.JournalPath != "" {
-			cursorKey = append(append([]string{}, target.Matches...), "journal-path="+target.JournalPath)
-		}
-		cPath := cursorPath(s.cursorDirectory, cursorKey, target.Database, target.Table)
+		cPath := cursorPath(s.cursorDirectory, target.Matches, target.Database, target.Table, target.JournalPath)
 		tailer := &tailer{
 			matches:        target.Matches,
 			database:       target.Database,

--- a/collector/logs/sources/journal/journal_linux.go
+++ b/collector/logs/sources/journal/journal_linux.go
@@ -72,16 +72,25 @@ func (s *Source) Open(ctx context.Context) error {
 
 	tailers := make([]*tailer, 0, len(s.targets))
 	for _, target := range s.targets {
-		logger.Info("Opening journal source", "filters", target.Matches, "database", target.Database, "table", target.Table)
+		logger.Info("Opening journal source", "filters", target.Matches, "database", target.Database, "table", target.Table, "path", target.JournalPath)
 		batchQueue := make(chan *types.Log, 512)
 		outputQueue := make(chan *types.LogBatch, 1)
 
-		cPath := cursorPath(s.cursorDirectory, target.Matches, target.Database, target.Table)
+		// Targets reading a non-default journal need their own cursor, or two
+		// targets that agree on database, table and matches would share one
+		// cursor file and clobber each other. Only mixed in when set, so cursor
+		// paths for existing configurations are unchanged.
+		cursorKey := target.Matches
+		if target.JournalPath != "" {
+			cursorKey = append(append([]string{}, target.Matches...), "journal-path="+target.JournalPath)
+		}
+		cPath := cursorPath(s.cursorDirectory, cursorKey, target.Database, target.Table)
 		tailer := &tailer{
 			matches:        target.Matches,
 			database:       target.Database,
 			table:          target.Table,
 			journalFields:  target.JournalFields,
+			journalPath:    target.JournalPath,
 			cursorFilePath: cPath,
 			logLineParsers: target.LogLineParsers,
 			batchQueue:     batchQueue,

--- a/collector/logs/sources/journal/journal_linux_test.go
+++ b/collector/logs/sources/journal/journal_linux_test.go
@@ -281,7 +281,7 @@ func TestJournalInvalidCursor(t *testing.T) {
 		Database: "testdb",
 		Table:    "testtable",
 	}
-	cursorFilePath := cursorPath(cursorDir, targetConfig.Matches, targetConfig.Database, targetConfig.Table)
+	cursorFilePath := cursorPath(cursorDir, targetConfig.Matches, targetConfig.Database, targetConfig.Table, "")
 
 	// Write an invalid cursor with the correct format, but not from this system
 	invalidCursor := "s=65a1fbde9961443ab61e48f57b1e1cfb;i=32904c2;b=93046e4a5c424d96ad6e02659ce7dde9;m=7b29e77112;t=639d5fa6bb246;x=1cacd317ebe1eb33"

--- a/collector/logs/sources/journal/tailer_linux.go
+++ b/collector/logs/sources/journal/tailer_linux.go
@@ -49,6 +49,10 @@ type tailer struct {
 	// journalFile is the path to journal files. This is used for testing purposes.
 	journalFiles []string
 
+	// journalPath is an optional directory to read journal files from instead
+	// of the local system journal.
+	journalPath string
+
 	// streamPartials maps _STREAM_ID to the accumulated partial log messages
 	streamPartials map[string]string
 
@@ -155,10 +159,13 @@ func (t *tailer) ReadFromJournal(ctx context.Context) {
 func (t *tailer) openJournal(mode openmode) (*sdjournal.Journal, error) {
 	var reader *sdjournal.Journal
 	var err error
-	if len(t.journalFiles) == 0 {
-		reader, err = sdjournal.NewJournal()
-	} else {
+	switch {
+	case t.journalPath != "":
+		reader, err = sdjournal.NewJournalFromDir(t.journalPath)
+	case len(t.journalFiles) > 0:
 		reader, err = sdjournal.NewJournalFromFiles(t.journalFiles...)
+	default:
+		reader, err = sdjournal.NewJournal()
 	}
 
 	if err != nil {

--- a/collector/logs/sources/journal/tailer_linux.go
+++ b/collector/logs/sources/journal/tailer_linux.go
@@ -46,9 +46,6 @@ type tailer struct {
 	logLineParsers []parser.Parser
 	batchQueue     chan<- *types.Log
 
-	// journalFile is the path to journal files. This is used for testing purposes.
-	journalFiles []string
-
 	// journalPath is an optional directory to read journal files from instead
 	// of the local system journal.
 	journalPath string
@@ -159,12 +156,9 @@ func (t *tailer) ReadFromJournal(ctx context.Context) {
 func (t *tailer) openJournal(mode openmode) (*sdjournal.Journal, error) {
 	var reader *sdjournal.Journal
 	var err error
-	switch {
-	case t.journalPath != "":
+	if t.journalPath != "" {
 		reader, err = sdjournal.NewJournalFromDir(t.journalPath)
-	case len(t.journalFiles) > 0:
-		reader, err = sdjournal.NewJournalFromFiles(t.journalFiles...)
-	default:
+	} else {
 		reader, err = sdjournal.NewJournal()
 	}
 

--- a/collector/logs/sources/journal/tailer_linux_test.go
+++ b/collector/logs/sources/journal/tailer_linux_test.go
@@ -108,9 +108,8 @@ func TestApplyMatches(t *testing.T) {
 // Can view in journalctl with journalctl --file test_file.journal
 
 func TestReadFile(t *testing.T) {
-	t.Skip("skipping test because of inconsistent journalctl feature support in some build containers. Some will error out with 'protocol not supported' based on compiled features.")
 	tmpdir := t.TempDir()
-	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable")
+	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable", "")
 	queue := make(chan *types.Log, 1000)
 
 	// journalPath opens a directory rather than individual files, so stage the
@@ -119,6 +118,17 @@ func TestReadFile(t *testing.T) {
 	contents, err := os.ReadFile("test_file.journal")
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(journalDir, "test_file.journal"), contents, 0o644))
+
+	// journalctl feature support varies between build containers: some are
+	// compiled without what this fixture needs and fail with "protocol not
+	// supported". Probe the staged directory once and skip only where the
+	// environment genuinely cannot read it, so the success path still runs
+	// everywhere else instead of being skipped unconditionally.
+	probe, err := sdjournal.NewJournalFromDir(journalDir)
+	if err != nil {
+		t.Skipf("journal directory reads unsupported in this environment: %v", err)
+	}
+	probe.Close()
 
 	tailer := &tailer{
 		database:       "testdb",
@@ -150,7 +160,7 @@ func TestReadFile(t *testing.T) {
 
 func TestReadFromJournalNonExisting(t *testing.T) {
 	tmpdir := t.TempDir()
-	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable")
+	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable", "")
 	queue := make(chan *types.Log, 1000)
 
 	tailer := &tailer{

--- a/collector/logs/sources/journal/tailer_linux_test.go
+++ b/collector/logs/sources/journal/tailer_linux_test.go
@@ -5,6 +5,8 @@ package journal
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -111,11 +113,18 @@ func TestReadFile(t *testing.T) {
 	cursorPath := cursorPath(tmpdir, []string{"test"}, "testdb", "testtable")
 	queue := make(chan *types.Log, 1000)
 
+	// journalPath opens a directory rather than individual files, so stage the
+	// fixture in a directory of its own.
+	journalDir := t.TempDir()
+	contents, err := os.ReadFile("test_file.journal")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(journalDir, "test_file.journal"), contents, 0o644))
+
 	tailer := &tailer{
 		database:       "testdb",
 		table:          "testtable",
 		cursorFilePath: cursorPath,
-		journalFiles:   []string{"test_file.journal"},
+		journalPath:    journalDir,
 		batchQueue:     queue,
 		streamPartials: make(map[string]string),
 	}
@@ -149,7 +158,7 @@ func TestReadFromJournalNonExisting(t *testing.T) {
 		table:          "testtable",
 		matches:        []string{"_SYSTEMD_UNIT=kubelet.service", "_HOSTNAME=testmachine"},
 		cursorFilePath: cursorPath,
-		journalFiles:   []string{"non_existing_file.journal"},
+		journalPath:    filepath.Join(t.TempDir(), "non_existing_dir"),
 		batchQueue:     queue,
 		streamPartials: make(map[string]string),
 	}

--- a/collector/logs/sources/journal/types.go
+++ b/collector/logs/sources/journal/types.go
@@ -14,6 +14,11 @@ type JournalTargetConfig struct {
 	LogLineParsers []parser.Parser
 	// JournalFields is a list of journal fields to include in the log.
 	JournalFields []string
+	// JournalPath is an optional directory to read journal files from. When
+	// empty, the local system journal is opened, which is scoped to the
+	// current machine ID. Set this to read a journal that belongs to a
+	// different machine ID, such as a host journal mounted into a container.
+	JournalPath string
 }
 
 type SourceConfig struct {

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,6 +427,8 @@ Available parser types:
     parsers = []
     # Optional journal metadata fields http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
     journal-fields = []
+    # Optional directory to read journal files from. When unset, the local system journal is opened, which only exposes the journal matching the current machine ID. Set this to read a journal belonging to another machine ID, such as a host journal bind-mounted into a container.
+    journal-path = ''
 
   # Defines a kernel target to scrape.
   [[host-log.kernel-target]]


### PR DESCRIPTION
## Problem

The journald source always opens the local system journal:

```go
reader, err = sdjournal.NewJournal()   // sd_journal_open(SD_JOURNAL_LOCAL_ONLY)
```

`SD_JOURNAL_LOCAL_ONLY` only picks up `/{run,var}/log/journal/<current machine ID>`. Any journal belonging to a *different* machine ID is invisible, even when it is right there in the filesystem — the same reason plain `journalctl` needs `--merge` to see container journals.

This is limiting when the collector runs inside a container whose machine ID differs from the host's. Under `systemd-nspawn`, for instance, kubelet and the workloads run *inside* the machine, so a pod's `hostPath: /var/log/journal` resolves to the machine's journal rather than the host's. Entries that only ever exist in the host journal — notably `_TRANSPORT=kernel` and `_TRANSPORT=syslog` — become silently uncollectable. The matches are perfectly valid, they just never hit, and nothing surfaces the reason.

Bind-mounting the host journal into the container does not help on its own, because the directory still carries the host's machine ID and `LOCAL_ONLY` filters it out.

## Change

Adds an optional `journal-path` to `journal-target`. When set, the tailer opens that directory with `sd_journal_open_directory` (`sdjournal.NewJournalFromDir`), which is not machine-ID scoped. When unset, behaviour is exactly as before.

```toml
[[host-log.journal-target]]
  matches = [ '_SYSTEMD_UNIT=kubelet.service' ]
  database = 'Logs'
  table = 'Kubelet'

[[host-log.journal-target]]
  matches = [ '_TRANSPORT=kernel' ]
  journal-path = '/var/log/host-journal'
  database = 'Logs'
  table = 'Kernel'
```

Targets already get one tailer, and therefore one journal handle, each — so paths can be mixed freely within a single collector. Above, the kernel target reads a bind-mounted host journal while the kubelet target keeps reading the local one.

## Notes

- **Backwards compatible.** `journal-path` is optional; unset targets take the identical `NewJournal()` path they take today.
- **Cursors.** These are keyed on database, table and a hash of the matches, so two targets differing *only* by journal path would otherwise share a cursor file and clobber each other. The path is mixed into that key only when non-empty, so cursor paths for existing configurations are byte-identical and no re-ingestion is triggered on upgrade.
- `NewJournalFromDir` reads every machine-ID subdirectory under the directory it is given, so pointing at a `/var/log/journal` root will also pick up stale journals from previous machine IDs. Pointing at a specific leaf avoids that.
- The `journalFiles` test hook has been removed: both tests that used it now go through `journal-path`, so there is a single way to aim the reader at fixture journals.

## Testing

- `go build ./cmd/... ./collector/...`, `go vet`, and `gofmt` are clean.
- `make gendocs` regenerated `docs/config.md`.
- I could not run the linux-only journal tests locally (macOS, no Docker), so I am relying on CI for those.

### Validated on a real cluster

I built this branch into an image and ran it on a node in one of our clusters.

With the host journal bind-mounted read-only into the machine and two targets pointed at it via `journal-path`, the collector opened it correctly:

```
"Opening journal source" filters:["_TRANSPORT=kernel"] table:"KernelTest" path:"/var/log/host-journal"
"Opening journal source" filters:["_TRANSPORT=syslog"] table:"SyslogTest" path:"/var/log/host-journal"
```

and the data landed in ADX — both tables were created on ingest, having never existed before:

| table | rows |
|---|---|
| `KernelTest` | 16 |
| `SyslogTest` | 101 |

Genuine kernel and syslog content from the host journal, read by a collector running inside the machine, which is not achievable on this build without `journal-path`. A third target with no `journal-path` kept reading the machine's own journal at the same time, confirming paths can be mixed within one collector.

